### PR TITLE
Update polkadot packages to v9.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1654,9 +1654,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.20.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
-            "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
+            "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
             "dependencies": {
                 "regenerator-runtime": "^0.13.11"
             },
@@ -2724,21 +2724,34 @@
                 "multiformats": "^9.5.4"
             }
         },
+        "node_modules/@noble/curves": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
+            "integrity": "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==",
+            "dev": true,
+            "dependencies": {
+                "@noble/hashes": "1.3.1"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@noble/hashes": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
-            "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ]
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+            "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
         },
         "node_modules/@noble/secp256k1": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.0.tgz",
-            "integrity": "sha512-DWSsg8zMHOYMYBqIQi96BQuthZrp98LCeMNcUOaffCIVYQ5yxDbNikLF+H7jEnmNNmXbtVic46iCuVWzar+MgA==",
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+            "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
             "funding": [
                 {
                     "type": "individual",
@@ -2782,510 +2795,541 @@
             }
         },
         "node_modules/@polkadot/api": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-8.2.1.tgz",
-            "integrity": "sha512-zq1sOb1dPIyUwClx5NAqWlhB/b6t6eiSDJyZdSzvWz9XL1YWcd7/m7VtrTcMQbvC8EyMKW09Xiv5G2MEI3bhVw==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-10.9.1.tgz",
+            "integrity": "sha512-ND/2UqZBWvtt4PfV03OStTKg0mxmPk4UpMAgJKutdgsz/wP9CYJ1KbjwFgPNekL9JnzbKQsWyQNPVrcw7kQk8A==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/api-augment": "8.2.1",
-                "@polkadot/api-base": "8.2.1",
-                "@polkadot/api-derive": "8.2.1",
-                "@polkadot/keyring": "^9.0.1",
-                "@polkadot/rpc-augment": "8.2.1",
-                "@polkadot/rpc-core": "8.2.1",
-                "@polkadot/rpc-provider": "8.2.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-augment": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/types-create": "8.2.1",
-                "@polkadot/types-known": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "@polkadot/util-crypto": "^9.0.1",
-                "eventemitter3": "^4.0.7",
-                "rxjs": "^7.5.5"
+                "@polkadot/api-augment": "10.9.1",
+                "@polkadot/api-base": "10.9.1",
+                "@polkadot/api-derive": "10.9.1",
+                "@polkadot/keyring": "^12.3.1",
+                "@polkadot/rpc-augment": "10.9.1",
+                "@polkadot/rpc-core": "10.9.1",
+                "@polkadot/rpc-provider": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-augment": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/types-create": "10.9.1",
+                "@polkadot/types-known": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "eventemitter3": "^5.0.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-augment": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-8.2.1.tgz",
-            "integrity": "sha512-kNS4Ff1KLL6FyR04s4CIR0wVi3I36ErvOUZnZqaHE3DRUBWSzmocAkXaHrwzYDs6nseoL98jtnEkBMRO50gJWw==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-10.9.1.tgz",
+            "integrity": "sha512-kRZZvCFVcN4hAH4dJ+Qzfdy27/4EEq3oLDf3ihj0LTVrAezSWcKPGE3EVFy+Mn6Lo4SUc7RVyoKvIUhSk2l4Dg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/api-base": "8.2.1",
-                "@polkadot/rpc-augment": "8.2.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-augment": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/api-base": "10.9.1",
+                "@polkadot/rpc-augment": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-augment": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-augment/node_modules/@polkadot/types": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.2.1.tgz",
-            "integrity": "sha512-Qvgvxt5GNb9RRXDNIXB9Gu+E4Vw/9aRKw76mamWqFgtRONOJ8l6HgKgWvzsCZ/lBIKLi5NE/BKPIkOhZAWfDmA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+            "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/keyring": "^9.0.1",
-                "@polkadot/types-augment": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/types-create": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "@polkadot/util-crypto": "^9.0.1",
-                "rxjs": "^7.5.5"
+                "@polkadot/keyring": "^12.3.1",
+                "@polkadot/types-augment": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/types-create": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-augment/node_modules/@polkadot/types-augment": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.2.1.tgz",
-            "integrity": "sha512-+uMC4JTYTghhbwyvvdjUnLcV3HeUZOqscfVYPYPtwctblXZRZae77b8TD1H+NqgBhloJPC8I8uBVflRIb+HcpA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+            "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-augment/node_modules/@polkadot/types-codec": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.2.1.tgz",
-            "integrity": "sha512-dG5QUCNVmRA8BuQQdxU+2DB4lp+kbO22rDimJMNCr7lOELCIkbo+GFNpWhPInIq+aLrTTAyyv0VguJ3ciQVFJA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+            "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/x-bigint": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-augment/node_modules/@polkadot/types-create": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.2.1.tgz",
-            "integrity": "sha512-pdzSZgozhe/2EXnnXlxEoBiFwcg19mZ+o0ICdM+cpHayume5C3DrJzIRhQpKu7ndUyEb+MorC5aZn9Cj8Kdp0Q==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+            "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/api-augment/node_modules/@polkadot/x-bigint": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+            "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/api-augment/node_modules/@polkadot/x-global": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+            "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-base": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-8.2.1.tgz",
-            "integrity": "sha512-z614lpNagsuFH47++CNOYaraET4lWRA2Y+d+CqMoWlCgAtKDuqraZfjF7SzYMGp67zSD+FYFSimReWPh5LMV/Q==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.9.1.tgz",
+            "integrity": "sha512-Q3m2KzlceMK2kX8bhnUZWk3RT6emmijeeFZZQgCePpEcrSeNjnqG4qjuTPgkveaOkUT8MAoDc5Avuzcc2jlW9g==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/rpc-core": "8.2.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "rxjs": "^7.5.5"
+                "@polkadot/rpc-core": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-base/node_modules/@polkadot/types": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.2.1.tgz",
-            "integrity": "sha512-Qvgvxt5GNb9RRXDNIXB9Gu+E4Vw/9aRKw76mamWqFgtRONOJ8l6HgKgWvzsCZ/lBIKLi5NE/BKPIkOhZAWfDmA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+            "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/keyring": "^9.0.1",
-                "@polkadot/types-augment": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/types-create": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "@polkadot/util-crypto": "^9.0.1",
-                "rxjs": "^7.5.5"
+                "@polkadot/keyring": "^12.3.1",
+                "@polkadot/types-augment": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/types-create": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-base/node_modules/@polkadot/types-augment": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.2.1.tgz",
-            "integrity": "sha512-+uMC4JTYTghhbwyvvdjUnLcV3HeUZOqscfVYPYPtwctblXZRZae77b8TD1H+NqgBhloJPC8I8uBVflRIb+HcpA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+            "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-base/node_modules/@polkadot/types-codec": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.2.1.tgz",
-            "integrity": "sha512-dG5QUCNVmRA8BuQQdxU+2DB4lp+kbO22rDimJMNCr7lOELCIkbo+GFNpWhPInIq+aLrTTAyyv0VguJ3ciQVFJA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+            "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/x-bigint": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-base/node_modules/@polkadot/types-create": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.2.1.tgz",
-            "integrity": "sha512-pdzSZgozhe/2EXnnXlxEoBiFwcg19mZ+o0ICdM+cpHayume5C3DrJzIRhQpKu7ndUyEb+MorC5aZn9Cj8Kdp0Q==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+            "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
-        "node_modules/@polkadot/api-contract": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/api-contract/-/api-contract-8.2.1.tgz",
-            "integrity": "sha512-y0HXHg3+8iodcdlyeXSn/ZZ2tuGs0dz8ehp09u6asZLyenWME4mi1ERSg4+WspHcQxR99TgAqfOZpCfDo1Yi8A==",
+        "node_modules/@polkadot/api-base/node_modules/@polkadot/x-bigint": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+            "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/api": "8.2.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/types-create": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "@polkadot/util-crypto": "^9.0.1",
-                "rxjs": "^7.5.5"
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
-        "node_modules/@polkadot/api-contract/node_modules/@polkadot/types": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.2.1.tgz",
-            "integrity": "sha512-Qvgvxt5GNb9RRXDNIXB9Gu+E4Vw/9aRKw76mamWqFgtRONOJ8l6HgKgWvzsCZ/lBIKLi5NE/BKPIkOhZAWfDmA==",
+        "node_modules/@polkadot/api-base/node_modules/@polkadot/x-global": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+            "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/keyring": "^9.0.1",
-                "@polkadot/types-augment": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/types-create": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "@polkadot/util-crypto": "^9.0.1",
-                "rxjs": "^7.5.5"
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@polkadot/api-contract/node_modules/@polkadot/types-augment": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.2.1.tgz",
-            "integrity": "sha512-+uMC4JTYTghhbwyvvdjUnLcV3HeUZOqscfVYPYPtwctblXZRZae77b8TD1H+NqgBhloJPC8I8uBVflRIb+HcpA==",
-            "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@polkadot/api-contract/node_modules/@polkadot/types-codec": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.2.1.tgz",
-            "integrity": "sha512-dG5QUCNVmRA8BuQQdxU+2DB4lp+kbO22rDimJMNCr7lOELCIkbo+GFNpWhPInIq+aLrTTAyyv0VguJ3ciQVFJA==",
-            "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/util": "^9.0.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@polkadot/api-contract/node_modules/@polkadot/types-create": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.2.1.tgz",
-            "integrity": "sha512-pdzSZgozhe/2EXnnXlxEoBiFwcg19mZ+o0ICdM+cpHayume5C3DrJzIRhQpKu7ndUyEb+MorC5aZn9Cj8Kdp0Q==",
-            "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-derive": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-8.2.1.tgz",
-            "integrity": "sha512-rLM99VyZMqsbYZf0ZxEYvKQCKjggJitDklHyemaVP1E2czOI+sKAy5R+oTyOXsAEk5QD2Bh6bLT6eDuuSDvdrA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-10.9.1.tgz",
+            "integrity": "sha512-mRud1UZCFIc4Z63qAoGSIHh/foyUYADfy1RQYCmPpeFKfIdCIrHpd7xFdJXTOMYOS0BwlM6u4qli/ZT4XigezQ==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/api": "8.2.1",
-                "@polkadot/api-augment": "8.2.1",
-                "@polkadot/api-base": "8.2.1",
-                "@polkadot/rpc-core": "8.2.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "@polkadot/util-crypto": "^9.0.1",
-                "rxjs": "^7.5.5"
+                "@polkadot/api": "10.9.1",
+                "@polkadot/api-augment": "10.9.1",
+                "@polkadot/api-base": "10.9.1",
+                "@polkadot/rpc-core": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-derive/node_modules/@polkadot/types": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.2.1.tgz",
-            "integrity": "sha512-Qvgvxt5GNb9RRXDNIXB9Gu+E4Vw/9aRKw76mamWqFgtRONOJ8l6HgKgWvzsCZ/lBIKLi5NE/BKPIkOhZAWfDmA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+            "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/keyring": "^9.0.1",
-                "@polkadot/types-augment": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/types-create": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "@polkadot/util-crypto": "^9.0.1",
-                "rxjs": "^7.5.5"
+                "@polkadot/keyring": "^12.3.1",
+                "@polkadot/types-augment": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/types-create": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-derive/node_modules/@polkadot/types-augment": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.2.1.tgz",
-            "integrity": "sha512-+uMC4JTYTghhbwyvvdjUnLcV3HeUZOqscfVYPYPtwctblXZRZae77b8TD1H+NqgBhloJPC8I8uBVflRIb+HcpA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+            "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-derive/node_modules/@polkadot/types-codec": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.2.1.tgz",
-            "integrity": "sha512-dG5QUCNVmRA8BuQQdxU+2DB4lp+kbO22rDimJMNCr7lOELCIkbo+GFNpWhPInIq+aLrTTAyyv0VguJ3ciQVFJA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+            "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/x-bigint": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api-derive/node_modules/@polkadot/types-create": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.2.1.tgz",
-            "integrity": "sha512-pdzSZgozhe/2EXnnXlxEoBiFwcg19mZ+o0ICdM+cpHayume5C3DrJzIRhQpKu7ndUyEb+MorC5aZn9Cj8Kdp0Q==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+            "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/api-derive/node_modules/@polkadot/x-bigint": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+            "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/api-derive/node_modules/@polkadot/x-global": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+            "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api/node_modules/@polkadot/rpc-provider": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-8.2.1.tgz",
-            "integrity": "sha512-aGmwAA588me4DASe01wmkcY75ABVhcRlFvozIIDtvmlCk2/4uWk4RSLMcdbhedK+XQurh1w6W9jKAddAofCAIA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.9.1.tgz",
+            "integrity": "sha512-4QzT2QzD+320+eT6b79sGAA85Tt3Bb8fQvse4r5Mom2iiBd2SO81vOhxSAOaIe4GUsw25VzFJmsbe7+OObItdg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/keyring": "^9.0.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-support": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "@polkadot/util-crypto": "^9.0.1",
-                "@polkadot/x-fetch": "^9.0.1",
-                "@polkadot/x-global": "^9.0.1",
-                "@polkadot/x-ws": "^9.0.1",
-                "@substrate/connect": "0.7.2",
-                "eventemitter3": "^4.0.7",
-                "mock-socket": "^9.1.3",
-                "nock": "^13.2.4"
+                "@polkadot/keyring": "^12.3.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-support": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "@polkadot/x-fetch": "^12.3.1",
+                "@polkadot/x-global": "^12.3.1",
+                "@polkadot/x-ws": "^12.3.1",
+                "eventemitter3": "^5.0.1",
+                "mock-socket": "^9.2.1",
+                "nock": "^13.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
+            },
+            "optionalDependencies": {
+                "@substrate/connect": "0.7.26"
             }
         },
         "node_modules/@polkadot/api/node_modules/@polkadot/types": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.2.1.tgz",
-            "integrity": "sha512-Qvgvxt5GNb9RRXDNIXB9Gu+E4Vw/9aRKw76mamWqFgtRONOJ8l6HgKgWvzsCZ/lBIKLi5NE/BKPIkOhZAWfDmA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+            "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/keyring": "^9.0.1",
-                "@polkadot/types-augment": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/types-create": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "@polkadot/util-crypto": "^9.0.1",
-                "rxjs": "^7.5.5"
+                "@polkadot/keyring": "^12.3.1",
+                "@polkadot/types-augment": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/types-create": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api/node_modules/@polkadot/types-augment": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.2.1.tgz",
-            "integrity": "sha512-+uMC4JTYTghhbwyvvdjUnLcV3HeUZOqscfVYPYPtwctblXZRZae77b8TD1H+NqgBhloJPC8I8uBVflRIb+HcpA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+            "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api/node_modules/@polkadot/types-codec": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.2.1.tgz",
-            "integrity": "sha512-dG5QUCNVmRA8BuQQdxU+2DB4lp+kbO22rDimJMNCr7lOELCIkbo+GFNpWhPInIq+aLrTTAyyv0VguJ3ciQVFJA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+            "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/x-bigint": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api/node_modules/@polkadot/types-create": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.2.1.tgz",
-            "integrity": "sha512-pdzSZgozhe/2EXnnXlxEoBiFwcg19mZ+o0ICdM+cpHayume5C3DrJzIRhQpKu7ndUyEb+MorC5aZn9Cj8Kdp0Q==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+            "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api/node_modules/@polkadot/types-support": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-8.2.1.tgz",
-            "integrity": "sha512-vXvcbioDOVGcSpKIq4UrMVfbQPLsLEnhmn0BRGQotACfWGtBqRr1En1SIfSo5nJ/gyBjoq4AUsdUQII2Sa4Drw==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.9.1.tgz",
+            "integrity": "sha512-XsieuLDsszvMZQlleacQBfx07i/JkwQV/UxH9q8Hz7Okmaz9pEVEW1h3ka2/cPuC7a4l32JhaORBUYshBZNdJg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/api/node_modules/@polkadot/x-bigint": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+            "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api/node_modules/@polkadot/x-fetch": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-9.7.2.tgz",
-            "integrity": "sha512-ysXpPNq2S+L98hKow3d59prU4QFRg5N86pMkJdONc4VxtKITVY2MfdLVCqfEOOFuuwCzE7Sfmx53I4XpDgbP7A==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.3.2.tgz",
+            "integrity": "sha512-3IEuZ5S+RI/t33NsdPLIIa5COfDCfpUW2sbaByEczn75aD1jLqJZSEDwiBniJ2osyNd4uUxBf6e5jw7LAZeZJg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.18.6",
-                "@polkadot/x-global": "9.7.2",
-                "@types/node-fetch": "^2.6.2",
-                "node-fetch": "^2.6.7"
+                "@polkadot/x-global": "12.3.2",
+                "node-fetch": "^3.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api/node_modules/@polkadot/x-global": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-9.7.2.tgz",
-            "integrity": "sha512-3NN5JhjosaelaFWBJSlv9mb/gDAlt7RuZ8NKlOjB+LQHd9g6ZbnYi5wwjW+i/x/3E4IVbBx66uvWgNaw7IBrkg==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+            "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.18.6"
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api/node_modules/@polkadot/x-ws": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-9.7.2.tgz",
-            "integrity": "sha512-yF2qKL00SGivbima22jxoBNYCZFI8Ph7dmnVm7fDztVtO8Fc2x30Lj3a8+qsSOrynLyJHAh2bjjQxpPmDCB9tw==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.3.2.tgz",
+            "integrity": "sha512-yM9Z64pLNlHpJE43+Xtr+iUXmYpFFY5u5hrke2PJt13O48H8f9Vb9cRaIh94appLyICoS0aekGhDkGH+MCspBA==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.18.6",
-                "@polkadot/x-global": "9.7.2",
-                "@types/websocket": "^1.0.5",
-                "websocket": "^1.0.34"
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3",
+                "ws": "^8.13.0"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/api/node_modules/@substrate/connect": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.2.tgz",
-            "integrity": "sha512-8GWdrN7qbClYLa9LmETJnywT5fknEQeMw+QKvkUMvsHKegHD0Zkhi0K484mKxRN9RGwcPsKHPj1gMk8xlZuJ9g==",
+            "version": "0.7.26",
+            "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.26.tgz",
+            "integrity": "sha512-uuGSiroGuKWj1+38n1kY5HReer5iL9bRwPCzuoLtqAOmI1fGI0hsSI2LlNQMAbfRgr7VRHXOk5MTuQf5ulsFRw==",
+            "dev": true,
+            "optional": true,
             "dependencies": {
-                "@substrate/connect-extension-protocol": "^1.0.0",
-                "@substrate/smoldot-light": "0.6.15",
-                "eventemitter3": "^4.0.7"
+                "@substrate/connect-extension-protocol": "^1.0.1",
+                "eventemitter3": "^4.0.7",
+                "smoldot": "1.0.4"
             }
         },
-        "node_modules/@polkadot/api/node_modules/@substrate/smoldot-light": {
-            "version": "0.6.15",
-            "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.15.tgz",
-            "integrity": "sha512-c2tJCSp9Litsn/p8wY1FfEqIkJI8Peh89BU7T43bruWRO2SSgLVh0cIVbOCY4en90tIOX4W0CueRWFBRQz7BjQ==",
-            "dependencies": {
-                "buffer": "^6.0.1",
-                "pako": "^2.0.4",
-                "websocket": "^1.0.32"
-            }
+        "node_modules/@polkadot/api/node_modules/@substrate/connect/node_modules/eventemitter3": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+            "dev": true,
+            "optional": true
         },
-        "node_modules/@polkadot/api/node_modules/node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
+        "node_modules/@polkadot/api/node_modules/eventemitter3": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+            "dev": true
         },
         "node_modules/@polkadot/extension-dapp": {
-            "version": "0.44.6",
-            "resolved": "https://registry.npmjs.org/@polkadot/extension-dapp/-/extension-dapp-0.44.6.tgz",
-            "integrity": "sha512-PKpc50df5dzAdYp/Btr46hdAdsUatoEInp8sc4HvIrIFDHXHcFq6I73pPDeq627SxkZjBiRGVpks8KOl9b6x6A==",
+            "version": "0.46.5",
+            "resolved": "https://registry.npmjs.org/@polkadot/extension-dapp/-/extension-dapp-0.46.5.tgz",
+            "integrity": "sha512-9Efm3oorx6orq1eue+tTk5rxuGFFCUdRxiZbdQMKiVl3lZnwBn0M61ceE3xXcf/oIwAm8RhUpQdwcbZfupJRgw==",
             "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.18.9",
-                "@polkadot/extension-inject": "^0.44.6",
-                "@polkadot/util": "^10.1.5",
-                "@polkadot/util-crypto": "^10.1.5"
+                "@polkadot/extension-inject": "0.46.5",
+                "@polkadot/util": "^12.3.2",
+                "@polkadot/util-crypto": "^12.3.2",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
             },
             "peerDependencies": {
                 "@polkadot/api": "*",
@@ -3293,97 +3337,198 @@
                 "@polkadot/util-crypto": "*"
             }
         },
-        "node_modules/@polkadot/extension-dapp/node_modules/@noble/hashes": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
-            "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ]
-        },
-        "node_modules/@polkadot/extension-dapp/node_modules/@noble/secp256k1": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
-            "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ]
-        },
-        "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/util": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.2.1.tgz",
-            "integrity": "sha512-ewGKSOp+VXKEeCvpCCP2Qqi/FVkewBF9vb/N8pRwuNQ2XE9k1lnsOZZeQemVBDhKsZz+h3IeNcWejaF6K3vYHQ==",
+        "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/extension-inject": {
+            "version": "0.46.5",
+            "resolved": "https://registry.npmjs.org/@polkadot/extension-inject/-/extension-inject-0.46.5.tgz",
+            "integrity": "sha512-QcpkCMuv7iFbWjufkw14JRozpEYFyjP0H8KOJ8IsHGfPd2DPiismQ0NXr+AS7f6U+0I+Rhv9E4dnXxtJPROVMQ==",
             "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.20.6",
-                "@polkadot/x-bigint": "10.2.1",
-                "@polkadot/x-global": "10.2.1",
-                "@polkadot/x-textdecoder": "10.2.1",
-                "@polkadot/x-textencoder": "10.2.1",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1"
+                "@polkadot/api": "^10.9.1",
+                "@polkadot/rpc-provider": "^10.9.1",
+                "@polkadot/types": "^10.9.1",
+                "@polkadot/util": "^12.3.2",
+                "@polkadot/util-crypto": "^12.3.2",
+                "@polkadot/x-global": "^12.3.2",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/util-crypto": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.2.1.tgz",
-            "integrity": "sha512-UH1J4oD92gkLXMfVTLee3Y2vYadNyp1lmS4P2nZwQ0SOzGZ4rN7khD2CrB1cXS9WPq196Zb5oZdGLnPYnXHtjw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.20.6",
-                "@noble/hashes": "1.1.3",
-                "@noble/secp256k1": "1.7.0",
-                "@polkadot/networks": "10.2.1",
-                "@polkadot/util": "10.2.1",
-                "@polkadot/wasm-crypto": "^6.4.1",
-                "@polkadot/x-bigint": "10.2.1",
-                "@polkadot/x-randomvalues": "10.2.1",
-                "@scure/base": "1.1.1",
-                "ed2curve": "^0.3.0",
-                "tweetnacl": "^1.0.3"
-            },
-            "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             },
             "peerDependencies": {
-                "@polkadot/util": "10.2.1"
+                "@polkadot/api": "*",
+                "@polkadot/util": "*"
             }
         },
-        "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/x-textdecoder": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.2.1.tgz",
-            "integrity": "sha512-hpFmrdv/rrSM4UNaV8TJBgMtwXsYlNgBTSUmnKWwJIN3PhOUeYxl1qIbPchxGbJBc35WviJCZe7rlLja9JvFcw==",
+        "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/rpc-provider": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.9.1.tgz",
+            "integrity": "sha512-4QzT2QzD+320+eT6b79sGAA85Tt3Bb8fQvse4r5Mom2iiBd2SO81vOhxSAOaIe4GUsw25VzFJmsbe7+OObItdg==",
             "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.20.6",
-                "@polkadot/x-global": "10.2.1"
+                "@polkadot/keyring": "^12.3.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-support": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "@polkadot/x-fetch": "^12.3.1",
+                "@polkadot/x-global": "^12.3.1",
+                "@polkadot/x-ws": "^12.3.1",
+                "eventemitter3": "^5.0.1",
+                "mock-socket": "^9.2.1",
+                "nock": "^13.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
+            },
+            "optionalDependencies": {
+                "@substrate/connect": "0.7.26"
             }
         },
-        "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/x-textencoder": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.2.1.tgz",
-            "integrity": "sha512-4gMyY6DCH34KA++bawu/zlUJ0/8+aZJsurwjRBbkdfOS2uLo0K+vJ5GBevAhl0VSznM36ptfh/MpkIBKK/6R0g==",
+        "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/rpc-provider/node_modules/eventemitter3": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+            "dev": true
+        },
+        "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/types": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+            "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
             "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.20.6",
-                "@polkadot/x-global": "10.2.1"
+                "@polkadot/keyring": "^12.3.1",
+                "@polkadot/types-augment": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/types-create": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/types-augment": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+            "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/types-codec": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+            "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/x-bigint": "^12.3.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/types-create": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+            "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/types-support": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.9.1.tgz",
+            "integrity": "sha512-XsieuLDsszvMZQlleacQBfx07i/JkwQV/UxH9q8Hz7Okmaz9pEVEW1h3ka2/cPuC7a4l32JhaORBUYshBZNdJg==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/x-bigint": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+            "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/x-fetch": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.3.2.tgz",
+            "integrity": "sha512-3IEuZ5S+RI/t33NsdPLIIa5COfDCfpUW2sbaByEczn75aD1jLqJZSEDwiBniJ2osyNd4uUxBf6e5jw7LAZeZJg==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/x-global": "12.3.2",
+                "node-fetch": "^3.3.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/x-global": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+            "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/x-ws": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.3.2.tgz",
+            "integrity": "sha512-yM9Z64pLNlHpJE43+Xtr+iUXmYpFFY5u5hrke2PJt13O48H8f9Vb9cRaIh94appLyICoS0aekGhDkGH+MCspBA==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3",
+                "ws": "^8.13.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/extension-dapp/node_modules/@substrate/connect": {
+            "version": "0.7.26",
+            "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.26.tgz",
+            "integrity": "sha512-uuGSiroGuKWj1+38n1kY5HReer5iL9bRwPCzuoLtqAOmI1fGI0hsSI2LlNQMAbfRgr7VRHXOk5MTuQf5ulsFRw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@substrate/connect-extension-protocol": "^1.0.1",
+                "eventemitter3": "^4.0.7",
+                "smoldot": "1.0.4"
             }
         },
         "node_modules/@polkadot/extension-inject": {
@@ -3497,26 +3642,28 @@
             }
         },
         "node_modules/@polkadot/keyring": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-9.7.2.tgz",
-            "integrity": "sha512-qY5baU1qduwTE04Cyrqtf2pCpsIk7Z5vi45CD9U3cbkKXaJoNUqIpfKoL8Vh/yVJBwhclMdxV9E2rEJs8Iv4bg==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.3.2.tgz",
+            "integrity": "sha512-NTdtDeI0DP9l/45hXynNABeP5VB8piw5YR+CbUxK2e36xpJWVXwbcOepzslg5ghE9rs8UKJb30Z/HqTU4sBY0Q==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.18.6",
-                "@polkadot/util": "9.7.2",
-                "@polkadot/util-crypto": "9.7.2"
+                "@polkadot/util": "12.3.2",
+                "@polkadot/util-crypto": "12.3.2",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             },
             "peerDependencies": {
-                "@polkadot/util": "9.7.2",
-                "@polkadot/util-crypto": "9.7.2"
+                "@polkadot/util": "12.3.2",
+                "@polkadot/util-crypto": "12.3.2"
             }
         },
         "node_modules/@polkadot/networks": {
             "version": "10.2.1",
             "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.2.1.tgz",
             "integrity": "sha512-cDZIY4jBo2tlDdSXNbECpuWer0NWlPcJNhHHveTiu2idje2QyIBNxBlAPViNGpz+ScAR0EknEzmQKuHOcSKxzg==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.6",
                 "@polkadot/util": "10.2.1",
@@ -3530,6 +3677,7 @@
             "version": "10.2.1",
             "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.2.1.tgz",
             "integrity": "sha512-ewGKSOp+VXKEeCvpCCP2Qqi/FVkewBF9vb/N8pRwuNQ2XE9k1lnsOZZeQemVBDhKsZz+h3IeNcWejaF6K3vYHQ==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.6",
                 "@polkadot/x-bigint": "10.2.1",
@@ -3547,6 +3695,7 @@
             "version": "10.2.1",
             "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.2.1.tgz",
             "integrity": "sha512-hpFmrdv/rrSM4UNaV8TJBgMtwXsYlNgBTSUmnKWwJIN3PhOUeYxl1qIbPchxGbJBc35WviJCZe7rlLja9JvFcw==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.6",
                 "@polkadot/x-global": "10.2.1"
@@ -3559,6 +3708,7 @@
             "version": "10.2.1",
             "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.2.1.tgz",
             "integrity": "sha512-4gMyY6DCH34KA++bawu/zlUJ0/8+aZJsurwjRBbkdfOS2uLo0K+vJ5GBevAhl0VSznM36ptfh/MpkIBKK/6R0g==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.6",
                 "@polkadot/x-global": "10.2.1"
@@ -3568,261 +3718,295 @@
             }
         },
         "node_modules/@polkadot/rpc-augment": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-8.2.1.tgz",
-            "integrity": "sha512-Fr0wB275SjXqdhY3A4cazKCmOVIIIX3NQSiXiqpsFYMpSgmPPMNwgDPjxngJ7aI3lqMUGGC1sSD4vkSkDntfnQ==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-10.9.1.tgz",
+            "integrity": "sha512-MaLHkNlyqN20ZRYr6uNd1BZr1OsrnX9qLAmsl0mcrri1vPGRH6VHjfFH1RBLkikpWD82v17g0l2hLwdV1ZHMcw==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/rpc-core": "8.2.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/rpc-core": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/types": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.2.1.tgz",
-            "integrity": "sha512-Qvgvxt5GNb9RRXDNIXB9Gu+E4Vw/9aRKw76mamWqFgtRONOJ8l6HgKgWvzsCZ/lBIKLi5NE/BKPIkOhZAWfDmA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+            "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/keyring": "^9.0.1",
-                "@polkadot/types-augment": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/types-create": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "@polkadot/util-crypto": "^9.0.1",
-                "rxjs": "^7.5.5"
+                "@polkadot/keyring": "^12.3.1",
+                "@polkadot/types-augment": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/types-create": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/types-augment": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.2.1.tgz",
-            "integrity": "sha512-+uMC4JTYTghhbwyvvdjUnLcV3HeUZOqscfVYPYPtwctblXZRZae77b8TD1H+NqgBhloJPC8I8uBVflRIb+HcpA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+            "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/types-codec": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.2.1.tgz",
-            "integrity": "sha512-dG5QUCNVmRA8BuQQdxU+2DB4lp+kbO22rDimJMNCr7lOELCIkbo+GFNpWhPInIq+aLrTTAyyv0VguJ3ciQVFJA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+            "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/x-bigint": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/types-create": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.2.1.tgz",
-            "integrity": "sha512-pdzSZgozhe/2EXnnXlxEoBiFwcg19mZ+o0ICdM+cpHayume5C3DrJzIRhQpKu7ndUyEb+MorC5aZn9Cj8Kdp0Q==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+            "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-bigint": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+            "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-global": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+            "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-core": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-8.2.1.tgz",
-            "integrity": "sha512-nRhUHQ5nkbbeFh/lV3OrCHJ/SAgV1KT7onPEVkSGG+OzuyY9yvGsDUbAtqfo+r2kBEDB6RhjV4Sx1HSeNHmQWg==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-10.9.1.tgz",
+            "integrity": "sha512-ZtA8B8SfXSAwVkBlCcKRHw0eSM7ec/sbiNOM5GasXPeRujUgT7lOwSH2GbUZSqe9RfRDMp6DvO9c2JoGc3LLWw==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/rpc-augment": "8.2.1",
-                "@polkadot/rpc-provider": "8.2.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "rxjs": "^7.5.5"
+                "@polkadot/rpc-augment": "10.9.1",
+                "@polkadot/rpc-provider": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-core/node_modules/@polkadot/rpc-provider": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-8.2.1.tgz",
-            "integrity": "sha512-aGmwAA588me4DASe01wmkcY75ABVhcRlFvozIIDtvmlCk2/4uWk4RSLMcdbhedK+XQurh1w6W9jKAddAofCAIA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.9.1.tgz",
+            "integrity": "sha512-4QzT2QzD+320+eT6b79sGAA85Tt3Bb8fQvse4r5Mom2iiBd2SO81vOhxSAOaIe4GUsw25VzFJmsbe7+OObItdg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/keyring": "^9.0.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-support": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "@polkadot/util-crypto": "^9.0.1",
-                "@polkadot/x-fetch": "^9.0.1",
-                "@polkadot/x-global": "^9.0.1",
-                "@polkadot/x-ws": "^9.0.1",
-                "@substrate/connect": "0.7.2",
-                "eventemitter3": "^4.0.7",
-                "mock-socket": "^9.1.3",
-                "nock": "^13.2.4"
+                "@polkadot/keyring": "^12.3.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-support": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "@polkadot/x-fetch": "^12.3.1",
+                "@polkadot/x-global": "^12.3.1",
+                "@polkadot/x-ws": "^12.3.1",
+                "eventemitter3": "^5.0.1",
+                "mock-socket": "^9.2.1",
+                "nock": "^13.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
+            },
+            "optionalDependencies": {
+                "@substrate/connect": "0.7.26"
             }
         },
+        "node_modules/@polkadot/rpc-core/node_modules/@polkadot/rpc-provider/node_modules/eventemitter3": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+            "dev": true
+        },
         "node_modules/@polkadot/rpc-core/node_modules/@polkadot/types": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.2.1.tgz",
-            "integrity": "sha512-Qvgvxt5GNb9RRXDNIXB9Gu+E4Vw/9aRKw76mamWqFgtRONOJ8l6HgKgWvzsCZ/lBIKLi5NE/BKPIkOhZAWfDmA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+            "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/keyring": "^9.0.1",
-                "@polkadot/types-augment": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/types-create": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "@polkadot/util-crypto": "^9.0.1",
-                "rxjs": "^7.5.5"
+                "@polkadot/keyring": "^12.3.1",
+                "@polkadot/types-augment": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/types-create": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-core/node_modules/@polkadot/types-augment": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.2.1.tgz",
-            "integrity": "sha512-+uMC4JTYTghhbwyvvdjUnLcV3HeUZOqscfVYPYPtwctblXZRZae77b8TD1H+NqgBhloJPC8I8uBVflRIb+HcpA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+            "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-core/node_modules/@polkadot/types-codec": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.2.1.tgz",
-            "integrity": "sha512-dG5QUCNVmRA8BuQQdxU+2DB4lp+kbO22rDimJMNCr7lOELCIkbo+GFNpWhPInIq+aLrTTAyyv0VguJ3ciQVFJA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+            "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/x-bigint": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-core/node_modules/@polkadot/types-create": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.2.1.tgz",
-            "integrity": "sha512-pdzSZgozhe/2EXnnXlxEoBiFwcg19mZ+o0ICdM+cpHayume5C3DrJzIRhQpKu7ndUyEb+MorC5aZn9Cj8Kdp0Q==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+            "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-core/node_modules/@polkadot/types-support": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-8.2.1.tgz",
-            "integrity": "sha512-vXvcbioDOVGcSpKIq4UrMVfbQPLsLEnhmn0BRGQotACfWGtBqRr1En1SIfSo5nJ/gyBjoq4AUsdUQII2Sa4Drw==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.9.1.tgz",
+            "integrity": "sha512-XsieuLDsszvMZQlleacQBfx07i/JkwQV/UxH9q8Hz7Okmaz9pEVEW1h3ka2/cPuC7a4l32JhaORBUYshBZNdJg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-bigint": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+            "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-fetch": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-9.7.2.tgz",
-            "integrity": "sha512-ysXpPNq2S+L98hKow3d59prU4QFRg5N86pMkJdONc4VxtKITVY2MfdLVCqfEOOFuuwCzE7Sfmx53I4XpDgbP7A==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.3.2.tgz",
+            "integrity": "sha512-3IEuZ5S+RI/t33NsdPLIIa5COfDCfpUW2sbaByEczn75aD1jLqJZSEDwiBniJ2osyNd4uUxBf6e5jw7LAZeZJg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.18.6",
-                "@polkadot/x-global": "9.7.2",
-                "@types/node-fetch": "^2.6.2",
-                "node-fetch": "^2.6.7"
+                "@polkadot/x-global": "12.3.2",
+                "node-fetch": "^3.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-global": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-9.7.2.tgz",
-            "integrity": "sha512-3NN5JhjosaelaFWBJSlv9mb/gDAlt7RuZ8NKlOjB+LQHd9g6ZbnYi5wwjW+i/x/3E4IVbBx66uvWgNaw7IBrkg==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+            "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.18.6"
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-ws": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-9.7.2.tgz",
-            "integrity": "sha512-yF2qKL00SGivbima22jxoBNYCZFI8Ph7dmnVm7fDztVtO8Fc2x30Lj3a8+qsSOrynLyJHAh2bjjQxpPmDCB9tw==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.3.2.tgz",
+            "integrity": "sha512-yM9Z64pLNlHpJE43+Xtr+iUXmYpFFY5u5hrke2PJt13O48H8f9Vb9cRaIh94appLyICoS0aekGhDkGH+MCspBA==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.18.6",
-                "@polkadot/x-global": "9.7.2",
-                "@types/websocket": "^1.0.5",
-                "websocket": "^1.0.34"
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3",
+                "ws": "^8.13.0"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/rpc-core/node_modules/@substrate/connect": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.2.tgz",
-            "integrity": "sha512-8GWdrN7qbClYLa9LmETJnywT5fknEQeMw+QKvkUMvsHKegHD0Zkhi0K484mKxRN9RGwcPsKHPj1gMk8xlZuJ9g==",
+            "version": "0.7.26",
+            "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.26.tgz",
+            "integrity": "sha512-uuGSiroGuKWj1+38n1kY5HReer5iL9bRwPCzuoLtqAOmI1fGI0hsSI2LlNQMAbfRgr7VRHXOk5MTuQf5ulsFRw==",
+            "dev": true,
+            "optional": true,
             "dependencies": {
-                "@substrate/connect-extension-protocol": "^1.0.0",
-                "@substrate/smoldot-light": "0.6.15",
-                "eventemitter3": "^4.0.7"
-            }
-        },
-        "node_modules/@polkadot/rpc-core/node_modules/@substrate/smoldot-light": {
-            "version": "0.6.15",
-            "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.15.tgz",
-            "integrity": "sha512-c2tJCSp9Litsn/p8wY1FfEqIkJI8Peh89BU7T43bruWRO2SSgLVh0cIVbOCY4en90tIOX4W0CueRWFBRQz7BjQ==",
-            "dependencies": {
-                "buffer": "^6.0.1",
-                "pako": "^2.0.4",
-                "websocket": "^1.0.32"
-            }
-        },
-        "node_modules/@polkadot/rpc-core/node_modules/node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
+                "@substrate/connect-extension-protocol": "^1.0.1",
+                "eventemitter3": "^4.0.7",
+                "smoldot": "1.0.4"
             }
         },
         "node_modules/@polkadot/rpc-provider": {
@@ -3983,6 +4167,7 @@
             "version": "9.7.1",
             "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.7.1.tgz",
             "integrity": "sha512-MnRVHFsQvJm+SV1lCiL+uSOYXjHKpDiFvDlmxUVQYnDtgZIK3Q5deKGbM0Lrg393/QbZr13+MhPhnlKCgiaeUg==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.1",
                 "@polkadot/keyring": "^10.1.11",
@@ -4259,89 +4444,121 @@
             }
         },
         "node_modules/@polkadot/types-known": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-8.2.1.tgz",
-            "integrity": "sha512-9d+LOffogl7HOJ9ooiaOjfbZttF3LgjkVMTU1BQduu5Ln/o6Bk5ARCDeJuSEwYIegtqxrwpxlJabUuUT9xNmew==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-10.9.1.tgz",
+            "integrity": "sha512-zCMVWc4pJtkbMFPu72bD4IhvV/gkHXPX3C5uu92WdmCfnn0vEIEsMKWlVXVVvQQZKAqvs/awpqIfrUtEViOGEA==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/networks": "^9.0.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/types-create": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/networks": "^12.3.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/types-create": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-known/node_modules/@polkadot/networks": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-9.7.2.tgz",
-            "integrity": "sha512-oMAdF8Y9CLBI0EUZBcycHcvbQQdbkJHevPJ/lwnZXJTaueXuav/Xm2yiFj5J3V8meIjLocURlMawgsAVItXOBQ==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.3.2.tgz",
+            "integrity": "sha512-uCkyybKoeEm1daKr0uT/9oNDHDDzCy2/ZdVl346hQqfdR1Ct3BaxMjxqvdmb5N8aCw0cBWSfgsxAYtw8ESmllQ==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.18.6",
-                "@polkadot/util": "9.7.2",
-                "@substrate/ss58-registry": "^1.23.0"
+                "@polkadot/util": "12.3.2",
+                "@substrate/ss58-registry": "^1.40.0",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-known/node_modules/@polkadot/types": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.2.1.tgz",
-            "integrity": "sha512-Qvgvxt5GNb9RRXDNIXB9Gu+E4Vw/9aRKw76mamWqFgtRONOJ8l6HgKgWvzsCZ/lBIKLi5NE/BKPIkOhZAWfDmA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+            "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/keyring": "^9.0.1",
-                "@polkadot/types-augment": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/types-create": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "@polkadot/util-crypto": "^9.0.1",
-                "rxjs": "^7.5.5"
+                "@polkadot/keyring": "^12.3.1",
+                "@polkadot/types-augment": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/types-create": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-known/node_modules/@polkadot/types-augment": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.2.1.tgz",
-            "integrity": "sha512-+uMC4JTYTghhbwyvvdjUnLcV3HeUZOqscfVYPYPtwctblXZRZae77b8TD1H+NqgBhloJPC8I8uBVflRIb+HcpA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+            "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-known/node_modules/@polkadot/types-codec": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.2.1.tgz",
-            "integrity": "sha512-dG5QUCNVmRA8BuQQdxU+2DB4lp+kbO22rDimJMNCr7lOELCIkbo+GFNpWhPInIq+aLrTTAyyv0VguJ3ciQVFJA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+            "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/x-bigint": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-known/node_modules/@polkadot/types-create": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.2.1.tgz",
-            "integrity": "sha512-pdzSZgozhe/2EXnnXlxEoBiFwcg19mZ+o0ICdM+cpHayume5C3DrJzIRhQpKu7ndUyEb+MorC5aZn9Cj8Kdp0Q==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+            "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/types-known/node_modules/@polkadot/x-bigint": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+            "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/types-known/node_modules/@polkadot/x-global": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+            "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/types-support": {
@@ -4405,6 +4622,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
             "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==",
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -4416,6 +4634,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
             "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -4427,6 +4646,7 @@
             "version": "10.2.1",
             "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.2.1.tgz",
             "integrity": "sha512-84/zzxDZANQ4AfsCT1vrjX3I23/mj9WUWl1F7q9ruK6UBFyGsl46Y3ABOopFHij9UXhppndhB65IeDnqoOKqxQ==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.6",
                 "@polkadot/util": "10.2.1",
@@ -4444,6 +4664,7 @@
             "version": "9.7.1",
             "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.7.1.tgz",
             "integrity": "sha512-rCzRrPxIUitrT2WxPi6FG9gLHyTzZ8SYHUb8Ha279YQQFxl6Lv6p33uzQJcUutQVmvaUAPJGGkAQLCbmXAFbnA==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.1",
                 "@polkadot/types": "9.7.1",
@@ -4458,6 +4679,7 @@
             "version": "9.7.1",
             "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.7.1.tgz",
             "integrity": "sha512-rzSUbDL7ytFVg7mnjV9zutLSDwTN7nEBSKYLtUK8vnGOG+nr8ds4IUcur0XK6VPj72Duz5ovvxi/JyUlE9+W3Q==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.1",
                 "@polkadot/util": "^10.1.11",
@@ -4471,6 +4693,7 @@
             "version": "9.7.1",
             "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.7.1.tgz",
             "integrity": "sha512-Bk1F3bHmK2yIeVj9dPP4v5TMvsPFMOquovFp2rTmW7gLGauiwQTS1WP356VtmSDbZWJ0H89nHpXdgYRqDDi5sg==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.1",
                 "@polkadot/types-codec": "9.7.1",
@@ -4484,6 +4707,7 @@
             "version": "10.2.1",
             "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.2.1.tgz",
             "integrity": "sha512-ewGKSOp+VXKEeCvpCCP2Qqi/FVkewBF9vb/N8pRwuNQ2XE9k1lnsOZZeQemVBDhKsZz+h3IeNcWejaF6K3vYHQ==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.6",
                 "@polkadot/x-bigint": "10.2.1",
@@ -4501,6 +4725,7 @@
             "version": "10.2.1",
             "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.2.1.tgz",
             "integrity": "sha512-UH1J4oD92gkLXMfVTLee3Y2vYadNyp1lmS4P2nZwQ0SOzGZ4rN7khD2CrB1cXS9WPq196Zb5oZdGLnPYnXHtjw==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.6",
                 "@noble/hashes": "1.1.3",
@@ -4525,6 +4750,7 @@
             "version": "10.2.1",
             "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.2.1.tgz",
             "integrity": "sha512-hpFmrdv/rrSM4UNaV8TJBgMtwXsYlNgBTSUmnKWwJIN3PhOUeYxl1qIbPchxGbJBc35WviJCZe7rlLja9JvFcw==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.6",
                 "@polkadot/x-global": "10.2.1"
@@ -4537,6 +4763,7 @@
             "version": "10.2.1",
             "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.2.1.tgz",
             "integrity": "sha512-4gMyY6DCH34KA++bawu/zlUJ0/8+aZJsurwjRBbkdfOS2uLo0K+vJ5GBevAhl0VSznM36ptfh/MpkIBKK/6R0g==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.6",
                 "@polkadot/x-global": "10.2.1"
@@ -4546,116 +4773,227 @@
             }
         },
         "node_modules/@polkadot/util": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-9.7.2.tgz",
-            "integrity": "sha512-ivTmA+KkPCq5i3O0Gk+dTds/hwdwlYCh89aKfeaG9ni3XHUbbuBgTqHneo648HqxwAwSAyiDiwE9EdXrzAdO4Q==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.3.2.tgz",
+            "integrity": "sha512-y/JShcGyOamCUiSIg++XZuLHt1ktSKBaSH2K5Nw5NXlgP0+7am+GZzqPB8fQ4qhYLruEOv+YRiz0GC1Zr9S+wg==",
             "dependencies": {
-                "@babel/runtime": "^7.18.6",
-                "@polkadot/x-bigint": "9.7.2",
-                "@polkadot/x-global": "9.7.2",
-                "@polkadot/x-textdecoder": "9.7.2",
-                "@polkadot/x-textencoder": "9.7.2",
-                "@types/bn.js": "^5.1.0",
+                "@polkadot/x-bigint": "12.3.2",
+                "@polkadot/x-global": "12.3.2",
+                "@polkadot/x-textdecoder": "12.3.2",
+                "@polkadot/x-textencoder": "12.3.2",
+                "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
-                "ip-regex": "^4.3.0"
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/util-crypto": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-9.7.2.tgz",
-            "integrity": "sha512-tfz6mJtPwoNteivKCmR+QklC4mr1/hGZRsDJLWKaFhanDinYZ3V2pJM1EbCI6WONLuuzlTxsDXjAffWzzRqlPA==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.3.2.tgz",
+            "integrity": "sha512-pTpx+YxolY0BDT4RcGmgeKbHHD/dI6Ll9xRsqmVdIjpcVVY20uDNTyXs81ZNtfKgyod1y9JQkfNv2Dz9iEpTkQ==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.18.6",
-                "@noble/hashes": "1.1.2",
-                "@noble/secp256k1": "1.6.0",
-                "@polkadot/networks": "9.7.2",
-                "@polkadot/util": "9.7.2",
-                "@polkadot/wasm-crypto": "^6.2.2",
-                "@polkadot/x-bigint": "9.7.2",
-                "@polkadot/x-randomvalues": "9.7.2",
+                "@noble/curves": "1.1.0",
+                "@noble/hashes": "1.3.1",
+                "@polkadot/networks": "12.3.2",
+                "@polkadot/util": "12.3.2",
+                "@polkadot/wasm-crypto": "^7.2.1",
+                "@polkadot/wasm-util": "^7.2.1",
+                "@polkadot/x-bigint": "12.3.2",
+                "@polkadot/x-randomvalues": "12.3.2",
                 "@scure/base": "1.1.1",
-                "ed2curve": "^0.3.0",
-                "tweetnacl": "^1.0.3"
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             },
             "peerDependencies": {
-                "@polkadot/util": "9.7.2"
+                "@polkadot/util": "12.3.2"
             }
         },
         "node_modules/@polkadot/util-crypto/node_modules/@polkadot/networks": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-9.7.2.tgz",
-            "integrity": "sha512-oMAdF8Y9CLBI0EUZBcycHcvbQQdbkJHevPJ/lwnZXJTaueXuav/Xm2yiFj5J3V8meIjLocURlMawgsAVItXOBQ==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.3.2.tgz",
+            "integrity": "sha512-uCkyybKoeEm1daKr0uT/9oNDHDDzCy2/ZdVl346hQqfdR1Ct3BaxMjxqvdmb5N8aCw0cBWSfgsxAYtw8ESmllQ==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.18.6",
-                "@polkadot/util": "9.7.2",
-                "@substrate/ss58-registry": "^1.23.0"
+                "@polkadot/util": "12.3.2",
+                "@substrate/ss58-registry": "^1.40.0",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
+            }
+        },
+        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-bridge": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.2.1.tgz",
+            "integrity": "sha512-uV/LHREDBGBbHrrv7HTki+Klw0PYZzFomagFWII4lp6Toj/VCvRh5WMzooVC+g/XsBGosAwrvBhoModabyHx+A==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/wasm-util": "7.2.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*",
+                "@polkadot/x-randomvalues": "*"
+            }
+        },
+        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-crypto": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.2.1.tgz",
+            "integrity": "sha512-SA2+33S9TAwGhniKgztVN6pxUKpGfN4Tre/eUZGUfpgRkT92wIUT2GpGWQE+fCCqGQgADrNiBcwt6XwdPqMQ4Q==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/wasm-bridge": "7.2.1",
+                "@polkadot/wasm-crypto-asmjs": "7.2.1",
+                "@polkadot/wasm-crypto-init": "7.2.1",
+                "@polkadot/wasm-crypto-wasm": "7.2.1",
+                "@polkadot/wasm-util": "7.2.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*",
+                "@polkadot/x-randomvalues": "*"
+            }
+        },
+        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-crypto-asmjs": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.2.1.tgz",
+            "integrity": "sha512-z/d21bmxyVfkzGsKef/FWswKX02x5lK97f4NPBZ9XBeiFkmzlXhdSnu58/+b1sKsRAGdW/Rn/rTNRDhW0GqCAg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-crypto-init": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.2.1.tgz",
+            "integrity": "sha512-GcEXtwN9LcSf32V9zSaYjHImFw16hCyo2Xzg4GLLDPPeaAAfbFr2oQMgwyDbvBrBjLKHVHjsPZyGhXae831amw==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/wasm-bridge": "7.2.1",
+                "@polkadot/wasm-crypto-asmjs": "7.2.1",
+                "@polkadot/wasm-crypto-wasm": "7.2.1",
+                "@polkadot/wasm-util": "7.2.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*",
+                "@polkadot/x-randomvalues": "*"
+            }
+        },
+        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-crypto-wasm": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.2.1.tgz",
+            "integrity": "sha512-DqyXE4rSD0CVlLIw88B58+HHNyrvm+JAnYyuEDYZwCvzUWOCNos/DDg9wi/K39VAIsCCKDmwKqkkfIofuOj/lA==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/wasm-util": "7.2.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-util": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.2.1.tgz",
+            "integrity": "sha512-FBSn/3aYJzhN0sYAYhHB8y9JL8mVgxLy4M1kUXYbyo+8GLRQEN5rns8Vcb8TAlIzBWgVTOOptYBvxo0oj0h7Og==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
             }
         },
         "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-bigint": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-9.7.2.tgz",
-            "integrity": "sha512-qi8/DTGypFSt5vvNOsYcEaqH72lymfyidGlsHlZ6e7nNASnEhk/NaOcINiTr1ds+fpu4dtKXWAIPZufujf2JeQ==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+            "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.18.6",
-                "@polkadot/x-global": "9.7.2"
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-global": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-9.7.2.tgz",
-            "integrity": "sha512-3NN5JhjosaelaFWBJSlv9mb/gDAlt7RuZ8NKlOjB+LQHd9g6ZbnYi5wwjW+i/x/3E4IVbBx66uvWgNaw7IBrkg==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+            "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.18.6"
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-randomvalues": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-9.7.2.tgz",
-            "integrity": "sha512-819slnXNpoVtqdhjI19ao7w5m+Zwx11VfwCZkFQypVv3b/1UEoKG/baJA9dVI6yMvhnBN//i8mLgNy3IXWbVVw==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.3.2.tgz",
+            "integrity": "sha512-ywjIs8CWpvOGmq+3cGCNPOHxAjPHdBUiXyDccftx5BRVdmtbt36gK/V84bKr6Xs73FGu0jprUAOSRRsLZX/3dg==",
+            "dev": true,
             "dependencies": {
-                "@babel/runtime": "^7.18.6",
-                "@polkadot/x-global": "9.7.2"
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "12.3.2",
+                "@polkadot/wasm-util": "*"
             }
         },
         "node_modules/@polkadot/util/node_modules/@polkadot/x-bigint": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-9.7.2.tgz",
-            "integrity": "sha512-qi8/DTGypFSt5vvNOsYcEaqH72lymfyidGlsHlZ6e7nNASnEhk/NaOcINiTr1ds+fpu4dtKXWAIPZufujf2JeQ==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+            "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
             "dependencies": {
-                "@babel/runtime": "^7.18.6",
-                "@polkadot/x-global": "9.7.2"
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/util/node_modules/@polkadot/x-global": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-9.7.2.tgz",
-            "integrity": "sha512-3NN5JhjosaelaFWBJSlv9mb/gDAlt7RuZ8NKlOjB+LQHd9g6ZbnYi5wwjW+i/x/3E4IVbBx66uvWgNaw7IBrkg==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+            "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
             "dependencies": {
-                "@babel/runtime": "^7.18.6"
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/wasm-bridge": {
@@ -4758,6 +5096,7 @@
             "version": "10.2.1",
             "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.2.1.tgz",
             "integrity": "sha512-asFroI2skC4gYv0oIqqb84DqCCxhNUTSCKobEg57WdXoT4TKrN9Uetg2AMSIHRiX/9lP3EPMhUjM1VVGobTQRQ==",
+            "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.20.6",
                 "@polkadot/x-global": "10.2.1"
@@ -4805,49 +5144,49 @@
             }
         },
         "node_modules/@polkadot/x-textdecoder": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-9.7.2.tgz",
-            "integrity": "sha512-hhrMNZwJBmusdpqjDRpOHZoMB4hpyJt9Gu9Bi9is7/D/vq/hpxq8z7s6NxrbRyXJf1SIk6NMK0jf5XjRLdKdbw==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.3.2.tgz",
+            "integrity": "sha512-lY5bfA5xArJRWEJlYOlQQMJeTjWD8s0yMhchirVgf5xj8Id9vPGeUoneH+VFDEwgXxrqBvDFJ4smN4T/r6a/fg==",
             "dependencies": {
-                "@babel/runtime": "^7.18.6",
-                "@polkadot/x-global": "9.7.2"
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/x-textdecoder/node_modules/@polkadot/x-global": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-9.7.2.tgz",
-            "integrity": "sha512-3NN5JhjosaelaFWBJSlv9mb/gDAlt7RuZ8NKlOjB+LQHd9g6ZbnYi5wwjW+i/x/3E4IVbBx66uvWgNaw7IBrkg==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+            "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
             "dependencies": {
-                "@babel/runtime": "^7.18.6"
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/x-textencoder": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-9.7.2.tgz",
-            "integrity": "sha512-GHbSdbMPixDAOnJ9cvL/x9sPNeHegPoDSqCAzY5H6/zHc/fNn0vUu0To9VpPgPhp/Jb9dbc0h8YqEyvOcOlphw==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.3.2.tgz",
+            "integrity": "sha512-iP3qEBiHzBckQ9zeY7ZHRWuu7mCEg5SMpOugs6UODRk8sx6KHzGQYlghBbWLit0uppPDVE0ifEwZ2n73djJHWQ==",
             "dependencies": {
-                "@babel/runtime": "^7.18.6",
-                "@polkadot/x-global": "9.7.2"
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/x-textencoder/node_modules/@polkadot/x-global": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-9.7.2.tgz",
-            "integrity": "sha512-3NN5JhjosaelaFWBJSlv9mb/gDAlt7RuZ8NKlOjB+LQHd9g6ZbnYi5wwjW+i/x/3E4IVbBx66uvWgNaw7IBrkg==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+            "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
             "dependencies": {
-                "@babel/runtime": "^7.18.6"
+                "tslib": "^2.5.3"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/@polkadot/x-ws": {
@@ -5004,9 +5343,9 @@
             }
         },
         "node_modules/@substrate/ss58-registry": {
-            "version": "1.35.0",
-            "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.35.0.tgz",
-            "integrity": "sha512-cIY3J7RlT4mfPNFwd2mv1q9vTp/shImw2gN2y2outMhOcagH/HG+W8/JohpifjxPC/1pbQ0Z8nxfL5Td3EchcA=="
+            "version": "1.41.0",
+            "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.41.0.tgz",
+            "integrity": "sha512-TLz5VkEaJRNFzf1Oiix9gqknKer3aKbLfjK9XHBFCIhdxlQpI+S6lZGu3wT4DHAGXPakYfXb8+9ZIOtWLcQ/2Q=="
         },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.9",
@@ -6897,7 +7236,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
             "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-            "dev": true,
             "engines": {
                 "node": ">= 12"
             }
@@ -7892,7 +8230,6 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
             "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -8020,7 +8357,6 @@
             "version": "4.0.10",
             "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
             "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-            "dev": true,
             "dependencies": {
                 "fetch-blob": "^3.1.2"
             },
@@ -8365,6 +8701,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
             "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -10914,9 +11251,9 @@
             "dev": true
         },
         "node_modules/mock-socket": {
-            "version": "9.1.5",
-            "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.1.5.tgz",
-            "integrity": "sha512-3DeNIcsQixWHHKk6NdoBhWI4t1VMj5/HzfnI1rE/pLl5qKx7+gd4DNA07ehTaZ6MoUU053si6Hd+YtiM/tQZfg==",
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.2.1.tgz",
+            "integrity": "sha512-aw9F9T9G2zpGipLLhSNh6ZpgUyUl4frcVmRN08uE1NWPWg43Wx6+sGPDbQ7E5iFZZDJW5b5bypMeAEHqTbIFag==",
             "engines": {
                 "node": ">= 8"
             }
@@ -10968,9 +11305,9 @@
             "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
         },
         "node_modules/nock": {
-            "version": "13.2.9",
-            "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.9.tgz",
-            "integrity": "sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==",
+            "version": "13.3.1",
+            "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.1.tgz",
+            "integrity": "sha512-vHnopocZuI93p2ccivFyGuUfzjq2fxNyNurp7816mlT5V5HF4SzXu8lvLrVzBbNqzs+ODooZ6OksuSUNM7Njkw==",
             "dependencies": {
                 "debug": "^4.1.0",
                 "json-stringify-safe": "^5.0.1",
@@ -10985,7 +11322,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
             "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -11001,10 +11337,9 @@
             }
         },
         "node_modules/node-fetch": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-            "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
-            "dev": true,
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+            "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
             "dependencies": {
                 "data-uri-to-buffer": "^4.0.0",
                 "fetch-blob": "^3.1.4",
@@ -11794,9 +12129,9 @@
             }
         },
         "node_modules/rxjs": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.6.0.tgz",
-            "integrity": "sha512-DDa7d8TFNUalGC9VqXvQ1euWNN7sc63TrUCuM9J998+ViviahMIjKSOU7rfcgFOF+FCD71BhDRv4hrFz+ImDLQ==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -11928,6 +12263,17 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/smoldot": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-1.0.4.tgz",
+            "integrity": "sha512-N3TazI1C4GGrseFH/piWyZCCCRJTRx2QhDfrUKRT4SzILlW5m8ayZ3QTKICcz1C/536T9cbHHJyP7afxI6Mi1A==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "pako": "^2.0.4",
+                "ws": "^8.8.1"
             }
         },
         "node_modules/source-map": {
@@ -12437,7 +12783,8 @@
         "node_modules/tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "dev": true
         },
         "node_modules/ts-jest": {
             "version": "28.0.8",
@@ -12645,9 +12992,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
         },
         "node_modules/tslint": {
             "version": "6.1.3",
@@ -12992,7 +13339,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
             "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-            "dev": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -13000,7 +13346,8 @@
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "dev": true
         },
         "node_modules/webpack": {
             "version": "5.75.0",
@@ -13200,6 +13547,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dev": true,
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -13328,16 +13676,15 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-            "dev": true,
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
             "engines": {
                 "node": ">=10.0.0"
             },
             "peerDependencies": {
                 "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
+                "utf-8-validate": ">=5.0.2"
             },
             "peerDependenciesMeta": {
                 "bufferutil": {
@@ -13450,8 +13797,8 @@
                 "@cere-ddc-sdk/core": "1.7.6-rc.1",
                 "@cere-ddc-sdk/proto": "1.7.6-rc.1",
                 "@cere-ddc-sdk/smart-contract": "1.7.6-rc.1",
-                "@polkadot/util": "~9.7.2",
-                "@polkadot/util-crypto": "~9.7.2",
+                "@polkadot/util": "^10.1.8",
+                "@polkadot/util-crypto": "^10.1.8",
                 "nanoid": "3.3.3",
                 "varint": "^6.0.0"
             },
@@ -13462,6 +13809,130 @@
                 "cross-fetch": "^3.1.5",
                 "rimraf": "^3.0.2",
                 "typescript": "4.5.4"
+            }
+        },
+        "packages/content-addressable-storage/node_modules/@noble/hashes": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+            "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ]
+        },
+        "packages/content-addressable-storage/node_modules/@polkadot/networks": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.4.2.tgz",
+            "integrity": "sha512-FAh/znrEvWBiA/LbcT5GXHsCFUl//y9KqxLghSr/CreAmAergiJNT0MVUezC7Y36nkATgmsr4ylFwIxhVtuuCw==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/util": "10.4.2",
+                "@substrate/ss58-registry": "^1.38.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/content-addressable-storage/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/content-addressable-storage/node_modules/@polkadot/util-crypto": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.4.2.tgz",
+            "integrity": "sha512-RxZvF7C4+EF3fzQv8hZOLrYCBq5+wA+2LWv98nECkroChY3C2ZZvyWDqn8+aonNULt4dCVTWDZM0QIY6y4LUAQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@noble/hashes": "1.2.0",
+                "@noble/secp256k1": "1.7.1",
+                "@polkadot/networks": "10.4.2",
+                "@polkadot/util": "10.4.2",
+                "@polkadot/wasm-crypto": "^6.4.1",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-randomvalues": "10.4.2",
+                "@scure/base": "1.1.1",
+                "ed2curve": "^0.3.0",
+                "tweetnacl": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "10.4.2"
+            }
+        },
+        "packages/content-addressable-storage/node_modules/@polkadot/x-bigint": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.4.2.tgz",
+            "integrity": "sha512-awRiox+/XSReLzimAU94fPldowiwnnMUkQJe8AebYhNocAj6SJU00GNoj6j6tAho6yleOwrTJXZaWFBaQVJQNg==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/content-addressable-storage/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/content-addressable-storage/node_modules/@polkadot/x-randomvalues": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.4.2.tgz",
+            "integrity": "sha512-mf1Wbpe7pRZHO0V3V89isPLqZOy5XGX2bCqsfUWHgb1NvV1MMx5TjVjdaYyNlGTiOkAmJKlOHshcfPU2sYWpNg==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/content-addressable-storage/node_modules/@polkadot/x-textdecoder": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.4.2.tgz",
+            "integrity": "sha512-d3ADduOKUTU+cliz839+KCFmi23pxTlabH7qh7Vs1GZQvXOELWdqFOqakdiAjtMn68n1KVF4O14Y+OUm7gp/zA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/content-addressable-storage/node_modules/@polkadot/x-textencoder": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.4.2.tgz",
+            "integrity": "sha512-mxcQuA1exnyv74Kasl5vxBq01QwckG088lYjc3KwmND6+pPrW2OWagbxFX5VFoDLDAE+UJtnUHsjdWyOTDhpQA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "packages/content-addressable-storage/node_modules/typescript": {
@@ -13482,10 +13953,9 @@
             "version": "1.7.6-rc.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@polkadot/keyring": "~9.7.2",
-                "@polkadot/util": "~9.7.2",
-                "@polkadot/util-crypto": "~9.7.2",
-                "@polkadot/wasm-crypto": "~6.4.1"
+                "@polkadot/keyring": "^10.1.8",
+                "@polkadot/util": "^10.1.8",
+                "@polkadot/util-crypto": "^10.1.8"
             },
             "devDependencies": {
                 "@multiformats/blake2": "^1.0.10",
@@ -13499,22 +13969,9 @@
             }
         },
         "packages/core/node_modules/@noble/hashes": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
-            "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ]
-        },
-        "packages/core/node_modules/@noble/secp256k1": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
-            "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==",
-            "dev": true,
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+            "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
             "funding": [
                 {
                     "type": "individual",
@@ -13539,6 +13996,219 @@
                 "@polkadot/util-crypto": "*"
             }
         },
+        "packages/core/node_modules/@polkadot/extension-dapp/node_modules/@noble/hashes": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+            "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ]
+        },
+        "packages/core/node_modules/@polkadot/extension-dapp/node_modules/@noble/secp256k1": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.0.tgz",
+            "integrity": "sha512-DWSsg8zMHOYMYBqIQi96BQuthZrp98LCeMNcUOaffCIVYQ5yxDbNikLF+H7jEnmNNmXbtVic46iCuVWzar+MgA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ]
+        },
+        "packages/core/node_modules/@polkadot/extension-dapp/node_modules/@polkadot/networks": {
+            "version": "9.7.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-9.7.2.tgz",
+            "integrity": "sha512-oMAdF8Y9CLBI0EUZBcycHcvbQQdbkJHevPJ/lwnZXJTaueXuav/Xm2yiFj5J3V8meIjLocURlMawgsAVItXOBQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.18.6",
+                "@polkadot/util": "9.7.2",
+                "@substrate/ss58-registry": "^1.23.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-dapp/node_modules/@polkadot/util": {
+            "version": "9.7.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-9.7.2.tgz",
+            "integrity": "sha512-ivTmA+KkPCq5i3O0Gk+dTds/hwdwlYCh89aKfeaG9ni3XHUbbuBgTqHneo648HqxwAwSAyiDiwE9EdXrzAdO4Q==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.18.6",
+                "@polkadot/x-bigint": "9.7.2",
+                "@polkadot/x-global": "9.7.2",
+                "@polkadot/x-textdecoder": "9.7.2",
+                "@polkadot/x-textencoder": "9.7.2",
+                "@types/bn.js": "^5.1.0",
+                "bn.js": "^5.2.1",
+                "ip-regex": "^4.3.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-dapp/node_modules/@polkadot/util-crypto": {
+            "version": "9.7.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-9.7.2.tgz",
+            "integrity": "sha512-tfz6mJtPwoNteivKCmR+QklC4mr1/hGZRsDJLWKaFhanDinYZ3V2pJM1EbCI6WONLuuzlTxsDXjAffWzzRqlPA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.18.6",
+                "@noble/hashes": "1.1.2",
+                "@noble/secp256k1": "1.6.0",
+                "@polkadot/networks": "9.7.2",
+                "@polkadot/util": "9.7.2",
+                "@polkadot/wasm-crypto": "^6.2.2",
+                "@polkadot/x-bigint": "9.7.2",
+                "@polkadot/x-randomvalues": "9.7.2",
+                "@scure/base": "1.1.1",
+                "ed2curve": "^0.3.0",
+                "tweetnacl": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "9.7.2"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-dapp/node_modules/@polkadot/wasm-crypto": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-6.4.1.tgz",
+            "integrity": "sha512-FH+dcDPdhSLJvwL0pMLtn/LIPd62QDPODZRCmDyw+pFjLOMaRBc7raomWUOqyRWJTnqVf/iscc2rLVLNMyt7ag==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.20.6",
+                "@polkadot/wasm-bridge": "6.4.1",
+                "@polkadot/wasm-crypto-asmjs": "6.4.1",
+                "@polkadot/wasm-crypto-init": "6.4.1",
+                "@polkadot/wasm-crypto-wasm": "6.4.1",
+                "@polkadot/wasm-util": "6.4.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*",
+                "@polkadot/x-randomvalues": "*"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-dapp/node_modules/@polkadot/wasm-crypto-asmjs": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-6.4.1.tgz",
+            "integrity": "sha512-UxZTwuBZlnODGIQdCsE2Sn/jU0O2xrNQ/TkhRFELfkZXEXTNu4lw6NpaKq7Iey4L+wKd8h4lT3VPVkMcPBLOvA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.20.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-dapp/node_modules/@polkadot/wasm-crypto-wasm": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-6.4.1.tgz",
+            "integrity": "sha512-3VV9ZGzh0ZY3SmkkSw+0TRXxIpiO0nB8lFwlRgcwaCihwrvLfRnH9GI8WE12mKsHVjWTEVR3ogzILJxccAUjDA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.20.6",
+                "@polkadot/wasm-util": "6.4.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-dapp/node_modules/@polkadot/wasm-util": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-6.4.1.tgz",
+            "integrity": "sha512-Uwo+WpEsDmFExWC5kTNvsVhvqXMZEKf4gUHXFn4c6Xz4lmieRT5g+1bO1KJ21pl4msuIgdV3Bksfs/oiqMFqlw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.20.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-dapp/node_modules/@polkadot/x-bigint": {
+            "version": "9.7.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-9.7.2.tgz",
+            "integrity": "sha512-qi8/DTGypFSt5vvNOsYcEaqH72lymfyidGlsHlZ6e7nNASnEhk/NaOcINiTr1ds+fpu4dtKXWAIPZufujf2JeQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.18.6",
+                "@polkadot/x-global": "9.7.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-dapp/node_modules/@polkadot/x-global": {
+            "version": "9.7.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-9.7.2.tgz",
+            "integrity": "sha512-3NN5JhjosaelaFWBJSlv9mb/gDAlt7RuZ8NKlOjB+LQHd9g6ZbnYi5wwjW+i/x/3E4IVbBx66uvWgNaw7IBrkg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.18.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-dapp/node_modules/@polkadot/x-randomvalues": {
+            "version": "9.7.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-9.7.2.tgz",
+            "integrity": "sha512-819slnXNpoVtqdhjI19ao7w5m+Zwx11VfwCZkFQypVv3b/1UEoKG/baJA9dVI6yMvhnBN//i8mLgNy3IXWbVVw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.18.6",
+                "@polkadot/x-global": "9.7.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-dapp/node_modules/@polkadot/x-textdecoder": {
+            "version": "9.7.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-9.7.2.tgz",
+            "integrity": "sha512-hhrMNZwJBmusdpqjDRpOHZoMB4hpyJt9Gu9Bi9is7/D/vq/hpxq8z7s6NxrbRyXJf1SIk6NMK0jf5XjRLdKdbw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.18.6",
+                "@polkadot/x-global": "9.7.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-dapp/node_modules/@polkadot/x-textencoder": {
+            "version": "9.7.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-9.7.2.tgz",
+            "integrity": "sha512-GHbSdbMPixDAOnJ9cvL/x9sPNeHegPoDSqCAzY5H6/zHc/fNn0vUu0To9VpPgPhp/Jb9dbc0h8YqEyvOcOlphw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.18.6",
+                "@polkadot/x-global": "9.7.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "packages/core/node_modules/@polkadot/extension-inject": {
             "version": "0.43.2",
             "resolved": "https://registry.npmjs.org/@polkadot/extension-inject/-/extension-inject-0.43.2.tgz",
@@ -13556,6 +14226,168 @@
                 "@polkadot/api": "*"
             }
         },
+        "packages/core/node_modules/@polkadot/extension-inject/node_modules/@noble/hashes": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+            "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ]
+        },
+        "packages/core/node_modules/@polkadot/extension-inject/node_modules/@noble/secp256k1": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.0.tgz",
+            "integrity": "sha512-DWSsg8zMHOYMYBqIQi96BQuthZrp98LCeMNcUOaffCIVYQ5yxDbNikLF+H7jEnmNNmXbtVic46iCuVWzar+MgA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ]
+        },
+        "packages/core/node_modules/@polkadot/extension-inject/node_modules/@polkadot/networks": {
+            "version": "9.7.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-9.7.2.tgz",
+            "integrity": "sha512-oMAdF8Y9CLBI0EUZBcycHcvbQQdbkJHevPJ/lwnZXJTaueXuav/Xm2yiFj5J3V8meIjLocURlMawgsAVItXOBQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.18.6",
+                "@polkadot/util": "9.7.2",
+                "@substrate/ss58-registry": "^1.23.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-inject/node_modules/@polkadot/util": {
+            "version": "9.7.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-9.7.2.tgz",
+            "integrity": "sha512-ivTmA+KkPCq5i3O0Gk+dTds/hwdwlYCh89aKfeaG9ni3XHUbbuBgTqHneo648HqxwAwSAyiDiwE9EdXrzAdO4Q==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.18.6",
+                "@polkadot/x-bigint": "9.7.2",
+                "@polkadot/x-global": "9.7.2",
+                "@polkadot/x-textdecoder": "9.7.2",
+                "@polkadot/x-textencoder": "9.7.2",
+                "@types/bn.js": "^5.1.0",
+                "bn.js": "^5.2.1",
+                "ip-regex": "^4.3.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-inject/node_modules/@polkadot/util-crypto": {
+            "version": "9.7.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-9.7.2.tgz",
+            "integrity": "sha512-tfz6mJtPwoNteivKCmR+QklC4mr1/hGZRsDJLWKaFhanDinYZ3V2pJM1EbCI6WONLuuzlTxsDXjAffWzzRqlPA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.18.6",
+                "@noble/hashes": "1.1.2",
+                "@noble/secp256k1": "1.6.0",
+                "@polkadot/networks": "9.7.2",
+                "@polkadot/util": "9.7.2",
+                "@polkadot/wasm-crypto": "^6.2.2",
+                "@polkadot/x-bigint": "9.7.2",
+                "@polkadot/x-randomvalues": "9.7.2",
+                "@scure/base": "1.1.1",
+                "ed2curve": "^0.3.0",
+                "tweetnacl": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "9.7.2"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-inject/node_modules/@polkadot/wasm-crypto": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-6.4.1.tgz",
+            "integrity": "sha512-FH+dcDPdhSLJvwL0pMLtn/LIPd62QDPODZRCmDyw+pFjLOMaRBc7raomWUOqyRWJTnqVf/iscc2rLVLNMyt7ag==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.20.6",
+                "@polkadot/wasm-bridge": "6.4.1",
+                "@polkadot/wasm-crypto-asmjs": "6.4.1",
+                "@polkadot/wasm-crypto-init": "6.4.1",
+                "@polkadot/wasm-crypto-wasm": "6.4.1",
+                "@polkadot/wasm-util": "6.4.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*",
+                "@polkadot/x-randomvalues": "*"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-inject/node_modules/@polkadot/wasm-crypto-asmjs": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-6.4.1.tgz",
+            "integrity": "sha512-UxZTwuBZlnODGIQdCsE2Sn/jU0O2xrNQ/TkhRFELfkZXEXTNu4lw6NpaKq7Iey4L+wKd8h4lT3VPVkMcPBLOvA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.20.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-inject/node_modules/@polkadot/wasm-crypto-wasm": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-6.4.1.tgz",
+            "integrity": "sha512-3VV9ZGzh0ZY3SmkkSw+0TRXxIpiO0nB8lFwlRgcwaCihwrvLfRnH9GI8WE12mKsHVjWTEVR3ogzILJxccAUjDA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.20.6",
+                "@polkadot/wasm-util": "6.4.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-inject/node_modules/@polkadot/wasm-util": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-6.4.1.tgz",
+            "integrity": "sha512-Uwo+WpEsDmFExWC5kTNvsVhvqXMZEKf4gUHXFn4c6Xz4lmieRT5g+1bO1KJ21pl4msuIgdV3Bksfs/oiqMFqlw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.20.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-bigint": {
+            "version": "9.7.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-9.7.2.tgz",
+            "integrity": "sha512-qi8/DTGypFSt5vvNOsYcEaqH72lymfyidGlsHlZ6e7nNASnEhk/NaOcINiTr1ds+fpu4dtKXWAIPZufujf2JeQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.18.6",
+                "@polkadot/x-global": "9.7.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "packages/core/node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-global": {
             "version": "9.7.2",
             "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-9.7.2.tgz",
@@ -13563,6 +14395,75 @@
             "dev": true,
             "dependencies": {
                 "@babel/runtime": "^7.18.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-randomvalues": {
+            "version": "9.7.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-9.7.2.tgz",
+            "integrity": "sha512-819slnXNpoVtqdhjI19ao7w5m+Zwx11VfwCZkFQypVv3b/1UEoKG/baJA9dVI6yMvhnBN//i8mLgNy3IXWbVVw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.18.6",
+                "@polkadot/x-global": "9.7.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-textdecoder": {
+            "version": "9.7.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-9.7.2.tgz",
+            "integrity": "sha512-hhrMNZwJBmusdpqjDRpOHZoMB4hpyJt9Gu9Bi9is7/D/vq/hpxq8z7s6NxrbRyXJf1SIk6NMK0jf5XjRLdKdbw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.18.6",
+                "@polkadot/x-global": "9.7.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-textencoder": {
+            "version": "9.7.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-9.7.2.tgz",
+            "integrity": "sha512-GHbSdbMPixDAOnJ9cvL/x9sPNeHegPoDSqCAzY5H6/zHc/fNn0vUu0To9VpPgPhp/Jb9dbc0h8YqEyvOcOlphw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.18.6",
+                "@polkadot/x-global": "9.7.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/keyring": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.4.2.tgz",
+            "integrity": "sha512-7iHhJuXaHrRTG6cJDbZE9G+c1ts1dujp0qbO4RfAPmT7YUvphHvAtCKueN9UKPz5+TYDL+rP/jDEaSKU8jl/qQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/util": "10.4.2",
+                "@polkadot/util-crypto": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "10.4.2",
+                "@polkadot/util-crypto": "10.4.2"
+            }
+        },
+        "packages/core/node_modules/@polkadot/networks": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.4.2.tgz",
+            "integrity": "sha512-FAh/znrEvWBiA/LbcT5GXHsCFUl//y9KqxLghSr/CreAmAergiJNT0MVUezC7Y36nkATgmsr4ylFwIxhVtuuCw==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/util": "10.4.2",
+                "@substrate/ss58-registry": "^1.38.0"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -13592,24 +14493,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "packages/core/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/keyring": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.2.1.tgz",
-            "integrity": "sha512-84/zzxDZANQ4AfsCT1vrjX3I23/mj9WUWl1F7q9ruK6UBFyGsl46Y3ABOopFHij9UXhppndhB65IeDnqoOKqxQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.20.6",
-                "@polkadot/util": "10.2.1",
-                "@polkadot/util-crypto": "10.2.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "@polkadot/util": "10.2.1",
-                "@polkadot/util-crypto": "10.2.1"
-            }
-        },
         "packages/core/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/util": {
             "version": "10.2.1",
             "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.2.1.tgz",
@@ -13626,31 +14509,6 @@
             },
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "packages/core/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/util-crypto": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.2.1.tgz",
-            "integrity": "sha512-UH1J4oD92gkLXMfVTLee3Y2vYadNyp1lmS4P2nZwQ0SOzGZ4rN7khD2CrB1cXS9WPq196Zb5oZdGLnPYnXHtjw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.20.6",
-                "@noble/hashes": "1.1.3",
-                "@noble/secp256k1": "1.7.0",
-                "@polkadot/networks": "10.2.1",
-                "@polkadot/util": "10.2.1",
-                "@polkadot/wasm-crypto": "^6.4.1",
-                "@polkadot/x-bigint": "10.2.1",
-                "@polkadot/x-randomvalues": "10.2.1",
-                "@scure/base": "1.1.1",
-                "ed2curve": "^0.3.0",
-                "tweetnacl": "^1.0.3"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "@polkadot/util": "10.2.1"
             }
         },
         "packages/core/node_modules/@polkadot/types": {
@@ -13687,24 +14545,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "packages/core/node_modules/@polkadot/types-augment/node_modules/@polkadot/util": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.2.1.tgz",
-            "integrity": "sha512-ewGKSOp+VXKEeCvpCCP2Qqi/FVkewBF9vb/N8pRwuNQ2XE9k1lnsOZZeQemVBDhKsZz+h3IeNcWejaF6K3vYHQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.20.6",
-                "@polkadot/x-bigint": "10.2.1",
-                "@polkadot/x-global": "10.2.1",
-                "@polkadot/x-textdecoder": "10.2.1",
-                "@polkadot/x-textencoder": "10.2.1",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "packages/core/node_modules/@polkadot/types-codec": {
             "version": "8.14.1",
             "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.14.1.tgz",
@@ -13714,24 +14554,6 @@
                 "@babel/runtime": "^7.18.9",
                 "@polkadot/util": "^10.1.1",
                 "@polkadot/x-bigint": "^10.1.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "packages/core/node_modules/@polkadot/types-codec/node_modules/@polkadot/util": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.2.1.tgz",
-            "integrity": "sha512-ewGKSOp+VXKEeCvpCCP2Qqi/FVkewBF9vb/N8pRwuNQ2XE9k1lnsOZZeQemVBDhKsZz+h3IeNcWejaF6K3vYHQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.20.6",
-                "@polkadot/x-bigint": "10.2.1",
-                "@polkadot/x-global": "10.2.1",
-                "@polkadot/x-textdecoder": "10.2.1",
-                "@polkadot/x-textencoder": "10.2.1",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -13751,24 +14573,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "packages/core/node_modules/@polkadot/types-create/node_modules/@polkadot/util": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.2.1.tgz",
-            "integrity": "sha512-ewGKSOp+VXKEeCvpCCP2Qqi/FVkewBF9vb/N8pRwuNQ2XE9k1lnsOZZeQemVBDhKsZz+h3IeNcWejaF6K3vYHQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.20.6",
-                "@polkadot/x-bigint": "10.2.1",
-                "@polkadot/x-global": "10.2.1",
-                "@polkadot/x-textdecoder": "10.2.1",
-                "@polkadot/x-textencoder": "10.2.1",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "packages/core/node_modules/@polkadot/types-support": {
             "version": "8.14.1",
             "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-8.14.1.tgz",
@@ -13780,42 +14584,6 @@
             },
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "packages/core/node_modules/@polkadot/types-support/node_modules/@polkadot/util": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.2.1.tgz",
-            "integrity": "sha512-ewGKSOp+VXKEeCvpCCP2Qqi/FVkewBF9vb/N8pRwuNQ2XE9k1lnsOZZeQemVBDhKsZz+h3IeNcWejaF6K3vYHQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.20.6",
-                "@polkadot/x-bigint": "10.2.1",
-                "@polkadot/x-global": "10.2.1",
-                "@polkadot/x-textdecoder": "10.2.1",
-                "@polkadot/x-textencoder": "10.2.1",
-                "@types/bn.js": "^5.1.1",
-                "bn.js": "^5.2.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "packages/core/node_modules/@polkadot/types/node_modules/@polkadot/keyring": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.2.1.tgz",
-            "integrity": "sha512-84/zzxDZANQ4AfsCT1vrjX3I23/mj9WUWl1F7q9ruK6UBFyGsl46Y3ABOopFHij9UXhppndhB65IeDnqoOKqxQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.20.6",
-                "@polkadot/util": "10.2.1",
-                "@polkadot/util-crypto": "10.2.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "@polkadot/util": "10.2.1",
-                "@polkadot/util-crypto": "10.2.1"
             }
         },
         "packages/core/node_modules/@polkadot/types/node_modules/@polkadot/util": {
@@ -13836,20 +14604,36 @@
                 "node": ">=14.0.0"
             }
         },
-        "packages/core/node_modules/@polkadot/types/node_modules/@polkadot/util-crypto": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.2.1.tgz",
-            "integrity": "sha512-UH1J4oD92gkLXMfVTLee3Y2vYadNyp1lmS4P2nZwQ0SOzGZ4rN7khD2CrB1cXS9WPq196Zb5oZdGLnPYnXHtjw==",
-            "dev": true,
+        "packages/core/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
             "dependencies": {
-                "@babel/runtime": "^7.20.6",
-                "@noble/hashes": "1.1.3",
-                "@noble/secp256k1": "1.7.0",
-                "@polkadot/networks": "10.2.1",
-                "@polkadot/util": "10.2.1",
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/util-crypto": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.4.2.tgz",
+            "integrity": "sha512-RxZvF7C4+EF3fzQv8hZOLrYCBq5+wA+2LWv98nECkroChY3C2ZZvyWDqn8+aonNULt4dCVTWDZM0QIY6y4LUAQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@noble/hashes": "1.2.0",
+                "@noble/secp256k1": "1.7.1",
+                "@polkadot/networks": "10.4.2",
+                "@polkadot/util": "10.4.2",
                 "@polkadot/wasm-crypto": "^6.4.1",
-                "@polkadot/x-bigint": "10.2.1",
-                "@polkadot/x-randomvalues": "10.2.1",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-randomvalues": "10.4.2",
                 "@scure/base": "1.1.1",
                 "ed2curve": "^0.3.0",
                 "tweetnacl": "^1.0.3"
@@ -13858,7 +14642,163 @@
                 "node": ">=14.0.0"
             },
             "peerDependencies": {
-                "@polkadot/util": "10.2.1"
+                "@polkadot/util": "10.4.2"
+            }
+        },
+        "packages/core/node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-crypto": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-6.4.1.tgz",
+            "integrity": "sha512-FH+dcDPdhSLJvwL0pMLtn/LIPd62QDPODZRCmDyw+pFjLOMaRBc7raomWUOqyRWJTnqVf/iscc2rLVLNMyt7ag==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.6",
+                "@polkadot/wasm-bridge": "6.4.1",
+                "@polkadot/wasm-crypto-asmjs": "6.4.1",
+                "@polkadot/wasm-crypto-init": "6.4.1",
+                "@polkadot/wasm-crypto-wasm": "6.4.1",
+                "@polkadot/wasm-util": "6.4.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*",
+                "@polkadot/x-randomvalues": "*"
+            }
+        },
+        "packages/core/node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-crypto/node_modules/@polkadot/wasm-crypto-asmjs": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-6.4.1.tgz",
+            "integrity": "sha512-UxZTwuBZlnODGIQdCsE2Sn/jU0O2xrNQ/TkhRFELfkZXEXTNu4lw6NpaKq7Iey4L+wKd8h4lT3VPVkMcPBLOvA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "packages/core/node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-crypto/node_modules/@polkadot/wasm-crypto-wasm": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-6.4.1.tgz",
+            "integrity": "sha512-3VV9ZGzh0ZY3SmkkSw+0TRXxIpiO0nB8lFwlRgcwaCihwrvLfRnH9GI8WE12mKsHVjWTEVR3ogzILJxccAUjDA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.6",
+                "@polkadot/wasm-util": "6.4.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "packages/core/node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-crypto/node_modules/@polkadot/wasm-util": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-6.4.1.tgz",
+            "integrity": "sha512-Uwo+WpEsDmFExWC5kTNvsVhvqXMZEKf4gUHXFn4c6Xz4lmieRT5g+1bO1KJ21pl4msuIgdV3Bksfs/oiqMFqlw==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "packages/core/node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-bigint": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.4.2.tgz",
+            "integrity": "sha512-awRiox+/XSReLzimAU94fPldowiwnnMUkQJe8AebYhNocAj6SJU00GNoj6j6tAho6yleOwrTJXZaWFBaQVJQNg==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/util/node_modules/@polkadot/x-bigint": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.4.2.tgz",
+            "integrity": "sha512-awRiox+/XSReLzimAU94fPldowiwnnMUkQJe8AebYhNocAj6SJU00GNoj6j6tAho6yleOwrTJXZaWFBaQVJQNg==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/util/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/util/node_modules/@polkadot/x-textdecoder": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.4.2.tgz",
+            "integrity": "sha512-d3ADduOKUTU+cliz839+KCFmi23pxTlabH7qh7Vs1GZQvXOELWdqFOqakdiAjtMn68n1KVF4O14Y+OUm7gp/zA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/util/node_modules/@polkadot/x-textencoder": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.4.2.tgz",
+            "integrity": "sha512-mxcQuA1exnyv74Kasl5vxBq01QwckG088lYjc3KwmND6+pPrW2OWagbxFX5VFoDLDAE+UJtnUHsjdWyOTDhpQA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/x-randomvalues": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.4.2.tgz",
+            "integrity": "sha512-mf1Wbpe7pRZHO0V3V89isPLqZOy5XGX2bCqsfUWHgb1NvV1MMx5TjVjdaYyNlGTiOkAmJKlOHshcfPU2sYWpNg==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/core/node_modules/@polkadot/x-randomvalues/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "packages/core/node_modules/@polkadot/x-textdecoder": {
@@ -13930,8 +14870,8 @@
                 "@cere-ddc-sdk/file-storage": "1.7.6-rc.1",
                 "@cere-ddc-sdk/key-value-storage": "1.7.6-rc.1",
                 "@cere-ddc-sdk/smart-contract": "1.7.6-rc.1",
-                "@polkadot/util": "~9.7.2",
-                "@polkadot/util-crypto": "~9.7.2"
+                "@polkadot/util": "^10.1.8",
+                "@polkadot/util-crypto": "^10.1.8"
             },
             "devDependencies": {
                 "@polkadot/extension-inject": "0.44.6",
@@ -13941,6 +14881,130 @@
                 "rimraf": "^3.0.2",
                 "tweetnacl": "^1.0.3",
                 "typescript": "4.5.4"
+            }
+        },
+        "packages/ddc-client/node_modules/@noble/hashes": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+            "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ]
+        },
+        "packages/ddc-client/node_modules/@polkadot/networks": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.4.2.tgz",
+            "integrity": "sha512-FAh/znrEvWBiA/LbcT5GXHsCFUl//y9KqxLghSr/CreAmAergiJNT0MVUezC7Y36nkATgmsr4ylFwIxhVtuuCw==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/util": "10.4.2",
+                "@substrate/ss58-registry": "^1.38.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/ddc-client/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/ddc-client/node_modules/@polkadot/util-crypto": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.4.2.tgz",
+            "integrity": "sha512-RxZvF7C4+EF3fzQv8hZOLrYCBq5+wA+2LWv98nECkroChY3C2ZZvyWDqn8+aonNULt4dCVTWDZM0QIY6y4LUAQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@noble/hashes": "1.2.0",
+                "@noble/secp256k1": "1.7.1",
+                "@polkadot/networks": "10.4.2",
+                "@polkadot/util": "10.4.2",
+                "@polkadot/wasm-crypto": "^6.4.1",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-randomvalues": "10.4.2",
+                "@scure/base": "1.1.1",
+                "ed2curve": "^0.3.0",
+                "tweetnacl": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "10.4.2"
+            }
+        },
+        "packages/ddc-client/node_modules/@polkadot/x-bigint": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.4.2.tgz",
+            "integrity": "sha512-awRiox+/XSReLzimAU94fPldowiwnnMUkQJe8AebYhNocAj6SJU00GNoj6j6tAho6yleOwrTJXZaWFBaQVJQNg==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/ddc-client/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/ddc-client/node_modules/@polkadot/x-randomvalues": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.4.2.tgz",
+            "integrity": "sha512-mf1Wbpe7pRZHO0V3V89isPLqZOy5XGX2bCqsfUWHgb1NvV1MMx5TjVjdaYyNlGTiOkAmJKlOHshcfPU2sYWpNg==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/ddc-client/node_modules/@polkadot/x-textdecoder": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.4.2.tgz",
+            "integrity": "sha512-d3ADduOKUTU+cliz839+KCFmi23pxTlabH7qh7Vs1GZQvXOELWdqFOqakdiAjtMn68n1KVF4O14Y+OUm7gp/zA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/ddc-client/node_modules/@polkadot/x-textencoder": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.4.2.tgz",
+            "integrity": "sha512-mxcQuA1exnyv74Kasl5vxBq01QwckG088lYjc3KwmND6+pPrW2OWagbxFX5VFoDLDAE+UJtnUHsjdWyOTDhpQA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "packages/ddc-client/node_modules/typescript": {
@@ -14012,16 +15076,15 @@
             "version": "1.7.6-rc.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@polkadot/api": "8.2.1",
-                "@polkadot/api-contract": "8.2.1",
-                "@polkadot/keyring": "~9.7.2",
-                "@polkadot/types": "~9.7.1",
-                "@polkadot/util-crypto": "~9.7.2",
-                "@polkadot/wasm-crypto": "~6.4.1"
+                "@polkadot/api": "9.4.1",
+                "@polkadot/api-contract": "9.4.1",
+                "@polkadot/keyring": "^10.1.8",
+                "@polkadot/types": "9.4.1",
+                "@polkadot/util-crypto": "^10.1.8"
             },
             "devDependencies": {
-                "@polkadot/extension-dapp": "^0.44.1",
-                "@polkadot/extension-inject": "^0.44.1",
+                "@polkadot/extension-dapp": "^0.46.5",
+                "@polkadot/extension-inject": "^0.46.5",
                 "@types/lodash": "^4.14.182",
                 "@types/node": "^16.0.0",
                 "clean-publish": "^4.0.1",
@@ -14030,6 +15093,1694 @@
                 "rimraf": "^3.0.2",
                 "stream-browserify": "^3.0.0",
                 "typescript": "4.5.4"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-9.4.1.tgz",
+            "integrity": "sha512-4xjt5M8f5K8dFvlRXGCjQO8ALplR7fG5TbOBmFdebbL9AinZkOCzKZg9J/nCUzwIYns8syjHFgakDchCkIIBTA==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@polkadot/api-augment": "9.4.1",
+                "@polkadot/api-base": "9.4.1",
+                "@polkadot/api-derive": "9.4.1",
+                "@polkadot/keyring": "^10.1.8",
+                "@polkadot/rpc-augment": "9.4.1",
+                "@polkadot/rpc-core": "9.4.1",
+                "@polkadot/rpc-provider": "9.4.1",
+                "@polkadot/types": "9.4.1",
+                "@polkadot/types-augment": "9.4.1",
+                "@polkadot/types-codec": "9.4.1",
+                "@polkadot/types-create": "9.4.1",
+                "@polkadot/types-known": "9.4.1",
+                "@polkadot/util": "^10.1.8",
+                "@polkadot/util-crypto": "^10.1.8",
+                "eventemitter3": "^4.0.7",
+                "rxjs": "^7.5.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api-augment": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-9.4.1.tgz",
+            "integrity": "sha512-I+jcPAeMUQn0YSs/JZhUsa9+SRcfGjlB0MtzkPb2w1uZhtXgg1bY36q6IXzhEHKxfjjUIjgITp/bSjJWlISzjw==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@polkadot/api-base": "9.4.1",
+                "@polkadot/rpc-augment": "9.4.1",
+                "@polkadot/types": "9.4.1",
+                "@polkadot/types-augment": "9.4.1",
+                "@polkadot/types-codec": "9.4.1",
+                "@polkadot/util": "^10.1.8"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api-augment/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api-augment/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api-base": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-9.4.1.tgz",
+            "integrity": "sha512-APEnF3EviNMI6wKDIqU9xKOpgXhNJoT4ax4qegTqIWltx7aFMLFM8RYPPtMwSF+bm8z5w8aeEJ1H+vVlp4ovQw==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@polkadot/rpc-core": "9.4.1",
+                "@polkadot/types": "9.4.1",
+                "@polkadot/util": "^10.1.8",
+                "rxjs": "^7.5.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api-base/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api-base/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api-contract": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-contract/-/api-contract-9.4.1.tgz",
+            "integrity": "sha512-wDGwGJhvkLStudmlsDaP6pQr4sjLRxtTrhfFU3paDkmAtOJoiUKWSiX62vGv+YMBoRQGvFGcWil5h8PNtTe45A==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@polkadot/api": "9.4.1",
+                "@polkadot/types": "9.4.1",
+                "@polkadot/types-codec": "9.4.1",
+                "@polkadot/types-create": "9.4.1",
+                "@polkadot/util": "^10.1.8",
+                "@polkadot/util-crypto": "^10.1.8",
+                "rxjs": "^7.5.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api-contract/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api-contract/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api-derive": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-9.4.1.tgz",
+            "integrity": "sha512-RgQtiVi+u2fxxleVZ1dxu7FPdj3YMGbwpaBDc9fr2/ys6Jna5myN1ZsGlO7LzUrGGzug1t8HwHmsy9Ssnlod7w==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@polkadot/api": "9.4.1",
+                "@polkadot/api-augment": "9.4.1",
+                "@polkadot/api-base": "9.4.1",
+                "@polkadot/rpc-core": "9.4.1",
+                "@polkadot/types": "9.4.1",
+                "@polkadot/types-codec": "9.4.1",
+                "@polkadot/util": "^10.1.8",
+                "@polkadot/util-crypto": "^10.1.8",
+                "rxjs": "^7.5.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api-derive/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api-derive/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api/node_modules/@polkadot/rpc-provider": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.4.1.tgz",
+            "integrity": "sha512-JBq049KGpM6pDkgbxiADZG1cuTbBcfEJer466SVp54fGaF7ZfpWN6yb9pQNNkHvvx6rzPnxrTxWpqJXHlI+fmw==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@polkadot/keyring": "^10.1.8",
+                "@polkadot/types": "9.4.1",
+                "@polkadot/types-support": "9.4.1",
+                "@polkadot/util": "^10.1.8",
+                "@polkadot/util-crypto": "^10.1.8",
+                "@polkadot/x-fetch": "^10.1.8",
+                "@polkadot/x-global": "^10.1.8",
+                "@polkadot/x-ws": "^10.1.8",
+                "@substrate/connect": "0.7.13",
+                "eventemitter3": "^4.0.7",
+                "mock-socket": "^9.1.5",
+                "nock": "^13.2.9"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api/node_modules/@polkadot/types-support": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.4.1.tgz",
+            "integrity": "sha512-5udvaZU/KvEDzhDTcU8Qv9WG/3mu6nwx7m7PqDDywzUo/MAy2zI4OT6JBHcvJIk8Qm3zVQkVftohR8CbF9FeSg==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@polkadot/util": "^10.1.8"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api/node_modules/@polkadot/x-fetch": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.4.2.tgz",
+            "integrity": "sha512-Ubb64yaM4qwhogNP+4mZ3ibRghEg5UuCYRMNaCFoPgNAY8tQXuDKrHzeks3+frlmeH9YRd89o8wXLtWouwZIcw==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2",
+                "@types/node-fetch": "^2.6.2",
+                "node-fetch": "^3.3.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api/node_modules/@polkadot/x-ws": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.4.2.tgz",
+            "integrity": "sha512-3gHSTXAWQu1EMcMVTF5QDKHhEHzKxhAArweEyDXE7VsgKUP/ixxw4hVZBrkX122iI5l5mjSiooRSnp/Zl3xqDQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2",
+                "@types/websocket": "^1.0.5",
+                "websocket": "^1.0.34"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/api/node_modules/@substrate/connect": {
+            "version": "0.7.13",
+            "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.13.tgz",
+            "integrity": "sha512-mGvvxLVVm2Zziff8SpTybeIy+jq0LN81kPqDp/bGwtxAnRctbCsERChAu4Q5HN27cCjI1iNdzSz5ihF/DP5SdQ==",
+            "dependencies": {
+                "@substrate/connect-extension-protocol": "^1.0.1",
+                "@substrate/smoldot-light": "0.6.33",
+                "eventemitter3": "^4.0.7"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject": {
+            "version": "0.46.5",
+            "resolved": "https://registry.npmjs.org/@polkadot/extension-inject/-/extension-inject-0.46.5.tgz",
+            "integrity": "sha512-QcpkCMuv7iFbWjufkw14JRozpEYFyjP0H8KOJ8IsHGfPd2DPiismQ0NXr+AS7f6U+0I+Rhv9E4dnXxtJPROVMQ==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/api": "^10.9.1",
+                "@polkadot/rpc-provider": "^10.9.1",
+                "@polkadot/types": "^10.9.1",
+                "@polkadot/util": "^12.3.2",
+                "@polkadot/util-crypto": "^12.3.2",
+                "@polkadot/x-global": "^12.3.2",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/api": "*",
+                "@polkadot/util": "*"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject/node_modules/@polkadot/api": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-10.9.1.tgz",
+            "integrity": "sha512-ND/2UqZBWvtt4PfV03OStTKg0mxmPk4UpMAgJKutdgsz/wP9CYJ1KbjwFgPNekL9JnzbKQsWyQNPVrcw7kQk8A==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/api-augment": "10.9.1",
+                "@polkadot/api-base": "10.9.1",
+                "@polkadot/api-derive": "10.9.1",
+                "@polkadot/keyring": "^12.3.1",
+                "@polkadot/rpc-augment": "10.9.1",
+                "@polkadot/rpc-core": "10.9.1",
+                "@polkadot/rpc-provider": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-augment": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/types-create": "10.9.1",
+                "@polkadot/types-known": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "eventemitter3": "^5.0.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject/node_modules/@polkadot/api-augment": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-10.9.1.tgz",
+            "integrity": "sha512-kRZZvCFVcN4hAH4dJ+Qzfdy27/4EEq3oLDf3ihj0LTVrAezSWcKPGE3EVFy+Mn6Lo4SUc7RVyoKvIUhSk2l4Dg==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/api-base": "10.9.1",
+                "@polkadot/rpc-augment": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-augment": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject/node_modules/@polkadot/api-base": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.9.1.tgz",
+            "integrity": "sha512-Q3m2KzlceMK2kX8bhnUZWk3RT6emmijeeFZZQgCePpEcrSeNjnqG4qjuTPgkveaOkUT8MAoDc5Avuzcc2jlW9g==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/rpc-core": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject/node_modules/@polkadot/api-derive": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-10.9.1.tgz",
+            "integrity": "sha512-mRud1UZCFIc4Z63qAoGSIHh/foyUYADfy1RQYCmPpeFKfIdCIrHpd7xFdJXTOMYOS0BwlM6u4qli/ZT4XigezQ==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/api": "10.9.1",
+                "@polkadot/api-augment": "10.9.1",
+                "@polkadot/api-base": "10.9.1",
+                "@polkadot/rpc-core": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject/node_modules/@polkadot/keyring": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.3.2.tgz",
+            "integrity": "sha512-NTdtDeI0DP9l/45hXynNABeP5VB8piw5YR+CbUxK2e36xpJWVXwbcOepzslg5ghE9rs8UKJb30Z/HqTU4sBY0Q==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/util": "12.3.2",
+                "@polkadot/util-crypto": "12.3.2",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "12.3.2",
+                "@polkadot/util-crypto": "12.3.2"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject/node_modules/@polkadot/networks": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.3.2.tgz",
+            "integrity": "sha512-uCkyybKoeEm1daKr0uT/9oNDHDDzCy2/ZdVl346hQqfdR1Ct3BaxMjxqvdmb5N8aCw0cBWSfgsxAYtw8ESmllQ==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/util": "12.3.2",
+                "@substrate/ss58-registry": "^1.40.0",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject/node_modules/@polkadot/rpc-augment": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-10.9.1.tgz",
+            "integrity": "sha512-MaLHkNlyqN20ZRYr6uNd1BZr1OsrnX9qLAmsl0mcrri1vPGRH6VHjfFH1RBLkikpWD82v17g0l2hLwdV1ZHMcw==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/rpc-core": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject/node_modules/@polkadot/rpc-core": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-10.9.1.tgz",
+            "integrity": "sha512-ZtA8B8SfXSAwVkBlCcKRHw0eSM7ec/sbiNOM5GasXPeRujUgT7lOwSH2GbUZSqe9RfRDMp6DvO9c2JoGc3LLWw==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/rpc-augment": "10.9.1",
+                "@polkadot/rpc-provider": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject/node_modules/@polkadot/types": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+            "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/keyring": "^12.3.1",
+                "@polkadot/types-augment": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/types-create": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-augment": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+            "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-codec": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+            "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/x-bigint": "^12.3.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-create": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+            "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-known": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-10.9.1.tgz",
+            "integrity": "sha512-zCMVWc4pJtkbMFPu72bD4IhvV/gkHXPX3C5uu92WdmCfnn0vEIEsMKWlVXVVvQQZKAqvs/awpqIfrUtEViOGEA==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/networks": "^12.3.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/types-create": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject/node_modules/@polkadot/util-crypto": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.3.2.tgz",
+            "integrity": "sha512-pTpx+YxolY0BDT4RcGmgeKbHHD/dI6Ll9xRsqmVdIjpcVVY20uDNTyXs81ZNtfKgyod1y9JQkfNv2Dz9iEpTkQ==",
+            "dev": true,
+            "dependencies": {
+                "@noble/curves": "1.1.0",
+                "@noble/hashes": "1.3.1",
+                "@polkadot/networks": "12.3.2",
+                "@polkadot/util": "12.3.2",
+                "@polkadot/wasm-crypto": "^7.2.1",
+                "@polkadot/wasm-util": "^7.2.1",
+                "@polkadot/x-bigint": "12.3.2",
+                "@polkadot/x-randomvalues": "12.3.2",
+                "@scure/base": "1.1.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "12.3.2"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-bigint": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+            "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-randomvalues": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.3.2.tgz",
+            "integrity": "sha512-ywjIs8CWpvOGmq+3cGCNPOHxAjPHdBUiXyDccftx5BRVdmtbt36gK/V84bKr6Xs73FGu0jprUAOSRRsLZX/3dg==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "12.3.2",
+                "@polkadot/wasm-util": "*"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/extension-inject/node_modules/eventemitter3": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+            "dev": true
+        },
+        "packages/smart-contract/node_modules/@polkadot/keyring": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.4.2.tgz",
+            "integrity": "sha512-7iHhJuXaHrRTG6cJDbZE9G+c1ts1dujp0qbO4RfAPmT7YUvphHvAtCKueN9UKPz5+TYDL+rP/jDEaSKU8jl/qQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/util": "10.4.2",
+                "@polkadot/util-crypto": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "10.4.2",
+                "@polkadot/util-crypto": "10.4.2"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/keyring/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/keyring/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/networks": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.4.2.tgz",
+            "integrity": "sha512-FAh/znrEvWBiA/LbcT5GXHsCFUl//y9KqxLghSr/CreAmAergiJNT0MVUezC7Y36nkATgmsr4ylFwIxhVtuuCw==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/util": "10.4.2",
+                "@substrate/ss58-registry": "^1.38.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/networks/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/networks/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-augment": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-9.4.1.tgz",
+            "integrity": "sha512-ZBI5YrVE5U23Zta+XrQt9qYyf0FHgalXvlCzytjNo/VpHhZ371yisBbOuoetyP14rnF+RWux3rgU4Y1c9LNN+Q==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@polkadot/rpc-core": "9.4.1",
+                "@polkadot/types": "9.4.1",
+                "@polkadot/types-codec": "9.4.1",
+                "@polkadot/util": "^10.1.8"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-augment/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-core": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-9.4.1.tgz",
+            "integrity": "sha512-nGiebijY+DW7qmyB5O0iIlwVpI+m3olWJrMZT0gy7eUehwhsdjWNo3CjePb+EWtdlSjhpcxTwKCc4EaikWQCyQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@polkadot/rpc-augment": "9.4.1",
+                "@polkadot/rpc-provider": "9.4.1",
+                "@polkadot/types": "9.4.1",
+                "@polkadot/util": "^10.1.8",
+                "rxjs": "^7.5.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-core/node_modules/@polkadot/rpc-provider": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.4.1.tgz",
+            "integrity": "sha512-JBq049KGpM6pDkgbxiADZG1cuTbBcfEJer466SVp54fGaF7ZfpWN6yb9pQNNkHvvx6rzPnxrTxWpqJXHlI+fmw==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@polkadot/keyring": "^10.1.8",
+                "@polkadot/types": "9.4.1",
+                "@polkadot/types-support": "9.4.1",
+                "@polkadot/util": "^10.1.8",
+                "@polkadot/util-crypto": "^10.1.8",
+                "@polkadot/x-fetch": "^10.1.8",
+                "@polkadot/x-global": "^10.1.8",
+                "@polkadot/x-ws": "^10.1.8",
+                "@substrate/connect": "0.7.13",
+                "eventemitter3": "^4.0.7",
+                "mock-socket": "^9.1.5",
+                "nock": "^13.2.9"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-core/node_modules/@polkadot/types-support": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.4.1.tgz",
+            "integrity": "sha512-5udvaZU/KvEDzhDTcU8Qv9WG/3mu6nwx7m7PqDDywzUo/MAy2zI4OT6JBHcvJIk8Qm3zVQkVftohR8CbF9FeSg==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@polkadot/util": "^10.1.8"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-core/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-fetch": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.4.2.tgz",
+            "integrity": "sha512-Ubb64yaM4qwhogNP+4mZ3ibRghEg5UuCYRMNaCFoPgNAY8tQXuDKrHzeks3+frlmeH9YRd89o8wXLtWouwZIcw==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2",
+                "@types/node-fetch": "^2.6.2",
+                "node-fetch": "^3.3.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-ws": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.4.2.tgz",
+            "integrity": "sha512-3gHSTXAWQu1EMcMVTF5QDKHhEHzKxhAArweEyDXE7VsgKUP/ixxw4hVZBrkX122iI5l5mjSiooRSnp/Zl3xqDQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2",
+                "@types/websocket": "^1.0.5",
+                "websocket": "^1.0.34"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-core/node_modules/@substrate/connect": {
+            "version": "0.7.13",
+            "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.13.tgz",
+            "integrity": "sha512-mGvvxLVVm2Zziff8SpTybeIy+jq0LN81kPqDp/bGwtxAnRctbCsERChAu4Q5HN27cCjI1iNdzSz5ihF/DP5SdQ==",
+            "dependencies": {
+                "@substrate/connect-extension-protocol": "^1.0.1",
+                "@substrate/smoldot-light": "0.6.33",
+                "eventemitter3": "^4.0.7"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-provider": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.9.1.tgz",
+            "integrity": "sha512-4QzT2QzD+320+eT6b79sGAA85Tt3Bb8fQvse4r5Mom2iiBd2SO81vOhxSAOaIe4GUsw25VzFJmsbe7+OObItdg==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/keyring": "^12.3.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-support": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "@polkadot/x-fetch": "^12.3.1",
+                "@polkadot/x-global": "^12.3.1",
+                "@polkadot/x-ws": "^12.3.1",
+                "eventemitter3": "^5.0.1",
+                "mock-socket": "^9.2.1",
+                "nock": "^13.3.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "optionalDependencies": {
+                "@substrate/connect": "0.7.26"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/keyring": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.3.2.tgz",
+            "integrity": "sha512-NTdtDeI0DP9l/45hXynNABeP5VB8piw5YR+CbUxK2e36xpJWVXwbcOepzslg5ghE9rs8UKJb30Z/HqTU4sBY0Q==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/util": "12.3.2",
+                "@polkadot/util-crypto": "12.3.2",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "12.3.2",
+                "@polkadot/util-crypto": "12.3.2"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/networks": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.3.2.tgz",
+            "integrity": "sha512-uCkyybKoeEm1daKr0uT/9oNDHDDzCy2/ZdVl346hQqfdR1Ct3BaxMjxqvdmb5N8aCw0cBWSfgsxAYtw8ESmllQ==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/util": "12.3.2",
+                "@substrate/ss58-registry": "^1.40.0",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/types": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+            "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/keyring": "^12.3.1",
+                "@polkadot/types-augment": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/types-create": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/types-augment": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+            "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/types-codec": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+            "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/x-bigint": "^12.3.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/types-create": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+            "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/util-crypto": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.3.2.tgz",
+            "integrity": "sha512-pTpx+YxolY0BDT4RcGmgeKbHHD/dI6Ll9xRsqmVdIjpcVVY20uDNTyXs81ZNtfKgyod1y9JQkfNv2Dz9iEpTkQ==",
+            "dev": true,
+            "dependencies": {
+                "@noble/curves": "1.1.0",
+                "@noble/hashes": "1.3.1",
+                "@polkadot/networks": "12.3.2",
+                "@polkadot/util": "12.3.2",
+                "@polkadot/wasm-crypto": "^7.2.1",
+                "@polkadot/wasm-util": "^7.2.1",
+                "@polkadot/x-bigint": "12.3.2",
+                "@polkadot/x-randomvalues": "12.3.2",
+                "@scure/base": "1.1.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "12.3.2"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-bigint": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+            "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-randomvalues": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.3.2.tgz",
+            "integrity": "sha512-ywjIs8CWpvOGmq+3cGCNPOHxAjPHdBUiXyDccftx5BRVdmtbt36gK/V84bKr6Xs73FGu0jprUAOSRRsLZX/3dg==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "12.3.2",
+                "@polkadot/wasm-util": "*"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/rpc-provider/node_modules/eventemitter3": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+            "dev": true
+        },
+        "packages/smart-contract/node_modules/@polkadot/types": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.4.1.tgz",
+            "integrity": "sha512-vUPHqlBS5neNmI+8IgJxywCL3izdCgd3SrMKWM/xlxzhGh8zfBXaGiRu1sreEk4yuNCAMMWYYDp+eqecZ6wXGA==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@polkadot/keyring": "^10.1.8",
+                "@polkadot/types-augment": "9.4.1",
+                "@polkadot/types-codec": "9.4.1",
+                "@polkadot/types-create": "9.4.1",
+                "@polkadot/util": "^10.1.8",
+                "@polkadot/util-crypto": "^10.1.8",
+                "rxjs": "^7.5.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/types-augment": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.4.1.tgz",
+            "integrity": "sha512-3GHoXSSUNVQF1iFJgTWoxo/VM5JLv8kJZjJR8T5mzPjqJQLa1zejkPqF7nvmJq39R/AarrNqg6R0xE6usZAtRw==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@polkadot/types": "9.4.1",
+                "@polkadot/types-codec": "9.4.1",
+                "@polkadot/util": "^10.1.8"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/types-augment/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/types-augment/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/types-codec": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.4.1.tgz",
+            "integrity": "sha512-S1aFDDK4GL/9SEFYZ6ZAzCvh2QFO/mf3dbTYZLFD7JHQLcbAgTi5E6oz+hWYzsJYW5SzTDW4VdIPoAjY+28UEA==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@polkadot/util": "^10.1.8",
+                "@polkadot/x-bigint": "^10.1.8"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/types-codec/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/types-codec/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/types-create": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.4.1.tgz",
+            "integrity": "sha512-XDGrefz0L8vRl5wjEtiCK8i/kwdcMCqm8vgCmXyMOsZxWkObzK9bex/EhdM/8kMBtXn/b4uQn67ZU89dptMWXw==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@polkadot/types-codec": "9.4.1",
+                "@polkadot/util": "^10.1.8"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/types-create/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/types-create/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/types-known": {
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-9.4.1.tgz",
+            "integrity": "sha512-1WE+3IEaWaxRvASa6lQgE2bbIaqyesZsArd1QAlsWbOVlV/mSPeRXgBKwF+uDpWOXojZ+oKsOEnBf23BHGdIPg==",
+            "dependencies": {
+                "@babel/runtime": "^7.19.0",
+                "@polkadot/networks": "^10.1.8",
+                "@polkadot/types": "9.4.1",
+                "@polkadot/types-codec": "9.4.1",
+                "@polkadot/types-create": "9.4.1",
+                "@polkadot/util": "^10.1.8"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/types-known/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/types-known/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/types-support": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.9.1.tgz",
+            "integrity": "sha512-XsieuLDsszvMZQlleacQBfx07i/JkwQV/UxH9q8Hz7Okmaz9pEVEW1h3ka2/cPuC7a4l32JhaORBUYshBZNdJg==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/types/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/types/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/util-crypto": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.4.2.tgz",
+            "integrity": "sha512-RxZvF7C4+EF3fzQv8hZOLrYCBq5+wA+2LWv98nECkroChY3C2ZZvyWDqn8+aonNULt4dCVTWDZM0QIY6y4LUAQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@noble/hashes": "1.2.0",
+                "@noble/secp256k1": "1.7.1",
+                "@polkadot/networks": "10.4.2",
+                "@polkadot/util": "10.4.2",
+                "@polkadot/wasm-crypto": "^6.4.1",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-randomvalues": "10.4.2",
+                "@scure/base": "1.1.1",
+                "ed2curve": "^0.3.0",
+                "tweetnacl": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "10.4.2"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/util-crypto/node_modules/@noble/hashes": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+            "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ]
+        },
+        "packages/smart-contract/node_modules/@polkadot/util-crypto/node_modules/@polkadot/util": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-bigint": "10.4.2",
+                "@polkadot/x-global": "10.4.2",
+                "@polkadot/x-textdecoder": "10.4.2",
+                "@polkadot/x-textencoder": "10.4.2",
+                "@types/bn.js": "^5.1.1",
+                "bn.js": "^5.2.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-crypto": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-6.4.1.tgz",
+            "integrity": "sha512-FH+dcDPdhSLJvwL0pMLtn/LIPd62QDPODZRCmDyw+pFjLOMaRBc7raomWUOqyRWJTnqVf/iscc2rLVLNMyt7ag==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.6",
+                "@polkadot/wasm-bridge": "6.4.1",
+                "@polkadot/wasm-crypto-asmjs": "6.4.1",
+                "@polkadot/wasm-crypto-init": "6.4.1",
+                "@polkadot/wasm-crypto-wasm": "6.4.1",
+                "@polkadot/wasm-util": "6.4.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*",
+                "@polkadot/x-randomvalues": "*"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-crypto-asmjs": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-6.4.1.tgz",
+            "integrity": "sha512-UxZTwuBZlnODGIQdCsE2Sn/jU0O2xrNQ/TkhRFELfkZXEXTNu4lw6NpaKq7Iey4L+wKd8h4lT3VPVkMcPBLOvA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-crypto-wasm": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-6.4.1.tgz",
+            "integrity": "sha512-3VV9ZGzh0ZY3SmkkSw+0TRXxIpiO0nB8lFwlRgcwaCihwrvLfRnH9GI8WE12mKsHVjWTEVR3ogzILJxccAUjDA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.6",
+                "@polkadot/wasm-util": "6.4.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-crypto/node_modules/@polkadot/wasm-bridge": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-6.4.1.tgz",
+            "integrity": "sha512-QZDvz6dsUlbYsaMV5biZgZWkYH9BC5AfhT0f0/knv8+LrbAoQdP3Asbvddw8vyU9sbpuCHXrd4bDLBwUCRfrBQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*",
+                "@polkadot/x-randomvalues": "*"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-crypto/node_modules/@polkadot/wasm-crypto-init": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-6.4.1.tgz",
+            "integrity": "sha512-1ALagSi/nfkyFaH6JDYfy/QbicVbSn99K8PV9rctDUfxc7P06R7CoqbjGQ4OMPX6w1WYVPU7B4jPHGLYBlVuMw==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.6",
+                "@polkadot/wasm-bridge": "6.4.1",
+                "@polkadot/wasm-crypto-asmjs": "6.4.1",
+                "@polkadot/wasm-crypto-wasm": "6.4.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*",
+                "@polkadot/x-randomvalues": "*"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/util-crypto/node_modules/@polkadot/wasm-util": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-6.4.1.tgz",
+            "integrity": "sha512-Uwo+WpEsDmFExWC5kTNvsVhvqXMZEKf4gUHXFn4c6Xz4lmieRT5g+1bO1KJ21pl4msuIgdV3Bksfs/oiqMFqlw==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.6"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/wasm-bridge": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.2.1.tgz",
+            "integrity": "sha512-uV/LHREDBGBbHrrv7HTki+Klw0PYZzFomagFWII4lp6Toj/VCvRh5WMzooVC+g/XsBGosAwrvBhoModabyHx+A==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/wasm-util": "7.2.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*",
+                "@polkadot/x-randomvalues": "*"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/wasm-crypto": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.2.1.tgz",
+            "integrity": "sha512-SA2+33S9TAwGhniKgztVN6pxUKpGfN4Tre/eUZGUfpgRkT92wIUT2GpGWQE+fCCqGQgADrNiBcwt6XwdPqMQ4Q==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/wasm-bridge": "7.2.1",
+                "@polkadot/wasm-crypto-asmjs": "7.2.1",
+                "@polkadot/wasm-crypto-init": "7.2.1",
+                "@polkadot/wasm-crypto-wasm": "7.2.1",
+                "@polkadot/wasm-util": "7.2.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*",
+                "@polkadot/x-randomvalues": "*"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/wasm-crypto-asmjs": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.2.1.tgz",
+            "integrity": "sha512-z/d21bmxyVfkzGsKef/FWswKX02x5lK97f4NPBZ9XBeiFkmzlXhdSnu58/+b1sKsRAGdW/Rn/rTNRDhW0GqCAg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/wasm-crypto-init": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.2.1.tgz",
+            "integrity": "sha512-GcEXtwN9LcSf32V9zSaYjHImFw16hCyo2Xzg4GLLDPPeaAAfbFr2oQMgwyDbvBrBjLKHVHjsPZyGhXae831amw==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/wasm-bridge": "7.2.1",
+                "@polkadot/wasm-crypto-asmjs": "7.2.1",
+                "@polkadot/wasm-crypto-wasm": "7.2.1",
+                "@polkadot/wasm-util": "7.2.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*",
+                "@polkadot/x-randomvalues": "*"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/wasm-crypto-wasm": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.2.1.tgz",
+            "integrity": "sha512-DqyXE4rSD0CVlLIw88B58+HHNyrvm+JAnYyuEDYZwCvzUWOCNos/DDg9wi/K39VAIsCCKDmwKqkkfIofuOj/lA==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/wasm-util": "7.2.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/wasm-util": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.2.1.tgz",
+            "integrity": "sha512-FBSn/3aYJzhN0sYAYhHB8y9JL8mVgxLy4M1kUXYbyo+8GLRQEN5rns8Vcb8TAlIzBWgVTOOptYBvxo0oj0h7Og==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "@polkadot/util": "*"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/x-bigint": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.4.2.tgz",
+            "integrity": "sha512-awRiox+/XSReLzimAU94fPldowiwnnMUkQJe8AebYhNocAj6SJU00GNoj6j6tAho6yleOwrTJXZaWFBaQVJQNg==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/x-bigint/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/x-fetch": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.3.2.tgz",
+            "integrity": "sha512-3IEuZ5S+RI/t33NsdPLIIa5COfDCfpUW2sbaByEczn75aD1jLqJZSEDwiBniJ2osyNd4uUxBf6e5jw7LAZeZJg==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/x-global": "12.3.2",
+                "node-fetch": "^3.3.1",
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/x-global": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+            "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.3"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/x-randomvalues": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.4.2.tgz",
+            "integrity": "sha512-mf1Wbpe7pRZHO0V3V89isPLqZOy5XGX2bCqsfUWHgb1NvV1MMx5TjVjdaYyNlGTiOkAmJKlOHshcfPU2sYWpNg==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/x-randomvalues/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/x-textdecoder": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.4.2.tgz",
+            "integrity": "sha512-d3ADduOKUTU+cliz839+KCFmi23pxTlabH7qh7Vs1GZQvXOELWdqFOqakdiAjtMn68n1KVF4O14Y+OUm7gp/zA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/x-textdecoder/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/x-textencoder": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.4.2.tgz",
+            "integrity": "sha512-mxcQuA1exnyv74Kasl5vxBq01QwckG088lYjc3KwmND6+pPrW2OWagbxFX5VFoDLDAE+UJtnUHsjdWyOTDhpQA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "@polkadot/x-global": "10.4.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/x-textencoder/node_modules/@polkadot/x-global": {
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "packages/smart-contract/node_modules/@polkadot/x-ws": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.3.2.tgz",
+            "integrity": "sha512-yM9Z64pLNlHpJE43+Xtr+iUXmYpFFY5u5hrke2PJt13O48H8f9Vb9cRaIh94appLyICoS0aekGhDkGH+MCspBA==",
+            "dev": true,
+            "dependencies": {
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3",
+                "ws": "^8.13.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/smart-contract/node_modules/@substrate/connect": {
+            "version": "0.7.26",
+            "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.26.tgz",
+            "integrity": "sha512-uuGSiroGuKWj1+38n1kY5HReer5iL9bRwPCzuoLtqAOmI1fGI0hsSI2LlNQMAbfRgr7VRHXOk5MTuQf5ulsFRw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@substrate/connect-extension-protocol": "^1.0.1",
+                "eventemitter3": "^4.0.7",
+                "smoldot": "1.0.4"
+            }
+        },
+        "packages/smart-contract/node_modules/@substrate/smoldot-light": {
+            "version": "0.6.33",
+            "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.33.tgz",
+            "integrity": "sha512-b1bgIcd6369Xa1Y2MelBD3xmyX2FeHnjq8xS0ohy5uC6bR1v6kEkEyCbcIJE1+GlwDzlfaNxbJjwJPIv8FaRYA==",
+            "dependencies": {
+                "pako": "^2.0.4",
+                "ws": "^8.8.1"
             }
         },
         "packages/smart-contract/node_modules/typescript": {
@@ -15156,9 +17907,9 @@
             }
         },
         "@babel/runtime": {
-            "version": "7.20.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
-            "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
+            "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
             "requires": {
                 "regenerator-runtime": "^0.13.11"
             }
@@ -15221,8 +17972,8 @@
                 "@cere-ddc-sdk/core": "1.7.6-rc.1",
                 "@cere-ddc-sdk/proto": "1.7.6-rc.1",
                 "@cere-ddc-sdk/smart-contract": "1.7.6-rc.1",
-                "@polkadot/util": "~9.7.2",
-                "@polkadot/util-crypto": "~9.7.2",
+                "@polkadot/util": "^10.1.8",
+                "@polkadot/util-crypto": "^10.1.8",
                 "@types/node": "^16.0.0",
                 "@types/varint": "^6.0.0",
                 "clean-publish": "^4.0.1",
@@ -15233,6 +17984,97 @@
                 "varint": "^6.0.0"
             },
             "dependencies": {
+                "@noble/hashes": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+                    "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ=="
+                },
+                "@polkadot/networks": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.4.2.tgz",
+                    "integrity": "sha512-FAh/znrEvWBiA/LbcT5GXHsCFUl//y9KqxLghSr/CreAmAergiJNT0MVUezC7Y36nkATgmsr4ylFwIxhVtuuCw==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/util": "10.4.2",
+                        "@substrate/ss58-registry": "^1.38.0"
+                    }
+                },
+                "@polkadot/util": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                    "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/x-bigint": "10.4.2",
+                        "@polkadot/x-global": "10.4.2",
+                        "@polkadot/x-textdecoder": "10.4.2",
+                        "@polkadot/x-textencoder": "10.4.2",
+                        "@types/bn.js": "^5.1.1",
+                        "bn.js": "^5.2.1"
+                    }
+                },
+                "@polkadot/util-crypto": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.4.2.tgz",
+                    "integrity": "sha512-RxZvF7C4+EF3fzQv8hZOLrYCBq5+wA+2LWv98nECkroChY3C2ZZvyWDqn8+aonNULt4dCVTWDZM0QIY6y4LUAQ==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@noble/hashes": "1.2.0",
+                        "@noble/secp256k1": "1.7.1",
+                        "@polkadot/networks": "10.4.2",
+                        "@polkadot/util": "10.4.2",
+                        "@polkadot/wasm-crypto": "^6.4.1",
+                        "@polkadot/x-bigint": "10.4.2",
+                        "@polkadot/x-randomvalues": "10.4.2",
+                        "@scure/base": "1.1.1",
+                        "ed2curve": "^0.3.0",
+                        "tweetnacl": "^1.0.3"
+                    }
+                },
+                "@polkadot/x-bigint": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.4.2.tgz",
+                    "integrity": "sha512-awRiox+/XSReLzimAU94fPldowiwnnMUkQJe8AebYhNocAj6SJU00GNoj6j6tAho6yleOwrTJXZaWFBaQVJQNg==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/x-global": "10.4.2"
+                    }
+                },
+                "@polkadot/x-global": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                    "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13"
+                    }
+                },
+                "@polkadot/x-randomvalues": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.4.2.tgz",
+                    "integrity": "sha512-mf1Wbpe7pRZHO0V3V89isPLqZOy5XGX2bCqsfUWHgb1NvV1MMx5TjVjdaYyNlGTiOkAmJKlOHshcfPU2sYWpNg==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/x-global": "10.4.2"
+                    }
+                },
+                "@polkadot/x-textdecoder": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.4.2.tgz",
+                    "integrity": "sha512-d3ADduOKUTU+cliz839+KCFmi23pxTlabH7qh7Vs1GZQvXOELWdqFOqakdiAjtMn68n1KVF4O14Y+OUm7gp/zA==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/x-global": "10.4.2"
+                    }
+                },
+                "@polkadot/x-textencoder": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.4.2.tgz",
+                    "integrity": "sha512-mxcQuA1exnyv74Kasl5vxBq01QwckG088lYjc3KwmND6+pPrW2OWagbxFX5VFoDLDAE+UJtnUHsjdWyOTDhpQA==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/x-global": "10.4.2"
+                    }
+                },
                 "typescript": {
                     "version": "4.5.4",
                     "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
@@ -15247,10 +18089,9 @@
                 "@multiformats/blake2": "^1.0.10",
                 "@polkadot/extension-dapp": "0.43.2",
                 "@polkadot/extension-inject": "0.43.2",
-                "@polkadot/keyring": "~9.7.2",
-                "@polkadot/util": "~9.7.2",
-                "@polkadot/util-crypto": "~9.7.2",
-                "@polkadot/wasm-crypto": "~6.4.1",
+                "@polkadot/keyring": "^10.1.8",
+                "@polkadot/util": "^10.1.8",
+                "@polkadot/util-crypto": "^10.1.8",
                 "@types/node": "^16.0.0",
                 "clean-publish": "^4.0.1",
                 "multiformats": "^9.6.5",
@@ -15259,16 +18100,9 @@
             },
             "dependencies": {
                 "@noble/hashes": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
-                    "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==",
-                    "dev": true
-                },
-                "@noble/secp256k1": {
-                    "version": "1.7.0",
-                    "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
-                    "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==",
-                    "dev": true
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+                    "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ=="
                 },
                 "@polkadot/extension-dapp": {
                     "version": "0.43.2",
@@ -15280,6 +18114,157 @@
                         "@polkadot/extension-inject": "^0.43.2",
                         "@polkadot/util": "^9.2.1",
                         "@polkadot/util-crypto": "^9.2.1"
+                    },
+                    "dependencies": {
+                        "@noble/hashes": {
+                            "version": "1.1.2",
+                            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+                            "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+                            "dev": true
+                        },
+                        "@noble/secp256k1": {
+                            "version": "1.6.0",
+                            "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.0.tgz",
+                            "integrity": "sha512-DWSsg8zMHOYMYBqIQi96BQuthZrp98LCeMNcUOaffCIVYQ5yxDbNikLF+H7jEnmNNmXbtVic46iCuVWzar+MgA==",
+                            "dev": true
+                        },
+                        "@polkadot/networks": {
+                            "version": "9.7.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-9.7.2.tgz",
+                            "integrity": "sha512-oMAdF8Y9CLBI0EUZBcycHcvbQQdbkJHevPJ/lwnZXJTaueXuav/Xm2yiFj5J3V8meIjLocURlMawgsAVItXOBQ==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.18.6",
+                                "@polkadot/util": "9.7.2",
+                                "@substrate/ss58-registry": "^1.23.0"
+                            }
+                        },
+                        "@polkadot/util": {
+                            "version": "9.7.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-9.7.2.tgz",
+                            "integrity": "sha512-ivTmA+KkPCq5i3O0Gk+dTds/hwdwlYCh89aKfeaG9ni3XHUbbuBgTqHneo648HqxwAwSAyiDiwE9EdXrzAdO4Q==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.18.6",
+                                "@polkadot/x-bigint": "9.7.2",
+                                "@polkadot/x-global": "9.7.2",
+                                "@polkadot/x-textdecoder": "9.7.2",
+                                "@polkadot/x-textencoder": "9.7.2",
+                                "@types/bn.js": "^5.1.0",
+                                "bn.js": "^5.2.1",
+                                "ip-regex": "^4.3.0"
+                            }
+                        },
+                        "@polkadot/util-crypto": {
+                            "version": "9.7.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-9.7.2.tgz",
+                            "integrity": "sha512-tfz6mJtPwoNteivKCmR+QklC4mr1/hGZRsDJLWKaFhanDinYZ3V2pJM1EbCI6WONLuuzlTxsDXjAffWzzRqlPA==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.18.6",
+                                "@noble/hashes": "1.1.2",
+                                "@noble/secp256k1": "1.6.0",
+                                "@polkadot/networks": "9.7.2",
+                                "@polkadot/util": "9.7.2",
+                                "@polkadot/wasm-crypto": "^6.2.2",
+                                "@polkadot/x-bigint": "9.7.2",
+                                "@polkadot/x-randomvalues": "9.7.2",
+                                "@scure/base": "1.1.1",
+                                "ed2curve": "^0.3.0",
+                                "tweetnacl": "^1.0.3"
+                            }
+                        },
+                        "@polkadot/wasm-crypto": {
+                            "version": "6.4.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-6.4.1.tgz",
+                            "integrity": "sha512-FH+dcDPdhSLJvwL0pMLtn/LIPd62QDPODZRCmDyw+pFjLOMaRBc7raomWUOqyRWJTnqVf/iscc2rLVLNMyt7ag==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.20.6",
+                                "@polkadot/wasm-bridge": "6.4.1",
+                                "@polkadot/wasm-crypto-asmjs": "6.4.1",
+                                "@polkadot/wasm-crypto-init": "6.4.1",
+                                "@polkadot/wasm-crypto-wasm": "6.4.1",
+                                "@polkadot/wasm-util": "6.4.1"
+                            }
+                        },
+                        "@polkadot/wasm-crypto-asmjs": {
+                            "version": "6.4.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-6.4.1.tgz",
+                            "integrity": "sha512-UxZTwuBZlnODGIQdCsE2Sn/jU0O2xrNQ/TkhRFELfkZXEXTNu4lw6NpaKq7Iey4L+wKd8h4lT3VPVkMcPBLOvA==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.20.6"
+                            }
+                        },
+                        "@polkadot/wasm-crypto-wasm": {
+                            "version": "6.4.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-6.4.1.tgz",
+                            "integrity": "sha512-3VV9ZGzh0ZY3SmkkSw+0TRXxIpiO0nB8lFwlRgcwaCihwrvLfRnH9GI8WE12mKsHVjWTEVR3ogzILJxccAUjDA==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.20.6",
+                                "@polkadot/wasm-util": "6.4.1"
+                            }
+                        },
+                        "@polkadot/wasm-util": {
+                            "version": "6.4.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-6.4.1.tgz",
+                            "integrity": "sha512-Uwo+WpEsDmFExWC5kTNvsVhvqXMZEKf4gUHXFn4c6Xz4lmieRT5g+1bO1KJ21pl4msuIgdV3Bksfs/oiqMFqlw==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.20.6"
+                            }
+                        },
+                        "@polkadot/x-bigint": {
+                            "version": "9.7.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-9.7.2.tgz",
+                            "integrity": "sha512-qi8/DTGypFSt5vvNOsYcEaqH72lymfyidGlsHlZ6e7nNASnEhk/NaOcINiTr1ds+fpu4dtKXWAIPZufujf2JeQ==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.18.6",
+                                "@polkadot/x-global": "9.7.2"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "9.7.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-9.7.2.tgz",
+                            "integrity": "sha512-3NN5JhjosaelaFWBJSlv9mb/gDAlt7RuZ8NKlOjB+LQHd9g6ZbnYi5wwjW+i/x/3E4IVbBx66uvWgNaw7IBrkg==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.18.6"
+                            }
+                        },
+                        "@polkadot/x-randomvalues": {
+                            "version": "9.7.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-9.7.2.tgz",
+                            "integrity": "sha512-819slnXNpoVtqdhjI19ao7w5m+Zwx11VfwCZkFQypVv3b/1UEoKG/baJA9dVI6yMvhnBN//i8mLgNy3IXWbVVw==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.18.6",
+                                "@polkadot/x-global": "9.7.2"
+                            }
+                        },
+                        "@polkadot/x-textdecoder": {
+                            "version": "9.7.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-9.7.2.tgz",
+                            "integrity": "sha512-hhrMNZwJBmusdpqjDRpOHZoMB4hpyJt9Gu9Bi9is7/D/vq/hpxq8z7s6NxrbRyXJf1SIk6NMK0jf5XjRLdKdbw==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.18.6",
+                                "@polkadot/x-global": "9.7.2"
+                            }
+                        },
+                        "@polkadot/x-textencoder": {
+                            "version": "9.7.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-9.7.2.tgz",
+                            "integrity": "sha512-GHbSdbMPixDAOnJ9cvL/x9sPNeHegPoDSqCAzY5H6/zHc/fNn0vUu0To9VpPgPhp/Jb9dbc0h8YqEyvOcOlphw==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.18.6",
+                                "@polkadot/x-global": "9.7.2"
+                            }
+                        }
                     }
                 },
                 "@polkadot/extension-inject": {
@@ -15296,6 +18281,116 @@
                         "@polkadot/x-global": "^9.2.1"
                     },
                     "dependencies": {
+                        "@noble/hashes": {
+                            "version": "1.1.2",
+                            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+                            "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+                            "dev": true
+                        },
+                        "@noble/secp256k1": {
+                            "version": "1.6.0",
+                            "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.0.tgz",
+                            "integrity": "sha512-DWSsg8zMHOYMYBqIQi96BQuthZrp98LCeMNcUOaffCIVYQ5yxDbNikLF+H7jEnmNNmXbtVic46iCuVWzar+MgA==",
+                            "dev": true
+                        },
+                        "@polkadot/networks": {
+                            "version": "9.7.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-9.7.2.tgz",
+                            "integrity": "sha512-oMAdF8Y9CLBI0EUZBcycHcvbQQdbkJHevPJ/lwnZXJTaueXuav/Xm2yiFj5J3V8meIjLocURlMawgsAVItXOBQ==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.18.6",
+                                "@polkadot/util": "9.7.2",
+                                "@substrate/ss58-registry": "^1.23.0"
+                            }
+                        },
+                        "@polkadot/util": {
+                            "version": "9.7.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-9.7.2.tgz",
+                            "integrity": "sha512-ivTmA+KkPCq5i3O0Gk+dTds/hwdwlYCh89aKfeaG9ni3XHUbbuBgTqHneo648HqxwAwSAyiDiwE9EdXrzAdO4Q==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.18.6",
+                                "@polkadot/x-bigint": "9.7.2",
+                                "@polkadot/x-global": "9.7.2",
+                                "@polkadot/x-textdecoder": "9.7.2",
+                                "@polkadot/x-textencoder": "9.7.2",
+                                "@types/bn.js": "^5.1.0",
+                                "bn.js": "^5.2.1",
+                                "ip-regex": "^4.3.0"
+                            }
+                        },
+                        "@polkadot/util-crypto": {
+                            "version": "9.7.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-9.7.2.tgz",
+                            "integrity": "sha512-tfz6mJtPwoNteivKCmR+QklC4mr1/hGZRsDJLWKaFhanDinYZ3V2pJM1EbCI6WONLuuzlTxsDXjAffWzzRqlPA==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.18.6",
+                                "@noble/hashes": "1.1.2",
+                                "@noble/secp256k1": "1.6.0",
+                                "@polkadot/networks": "9.7.2",
+                                "@polkadot/util": "9.7.2",
+                                "@polkadot/wasm-crypto": "^6.2.2",
+                                "@polkadot/x-bigint": "9.7.2",
+                                "@polkadot/x-randomvalues": "9.7.2",
+                                "@scure/base": "1.1.1",
+                                "ed2curve": "^0.3.0",
+                                "tweetnacl": "^1.0.3"
+                            }
+                        },
+                        "@polkadot/wasm-crypto": {
+                            "version": "6.4.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-6.4.1.tgz",
+                            "integrity": "sha512-FH+dcDPdhSLJvwL0pMLtn/LIPd62QDPODZRCmDyw+pFjLOMaRBc7raomWUOqyRWJTnqVf/iscc2rLVLNMyt7ag==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.20.6",
+                                "@polkadot/wasm-bridge": "6.4.1",
+                                "@polkadot/wasm-crypto-asmjs": "6.4.1",
+                                "@polkadot/wasm-crypto-init": "6.4.1",
+                                "@polkadot/wasm-crypto-wasm": "6.4.1",
+                                "@polkadot/wasm-util": "6.4.1"
+                            }
+                        },
+                        "@polkadot/wasm-crypto-asmjs": {
+                            "version": "6.4.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-6.4.1.tgz",
+                            "integrity": "sha512-UxZTwuBZlnODGIQdCsE2Sn/jU0O2xrNQ/TkhRFELfkZXEXTNu4lw6NpaKq7Iey4L+wKd8h4lT3VPVkMcPBLOvA==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.20.6"
+                            }
+                        },
+                        "@polkadot/wasm-crypto-wasm": {
+                            "version": "6.4.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-6.4.1.tgz",
+                            "integrity": "sha512-3VV9ZGzh0ZY3SmkkSw+0TRXxIpiO0nB8lFwlRgcwaCihwrvLfRnH9GI8WE12mKsHVjWTEVR3ogzILJxccAUjDA==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.20.6",
+                                "@polkadot/wasm-util": "6.4.1"
+                            }
+                        },
+                        "@polkadot/wasm-util": {
+                            "version": "6.4.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-6.4.1.tgz",
+                            "integrity": "sha512-Uwo+WpEsDmFExWC5kTNvsVhvqXMZEKf4gUHXFn4c6Xz4lmieRT5g+1bO1KJ21pl4msuIgdV3Bksfs/oiqMFqlw==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.20.6"
+                            }
+                        },
+                        "@polkadot/x-bigint": {
+                            "version": "9.7.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-9.7.2.tgz",
+                            "integrity": "sha512-qi8/DTGypFSt5vvNOsYcEaqH72lymfyidGlsHlZ6e7nNASnEhk/NaOcINiTr1ds+fpu4dtKXWAIPZufujf2JeQ==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.18.6",
+                                "@polkadot/x-global": "9.7.2"
+                            }
+                        },
                         "@polkadot/x-global": {
                             "version": "9.7.2",
                             "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-9.7.2.tgz",
@@ -15304,7 +18399,57 @@
                             "requires": {
                                 "@babel/runtime": "^7.18.6"
                             }
+                        },
+                        "@polkadot/x-randomvalues": {
+                            "version": "9.7.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-9.7.2.tgz",
+                            "integrity": "sha512-819slnXNpoVtqdhjI19ao7w5m+Zwx11VfwCZkFQypVv3b/1UEoKG/baJA9dVI6yMvhnBN//i8mLgNy3IXWbVVw==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.18.6",
+                                "@polkadot/x-global": "9.7.2"
+                            }
+                        },
+                        "@polkadot/x-textdecoder": {
+                            "version": "9.7.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-9.7.2.tgz",
+                            "integrity": "sha512-hhrMNZwJBmusdpqjDRpOHZoMB4hpyJt9Gu9Bi9is7/D/vq/hpxq8z7s6NxrbRyXJf1SIk6NMK0jf5XjRLdKdbw==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.18.6",
+                                "@polkadot/x-global": "9.7.2"
+                            }
+                        },
+                        "@polkadot/x-textencoder": {
+                            "version": "9.7.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-9.7.2.tgz",
+                            "integrity": "sha512-GHbSdbMPixDAOnJ9cvL/x9sPNeHegPoDSqCAzY5H6/zHc/fNn0vUu0To9VpPgPhp/Jb9dbc0h8YqEyvOcOlphw==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/runtime": "^7.18.6",
+                                "@polkadot/x-global": "9.7.2"
+                            }
                         }
+                    }
+                },
+                "@polkadot/keyring": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.4.2.tgz",
+                    "integrity": "sha512-7iHhJuXaHrRTG6cJDbZE9G+c1ts1dujp0qbO4RfAPmT7YUvphHvAtCKueN9UKPz5+TYDL+rP/jDEaSKU8jl/qQ==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/util": "10.4.2",
+                        "@polkadot/util-crypto": "10.4.2"
+                    }
+                },
+                "@polkadot/networks": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.4.2.tgz",
+                    "integrity": "sha512-FAh/znrEvWBiA/LbcT5GXHsCFUl//y9KqxLghSr/CreAmAergiJNT0MVUezC7Y36nkATgmsr4ylFwIxhVtuuCw==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/util": "10.4.2",
+                        "@substrate/ss58-registry": "^1.38.0"
                     }
                 },
                 "@polkadot/rpc-provider": {
@@ -15328,17 +18473,6 @@
                         "nock": "^13.2.9"
                     },
                     "dependencies": {
-                        "@polkadot/keyring": {
-                            "version": "10.2.1",
-                            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.2.1.tgz",
-                            "integrity": "sha512-84/zzxDZANQ4AfsCT1vrjX3I23/mj9WUWl1F7q9ruK6UBFyGsl46Y3ABOopFHij9UXhppndhB65IeDnqoOKqxQ==",
-                            "dev": true,
-                            "requires": {
-                                "@babel/runtime": "^7.20.6",
-                                "@polkadot/util": "10.2.1",
-                                "@polkadot/util-crypto": "10.2.1"
-                            }
-                        },
                         "@polkadot/util": {
                             "version": "10.2.1",
                             "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.2.1.tgz",
@@ -15352,25 +18486,6 @@
                                 "@polkadot/x-textencoder": "10.2.1",
                                 "@types/bn.js": "^5.1.1",
                                 "bn.js": "^5.2.1"
-                            }
-                        },
-                        "@polkadot/util-crypto": {
-                            "version": "10.2.1",
-                            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.2.1.tgz",
-                            "integrity": "sha512-UH1J4oD92gkLXMfVTLee3Y2vYadNyp1lmS4P2nZwQ0SOzGZ4rN7khD2CrB1cXS9WPq196Zb5oZdGLnPYnXHtjw==",
-                            "dev": true,
-                            "requires": {
-                                "@babel/runtime": "^7.20.6",
-                                "@noble/hashes": "1.1.3",
-                                "@noble/secp256k1": "1.7.0",
-                                "@polkadot/networks": "10.2.1",
-                                "@polkadot/util": "10.2.1",
-                                "@polkadot/wasm-crypto": "^6.4.1",
-                                "@polkadot/x-bigint": "10.2.1",
-                                "@polkadot/x-randomvalues": "10.2.1",
-                                "@scure/base": "1.1.1",
-                                "ed2curve": "^0.3.0",
-                                "tweetnacl": "^1.0.3"
                             }
                         }
                     }
@@ -15391,17 +18506,6 @@
                         "rxjs": "^7.5.6"
                     },
                     "dependencies": {
-                        "@polkadot/keyring": {
-                            "version": "10.2.1",
-                            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.2.1.tgz",
-                            "integrity": "sha512-84/zzxDZANQ4AfsCT1vrjX3I23/mj9WUWl1F7q9ruK6UBFyGsl46Y3ABOopFHij9UXhppndhB65IeDnqoOKqxQ==",
-                            "dev": true,
-                            "requires": {
-                                "@babel/runtime": "^7.20.6",
-                                "@polkadot/util": "10.2.1",
-                                "@polkadot/util-crypto": "10.2.1"
-                            }
-                        },
                         "@polkadot/util": {
                             "version": "10.2.1",
                             "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.2.1.tgz",
@@ -15415,25 +18519,6 @@
                                 "@polkadot/x-textencoder": "10.2.1",
                                 "@types/bn.js": "^5.1.1",
                                 "bn.js": "^5.2.1"
-                            }
-                        },
-                        "@polkadot/util-crypto": {
-                            "version": "10.2.1",
-                            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.2.1.tgz",
-                            "integrity": "sha512-UH1J4oD92gkLXMfVTLee3Y2vYadNyp1lmS4P2nZwQ0SOzGZ4rN7khD2CrB1cXS9WPq196Zb5oZdGLnPYnXHtjw==",
-                            "dev": true,
-                            "requires": {
-                                "@babel/runtime": "^7.20.6",
-                                "@noble/hashes": "1.1.3",
-                                "@noble/secp256k1": "1.7.0",
-                                "@polkadot/networks": "10.2.1",
-                                "@polkadot/util": "10.2.1",
-                                "@polkadot/wasm-crypto": "^6.4.1",
-                                "@polkadot/x-bigint": "10.2.1",
-                                "@polkadot/x-randomvalues": "10.2.1",
-                                "@scure/base": "1.1.1",
-                                "ed2curve": "^0.3.0",
-                                "tweetnacl": "^1.0.3"
                             }
                         }
                     }
@@ -15448,23 +18533,6 @@
                         "@polkadot/types": "8.14.1",
                         "@polkadot/types-codec": "8.14.1",
                         "@polkadot/util": "^10.1.1"
-                    },
-                    "dependencies": {
-                        "@polkadot/util": {
-                            "version": "10.2.1",
-                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.2.1.tgz",
-                            "integrity": "sha512-ewGKSOp+VXKEeCvpCCP2Qqi/FVkewBF9vb/N8pRwuNQ2XE9k1lnsOZZeQemVBDhKsZz+h3IeNcWejaF6K3vYHQ==",
-                            "dev": true,
-                            "requires": {
-                                "@babel/runtime": "^7.20.6",
-                                "@polkadot/x-bigint": "10.2.1",
-                                "@polkadot/x-global": "10.2.1",
-                                "@polkadot/x-textdecoder": "10.2.1",
-                                "@polkadot/x-textencoder": "10.2.1",
-                                "@types/bn.js": "^5.1.1",
-                                "bn.js": "^5.2.1"
-                            }
-                        }
                     }
                 },
                 "@polkadot/types-codec": {
@@ -15476,23 +18544,6 @@
                         "@babel/runtime": "^7.18.9",
                         "@polkadot/util": "^10.1.1",
                         "@polkadot/x-bigint": "^10.1.1"
-                    },
-                    "dependencies": {
-                        "@polkadot/util": {
-                            "version": "10.2.1",
-                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.2.1.tgz",
-                            "integrity": "sha512-ewGKSOp+VXKEeCvpCCP2Qqi/FVkewBF9vb/N8pRwuNQ2XE9k1lnsOZZeQemVBDhKsZz+h3IeNcWejaF6K3vYHQ==",
-                            "dev": true,
-                            "requires": {
-                                "@babel/runtime": "^7.20.6",
-                                "@polkadot/x-bigint": "10.2.1",
-                                "@polkadot/x-global": "10.2.1",
-                                "@polkadot/x-textdecoder": "10.2.1",
-                                "@polkadot/x-textencoder": "10.2.1",
-                                "@types/bn.js": "^5.1.1",
-                                "bn.js": "^5.2.1"
-                            }
-                        }
                     }
                 },
                 "@polkadot/types-create": {
@@ -15504,23 +18555,6 @@
                         "@babel/runtime": "^7.18.9",
                         "@polkadot/types-codec": "8.14.1",
                         "@polkadot/util": "^10.1.1"
-                    },
-                    "dependencies": {
-                        "@polkadot/util": {
-                            "version": "10.2.1",
-                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.2.1.tgz",
-                            "integrity": "sha512-ewGKSOp+VXKEeCvpCCP2Qqi/FVkewBF9vb/N8pRwuNQ2XE9k1lnsOZZeQemVBDhKsZz+h3IeNcWejaF6K3vYHQ==",
-                            "dev": true,
-                            "requires": {
-                                "@babel/runtime": "^7.20.6",
-                                "@polkadot/x-bigint": "10.2.1",
-                                "@polkadot/x-global": "10.2.1",
-                                "@polkadot/x-textdecoder": "10.2.1",
-                                "@polkadot/x-textencoder": "10.2.1",
-                                "@types/bn.js": "^5.1.1",
-                                "bn.js": "^5.2.1"
-                            }
-                        }
                     }
                 },
                 "@polkadot/types-support": {
@@ -15531,21 +18565,151 @@
                     "requires": {
                         "@babel/runtime": "^7.18.9",
                         "@polkadot/util": "^10.1.1"
+                    }
+                },
+                "@polkadot/util": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                    "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/x-bigint": "10.4.2",
+                        "@polkadot/x-global": "10.4.2",
+                        "@polkadot/x-textdecoder": "10.4.2",
+                        "@polkadot/x-textencoder": "10.4.2",
+                        "@types/bn.js": "^5.1.1",
+                        "bn.js": "^5.2.1"
                     },
                     "dependencies": {
-                        "@polkadot/util": {
-                            "version": "10.2.1",
-                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.2.1.tgz",
-                            "integrity": "sha512-ewGKSOp+VXKEeCvpCCP2Qqi/FVkewBF9vb/N8pRwuNQ2XE9k1lnsOZZeQemVBDhKsZz+h3IeNcWejaF6K3vYHQ==",
-                            "dev": true,
+                        "@polkadot/x-bigint": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.4.2.tgz",
+                            "integrity": "sha512-awRiox+/XSReLzimAU94fPldowiwnnMUkQJe8AebYhNocAj6SJU00GNoj6j6tAho6yleOwrTJXZaWFBaQVJQNg==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-global": "10.4.2"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        },
+                        "@polkadot/x-textdecoder": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.4.2.tgz",
+                            "integrity": "sha512-d3ADduOKUTU+cliz839+KCFmi23pxTlabH7qh7Vs1GZQvXOELWdqFOqakdiAjtMn68n1KVF4O14Y+OUm7gp/zA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-global": "10.4.2"
+                            }
+                        },
+                        "@polkadot/x-textencoder": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.4.2.tgz",
+                            "integrity": "sha512-mxcQuA1exnyv74Kasl5vxBq01QwckG088lYjc3KwmND6+pPrW2OWagbxFX5VFoDLDAE+UJtnUHsjdWyOTDhpQA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-global": "10.4.2"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/util-crypto": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.4.2.tgz",
+                    "integrity": "sha512-RxZvF7C4+EF3fzQv8hZOLrYCBq5+wA+2LWv98nECkroChY3C2ZZvyWDqn8+aonNULt4dCVTWDZM0QIY6y4LUAQ==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@noble/hashes": "1.2.0",
+                        "@noble/secp256k1": "1.7.1",
+                        "@polkadot/networks": "10.4.2",
+                        "@polkadot/util": "10.4.2",
+                        "@polkadot/wasm-crypto": "^6.4.1",
+                        "@polkadot/x-bigint": "10.4.2",
+                        "@polkadot/x-randomvalues": "10.4.2",
+                        "@scure/base": "1.1.1",
+                        "ed2curve": "^0.3.0",
+                        "tweetnacl": "^1.0.3"
+                    },
+                    "dependencies": {
+                        "@polkadot/wasm-crypto": {
+                            "version": "6.4.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-6.4.1.tgz",
+                            "integrity": "sha512-FH+dcDPdhSLJvwL0pMLtn/LIPd62QDPODZRCmDyw+pFjLOMaRBc7raomWUOqyRWJTnqVf/iscc2rLVLNMyt7ag==",
                             "requires": {
                                 "@babel/runtime": "^7.20.6",
-                                "@polkadot/x-bigint": "10.2.1",
-                                "@polkadot/x-global": "10.2.1",
-                                "@polkadot/x-textdecoder": "10.2.1",
-                                "@polkadot/x-textencoder": "10.2.1",
-                                "@types/bn.js": "^5.1.1",
-                                "bn.js": "^5.2.1"
+                                "@polkadot/wasm-bridge": "6.4.1",
+                                "@polkadot/wasm-crypto-asmjs": "6.4.1",
+                                "@polkadot/wasm-crypto-init": "6.4.1",
+                                "@polkadot/wasm-crypto-wasm": "6.4.1",
+                                "@polkadot/wasm-util": "6.4.1"
+                            },
+                            "dependencies": {
+                                "@polkadot/wasm-crypto-asmjs": {
+                                    "version": "6.4.1",
+                                    "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-6.4.1.tgz",
+                                    "integrity": "sha512-UxZTwuBZlnODGIQdCsE2Sn/jU0O2xrNQ/TkhRFELfkZXEXTNu4lw6NpaKq7Iey4L+wKd8h4lT3VPVkMcPBLOvA==",
+                                    "requires": {
+                                        "@babel/runtime": "^7.20.6"
+                                    }
+                                },
+                                "@polkadot/wasm-crypto-wasm": {
+                                    "version": "6.4.1",
+                                    "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-6.4.1.tgz",
+                                    "integrity": "sha512-3VV9ZGzh0ZY3SmkkSw+0TRXxIpiO0nB8lFwlRgcwaCihwrvLfRnH9GI8WE12mKsHVjWTEVR3ogzILJxccAUjDA==",
+                                    "requires": {
+                                        "@babel/runtime": "^7.20.6",
+                                        "@polkadot/wasm-util": "6.4.1"
+                                    }
+                                },
+                                "@polkadot/wasm-util": {
+                                    "version": "6.4.1",
+                                    "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-6.4.1.tgz",
+                                    "integrity": "sha512-Uwo+WpEsDmFExWC5kTNvsVhvqXMZEKf4gUHXFn4c6Xz4lmieRT5g+1bO1KJ21pl4msuIgdV3Bksfs/oiqMFqlw==",
+                                    "requires": {
+                                        "@babel/runtime": "^7.20.6"
+                                    }
+                                }
+                            }
+                        },
+                        "@polkadot/x-bigint": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.4.2.tgz",
+                            "integrity": "sha512-awRiox+/XSReLzimAU94fPldowiwnnMUkQJe8AebYhNocAj6SJU00GNoj6j6tAho6yleOwrTJXZaWFBaQVJQNg==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-global": "10.4.2"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/x-randomvalues": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.4.2.tgz",
+                    "integrity": "sha512-mf1Wbpe7pRZHO0V3V89isPLqZOy5XGX2bCqsfUWHgb1NvV1MMx5TjVjdaYyNlGTiOkAmJKlOHshcfPU2sYWpNg==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/x-global": "10.4.2"
+                    },
+                    "dependencies": {
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
                             }
                         }
                     }
@@ -15607,8 +18771,8 @@
                 "@cere-ddc-sdk/key-value-storage": "1.7.6-rc.1",
                 "@cere-ddc-sdk/smart-contract": "1.7.6-rc.1",
                 "@polkadot/extension-inject": "0.44.6",
-                "@polkadot/util": "~9.7.2",
-                "@polkadot/util-crypto": "~9.7.2",
+                "@polkadot/util": "^10.1.8",
+                "@polkadot/util-crypto": "^10.1.8",
                 "@types/node": "^16.0.0",
                 "buffer": "^6.0.3",
                 "clean-publish": "^4.0.1",
@@ -15617,6 +18781,97 @@
                 "typescript": "4.5.4"
             },
             "dependencies": {
+                "@noble/hashes": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+                    "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ=="
+                },
+                "@polkadot/networks": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.4.2.tgz",
+                    "integrity": "sha512-FAh/znrEvWBiA/LbcT5GXHsCFUl//y9KqxLghSr/CreAmAergiJNT0MVUezC7Y36nkATgmsr4ylFwIxhVtuuCw==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/util": "10.4.2",
+                        "@substrate/ss58-registry": "^1.38.0"
+                    }
+                },
+                "@polkadot/util": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                    "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/x-bigint": "10.4.2",
+                        "@polkadot/x-global": "10.4.2",
+                        "@polkadot/x-textdecoder": "10.4.2",
+                        "@polkadot/x-textencoder": "10.4.2",
+                        "@types/bn.js": "^5.1.1",
+                        "bn.js": "^5.2.1"
+                    }
+                },
+                "@polkadot/util-crypto": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.4.2.tgz",
+                    "integrity": "sha512-RxZvF7C4+EF3fzQv8hZOLrYCBq5+wA+2LWv98nECkroChY3C2ZZvyWDqn8+aonNULt4dCVTWDZM0QIY6y4LUAQ==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@noble/hashes": "1.2.0",
+                        "@noble/secp256k1": "1.7.1",
+                        "@polkadot/networks": "10.4.2",
+                        "@polkadot/util": "10.4.2",
+                        "@polkadot/wasm-crypto": "^6.4.1",
+                        "@polkadot/x-bigint": "10.4.2",
+                        "@polkadot/x-randomvalues": "10.4.2",
+                        "@scure/base": "1.1.1",
+                        "ed2curve": "^0.3.0",
+                        "tweetnacl": "^1.0.3"
+                    }
+                },
+                "@polkadot/x-bigint": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.4.2.tgz",
+                    "integrity": "sha512-awRiox+/XSReLzimAU94fPldowiwnnMUkQJe8AebYhNocAj6SJU00GNoj6j6tAho6yleOwrTJXZaWFBaQVJQNg==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/x-global": "10.4.2"
+                    }
+                },
+                "@polkadot/x-global": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                    "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13"
+                    }
+                },
+                "@polkadot/x-randomvalues": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.4.2.tgz",
+                    "integrity": "sha512-mf1Wbpe7pRZHO0V3V89isPLqZOy5XGX2bCqsfUWHgb1NvV1MMx5TjVjdaYyNlGTiOkAmJKlOHshcfPU2sYWpNg==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/x-global": "10.4.2"
+                    }
+                },
+                "@polkadot/x-textdecoder": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.4.2.tgz",
+                    "integrity": "sha512-d3ADduOKUTU+cliz839+KCFmi23pxTlabH7qh7Vs1GZQvXOELWdqFOqakdiAjtMn68n1KVF4O14Y+OUm7gp/zA==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/x-global": "10.4.2"
+                    }
+                },
+                "@polkadot/x-textencoder": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.4.2.tgz",
+                    "integrity": "sha512-mxcQuA1exnyv74Kasl5vxBq01QwckG088lYjc3KwmND6+pPrW2OWagbxFX5VFoDLDAE+UJtnUHsjdWyOTDhpQA==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/x-global": "10.4.2"
+                    }
+                },
                 "typescript": {
                     "version": "4.5.4",
                     "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
@@ -15664,14 +18919,13 @@
         "@cere-ddc-sdk/smart-contract": {
             "version": "file:packages/smart-contract",
             "requires": {
-                "@polkadot/api": "8.2.1",
-                "@polkadot/api-contract": "8.2.1",
-                "@polkadot/extension-dapp": "^0.44.1",
-                "@polkadot/extension-inject": "^0.44.1",
-                "@polkadot/keyring": "~9.7.2",
-                "@polkadot/types": "~9.7.1",
-                "@polkadot/util-crypto": "~9.7.2",
-                "@polkadot/wasm-crypto": "~6.4.1",
+                "@polkadot/api": "9.4.1",
+                "@polkadot/api-contract": "9.4.1",
+                "@polkadot/extension-dapp": "^0.46.5",
+                "@polkadot/extension-inject": "^0.46.5",
+                "@polkadot/keyring": "^10.1.8",
+                "@polkadot/types": "9.4.1",
+                "@polkadot/util-crypto": "^10.1.8",
                 "@types/lodash": "^4.14.182",
                 "@types/node": "^16.0.0",
                 "clean-publish": "^4.0.1",
@@ -15682,6 +18936,1343 @@
                 "typescript": "4.5.4"
             },
             "dependencies": {
+                "@polkadot/api": {
+                    "version": "9.4.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-9.4.1.tgz",
+                    "integrity": "sha512-4xjt5M8f5K8dFvlRXGCjQO8ALplR7fG5TbOBmFdebbL9AinZkOCzKZg9J/nCUzwIYns8syjHFgakDchCkIIBTA==",
+                    "requires": {
+                        "@babel/runtime": "^7.19.0",
+                        "@polkadot/api-augment": "9.4.1",
+                        "@polkadot/api-base": "9.4.1",
+                        "@polkadot/api-derive": "9.4.1",
+                        "@polkadot/keyring": "^10.1.8",
+                        "@polkadot/rpc-augment": "9.4.1",
+                        "@polkadot/rpc-core": "9.4.1",
+                        "@polkadot/rpc-provider": "9.4.1",
+                        "@polkadot/types": "9.4.1",
+                        "@polkadot/types-augment": "9.4.1",
+                        "@polkadot/types-codec": "9.4.1",
+                        "@polkadot/types-create": "9.4.1",
+                        "@polkadot/types-known": "9.4.1",
+                        "@polkadot/util": "^10.1.8",
+                        "@polkadot/util-crypto": "^10.1.8",
+                        "eventemitter3": "^4.0.7",
+                        "rxjs": "^7.5.6"
+                    },
+                    "dependencies": {
+                        "@polkadot/rpc-provider": {
+                            "version": "9.4.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.4.1.tgz",
+                            "integrity": "sha512-JBq049KGpM6pDkgbxiADZG1cuTbBcfEJer466SVp54fGaF7ZfpWN6yb9pQNNkHvvx6rzPnxrTxWpqJXHlI+fmw==",
+                            "requires": {
+                                "@babel/runtime": "^7.19.0",
+                                "@polkadot/keyring": "^10.1.8",
+                                "@polkadot/types": "9.4.1",
+                                "@polkadot/types-support": "9.4.1",
+                                "@polkadot/util": "^10.1.8",
+                                "@polkadot/util-crypto": "^10.1.8",
+                                "@polkadot/x-fetch": "^10.1.8",
+                                "@polkadot/x-global": "^10.1.8",
+                                "@polkadot/x-ws": "^10.1.8",
+                                "@substrate/connect": "0.7.13",
+                                "eventemitter3": "^4.0.7",
+                                "mock-socket": "^9.1.5",
+                                "nock": "^13.2.9"
+                            }
+                        },
+                        "@polkadot/types-support": {
+                            "version": "9.4.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.4.1.tgz",
+                            "integrity": "sha512-5udvaZU/KvEDzhDTcU8Qv9WG/3mu6nwx7m7PqDDywzUo/MAy2zI4OT6JBHcvJIk8Qm3zVQkVftohR8CbF9FeSg==",
+                            "requires": {
+                                "@babel/runtime": "^7.19.0",
+                                "@polkadot/util": "^10.1.8"
+                            }
+                        },
+                        "@polkadot/util": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-bigint": "10.4.2",
+                                "@polkadot/x-global": "10.4.2",
+                                "@polkadot/x-textdecoder": "10.4.2",
+                                "@polkadot/x-textencoder": "10.4.2",
+                                "@types/bn.js": "^5.1.1",
+                                "bn.js": "^5.2.1"
+                            }
+                        },
+                        "@polkadot/x-fetch": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.4.2.tgz",
+                            "integrity": "sha512-Ubb64yaM4qwhogNP+4mZ3ibRghEg5UuCYRMNaCFoPgNAY8tQXuDKrHzeks3+frlmeH9YRd89o8wXLtWouwZIcw==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-global": "10.4.2",
+                                "@types/node-fetch": "^2.6.2",
+                                "node-fetch": "^3.3.0"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        },
+                        "@polkadot/x-ws": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.4.2.tgz",
+                            "integrity": "sha512-3gHSTXAWQu1EMcMVTF5QDKHhEHzKxhAArweEyDXE7VsgKUP/ixxw4hVZBrkX122iI5l5mjSiooRSnp/Zl3xqDQ==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-global": "10.4.2",
+                                "@types/websocket": "^1.0.5",
+                                "websocket": "^1.0.34"
+                            }
+                        },
+                        "@substrate/connect": {
+                            "version": "0.7.13",
+                            "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.13.tgz",
+                            "integrity": "sha512-mGvvxLVVm2Zziff8SpTybeIy+jq0LN81kPqDp/bGwtxAnRctbCsERChAu4Q5HN27cCjI1iNdzSz5ihF/DP5SdQ==",
+                            "requires": {
+                                "@substrate/connect-extension-protocol": "^1.0.1",
+                                "@substrate/smoldot-light": "0.6.33",
+                                "eventemitter3": "^4.0.7"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/api-augment": {
+                    "version": "9.4.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-9.4.1.tgz",
+                    "integrity": "sha512-I+jcPAeMUQn0YSs/JZhUsa9+SRcfGjlB0MtzkPb2w1uZhtXgg1bY36q6IXzhEHKxfjjUIjgITp/bSjJWlISzjw==",
+                    "requires": {
+                        "@babel/runtime": "^7.19.0",
+                        "@polkadot/api-base": "9.4.1",
+                        "@polkadot/rpc-augment": "9.4.1",
+                        "@polkadot/types": "9.4.1",
+                        "@polkadot/types-augment": "9.4.1",
+                        "@polkadot/types-codec": "9.4.1",
+                        "@polkadot/util": "^10.1.8"
+                    },
+                    "dependencies": {
+                        "@polkadot/util": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-bigint": "10.4.2",
+                                "@polkadot/x-global": "10.4.2",
+                                "@polkadot/x-textdecoder": "10.4.2",
+                                "@polkadot/x-textencoder": "10.4.2",
+                                "@types/bn.js": "^5.1.1",
+                                "bn.js": "^5.2.1"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/api-base": {
+                    "version": "9.4.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-9.4.1.tgz",
+                    "integrity": "sha512-APEnF3EviNMI6wKDIqU9xKOpgXhNJoT4ax4qegTqIWltx7aFMLFM8RYPPtMwSF+bm8z5w8aeEJ1H+vVlp4ovQw==",
+                    "requires": {
+                        "@babel/runtime": "^7.19.0",
+                        "@polkadot/rpc-core": "9.4.1",
+                        "@polkadot/types": "9.4.1",
+                        "@polkadot/util": "^10.1.8",
+                        "rxjs": "^7.5.6"
+                    },
+                    "dependencies": {
+                        "@polkadot/util": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-bigint": "10.4.2",
+                                "@polkadot/x-global": "10.4.2",
+                                "@polkadot/x-textdecoder": "10.4.2",
+                                "@polkadot/x-textencoder": "10.4.2",
+                                "@types/bn.js": "^5.1.1",
+                                "bn.js": "^5.2.1"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/api-contract": {
+                    "version": "9.4.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/api-contract/-/api-contract-9.4.1.tgz",
+                    "integrity": "sha512-wDGwGJhvkLStudmlsDaP6pQr4sjLRxtTrhfFU3paDkmAtOJoiUKWSiX62vGv+YMBoRQGvFGcWil5h8PNtTe45A==",
+                    "requires": {
+                        "@babel/runtime": "^7.19.0",
+                        "@polkadot/api": "9.4.1",
+                        "@polkadot/types": "9.4.1",
+                        "@polkadot/types-codec": "9.4.1",
+                        "@polkadot/types-create": "9.4.1",
+                        "@polkadot/util": "^10.1.8",
+                        "@polkadot/util-crypto": "^10.1.8",
+                        "rxjs": "^7.5.6"
+                    },
+                    "dependencies": {
+                        "@polkadot/util": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-bigint": "10.4.2",
+                                "@polkadot/x-global": "10.4.2",
+                                "@polkadot/x-textdecoder": "10.4.2",
+                                "@polkadot/x-textencoder": "10.4.2",
+                                "@types/bn.js": "^5.1.1",
+                                "bn.js": "^5.2.1"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/api-derive": {
+                    "version": "9.4.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-9.4.1.tgz",
+                    "integrity": "sha512-RgQtiVi+u2fxxleVZ1dxu7FPdj3YMGbwpaBDc9fr2/ys6Jna5myN1ZsGlO7LzUrGGzug1t8HwHmsy9Ssnlod7w==",
+                    "requires": {
+                        "@babel/runtime": "^7.19.0",
+                        "@polkadot/api": "9.4.1",
+                        "@polkadot/api-augment": "9.4.1",
+                        "@polkadot/api-base": "9.4.1",
+                        "@polkadot/rpc-core": "9.4.1",
+                        "@polkadot/types": "9.4.1",
+                        "@polkadot/types-codec": "9.4.1",
+                        "@polkadot/util": "^10.1.8",
+                        "@polkadot/util-crypto": "^10.1.8",
+                        "rxjs": "^7.5.6"
+                    },
+                    "dependencies": {
+                        "@polkadot/util": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-bigint": "10.4.2",
+                                "@polkadot/x-global": "10.4.2",
+                                "@polkadot/x-textdecoder": "10.4.2",
+                                "@polkadot/x-textencoder": "10.4.2",
+                                "@types/bn.js": "^5.1.1",
+                                "bn.js": "^5.2.1"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/extension-inject": {
+                    "version": "0.46.5",
+                    "resolved": "https://registry.npmjs.org/@polkadot/extension-inject/-/extension-inject-0.46.5.tgz",
+                    "integrity": "sha512-QcpkCMuv7iFbWjufkw14JRozpEYFyjP0H8KOJ8IsHGfPd2DPiismQ0NXr+AS7f6U+0I+Rhv9E4dnXxtJPROVMQ==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/api": "^10.9.1",
+                        "@polkadot/rpc-provider": "^10.9.1",
+                        "@polkadot/types": "^10.9.1",
+                        "@polkadot/util": "^12.3.2",
+                        "@polkadot/util-crypto": "^12.3.2",
+                        "@polkadot/x-global": "^12.3.2",
+                        "tslib": "^2.5.3"
+                    },
+                    "dependencies": {
+                        "@polkadot/api": {
+                            "version": "10.9.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-10.9.1.tgz",
+                            "integrity": "sha512-ND/2UqZBWvtt4PfV03OStTKg0mxmPk4UpMAgJKutdgsz/wP9CYJ1KbjwFgPNekL9JnzbKQsWyQNPVrcw7kQk8A==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/api-augment": "10.9.1",
+                                "@polkadot/api-base": "10.9.1",
+                                "@polkadot/api-derive": "10.9.1",
+                                "@polkadot/keyring": "^12.3.1",
+                                "@polkadot/rpc-augment": "10.9.1",
+                                "@polkadot/rpc-core": "10.9.1",
+                                "@polkadot/rpc-provider": "10.9.1",
+                                "@polkadot/types": "10.9.1",
+                                "@polkadot/types-augment": "10.9.1",
+                                "@polkadot/types-codec": "10.9.1",
+                                "@polkadot/types-create": "10.9.1",
+                                "@polkadot/types-known": "10.9.1",
+                                "@polkadot/util": "^12.3.1",
+                                "@polkadot/util-crypto": "^12.3.1",
+                                "eventemitter3": "^5.0.1",
+                                "rxjs": "^7.8.1",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/api-augment": {
+                            "version": "10.9.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-10.9.1.tgz",
+                            "integrity": "sha512-kRZZvCFVcN4hAH4dJ+Qzfdy27/4EEq3oLDf3ihj0LTVrAezSWcKPGE3EVFy+Mn6Lo4SUc7RVyoKvIUhSk2l4Dg==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/api-base": "10.9.1",
+                                "@polkadot/rpc-augment": "10.9.1",
+                                "@polkadot/types": "10.9.1",
+                                "@polkadot/types-augment": "10.9.1",
+                                "@polkadot/types-codec": "10.9.1",
+                                "@polkadot/util": "^12.3.1",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/api-base": {
+                            "version": "10.9.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.9.1.tgz",
+                            "integrity": "sha512-Q3m2KzlceMK2kX8bhnUZWk3RT6emmijeeFZZQgCePpEcrSeNjnqG4qjuTPgkveaOkUT8MAoDc5Avuzcc2jlW9g==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/rpc-core": "10.9.1",
+                                "@polkadot/types": "10.9.1",
+                                "@polkadot/util": "^12.3.1",
+                                "rxjs": "^7.8.1",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/api-derive": {
+                            "version": "10.9.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-10.9.1.tgz",
+                            "integrity": "sha512-mRud1UZCFIc4Z63qAoGSIHh/foyUYADfy1RQYCmPpeFKfIdCIrHpd7xFdJXTOMYOS0BwlM6u4qli/ZT4XigezQ==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/api": "10.9.1",
+                                "@polkadot/api-augment": "10.9.1",
+                                "@polkadot/api-base": "10.9.1",
+                                "@polkadot/rpc-core": "10.9.1",
+                                "@polkadot/types": "10.9.1",
+                                "@polkadot/types-codec": "10.9.1",
+                                "@polkadot/util": "^12.3.1",
+                                "@polkadot/util-crypto": "^12.3.1",
+                                "rxjs": "^7.8.1",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/keyring": {
+                            "version": "12.3.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.3.2.tgz",
+                            "integrity": "sha512-NTdtDeI0DP9l/45hXynNABeP5VB8piw5YR+CbUxK2e36xpJWVXwbcOepzslg5ghE9rs8UKJb30Z/HqTU4sBY0Q==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/util": "12.3.2",
+                                "@polkadot/util-crypto": "12.3.2",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/networks": {
+                            "version": "12.3.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.3.2.tgz",
+                            "integrity": "sha512-uCkyybKoeEm1daKr0uT/9oNDHDDzCy2/ZdVl346hQqfdR1Ct3BaxMjxqvdmb5N8aCw0cBWSfgsxAYtw8ESmllQ==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/util": "12.3.2",
+                                "@substrate/ss58-registry": "^1.40.0",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/rpc-augment": {
+                            "version": "10.9.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-10.9.1.tgz",
+                            "integrity": "sha512-MaLHkNlyqN20ZRYr6uNd1BZr1OsrnX9qLAmsl0mcrri1vPGRH6VHjfFH1RBLkikpWD82v17g0l2hLwdV1ZHMcw==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/rpc-core": "10.9.1",
+                                "@polkadot/types": "10.9.1",
+                                "@polkadot/types-codec": "10.9.1",
+                                "@polkadot/util": "^12.3.1",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/rpc-core": {
+                            "version": "10.9.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-10.9.1.tgz",
+                            "integrity": "sha512-ZtA8B8SfXSAwVkBlCcKRHw0eSM7ec/sbiNOM5GasXPeRujUgT7lOwSH2GbUZSqe9RfRDMp6DvO9c2JoGc3LLWw==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/rpc-augment": "10.9.1",
+                                "@polkadot/rpc-provider": "10.9.1",
+                                "@polkadot/types": "10.9.1",
+                                "@polkadot/util": "^12.3.1",
+                                "rxjs": "^7.8.1",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/types": {
+                            "version": "10.9.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+                            "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/keyring": "^12.3.1",
+                                "@polkadot/types-augment": "10.9.1",
+                                "@polkadot/types-codec": "10.9.1",
+                                "@polkadot/types-create": "10.9.1",
+                                "@polkadot/util": "^12.3.1",
+                                "@polkadot/util-crypto": "^12.3.1",
+                                "rxjs": "^7.8.1",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/types-augment": {
+                            "version": "10.9.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+                            "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/types": "10.9.1",
+                                "@polkadot/types-codec": "10.9.1",
+                                "@polkadot/util": "^12.3.1",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/types-codec": {
+                            "version": "10.9.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+                            "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/util": "^12.3.1",
+                                "@polkadot/x-bigint": "^12.3.1",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/types-create": {
+                            "version": "10.9.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+                            "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/types-codec": "10.9.1",
+                                "@polkadot/util": "^12.3.1",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/types-known": {
+                            "version": "10.9.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-10.9.1.tgz",
+                            "integrity": "sha512-zCMVWc4pJtkbMFPu72bD4IhvV/gkHXPX3C5uu92WdmCfnn0vEIEsMKWlVXVVvQQZKAqvs/awpqIfrUtEViOGEA==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/networks": "^12.3.1",
+                                "@polkadot/types": "10.9.1",
+                                "@polkadot/types-codec": "10.9.1",
+                                "@polkadot/types-create": "10.9.1",
+                                "@polkadot/util": "^12.3.1",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/util-crypto": {
+                            "version": "12.3.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.3.2.tgz",
+                            "integrity": "sha512-pTpx+YxolY0BDT4RcGmgeKbHHD/dI6Ll9xRsqmVdIjpcVVY20uDNTyXs81ZNtfKgyod1y9JQkfNv2Dz9iEpTkQ==",
+                            "dev": true,
+                            "requires": {
+                                "@noble/curves": "1.1.0",
+                                "@noble/hashes": "1.3.1",
+                                "@polkadot/networks": "12.3.2",
+                                "@polkadot/util": "12.3.2",
+                                "@polkadot/wasm-crypto": "^7.2.1",
+                                "@polkadot/wasm-util": "^7.2.1",
+                                "@polkadot/x-bigint": "12.3.2",
+                                "@polkadot/x-randomvalues": "12.3.2",
+                                "@scure/base": "1.1.1",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/x-bigint": {
+                            "version": "12.3.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+                            "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/x-global": "12.3.2",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/x-randomvalues": {
+                            "version": "12.3.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.3.2.tgz",
+                            "integrity": "sha512-ywjIs8CWpvOGmq+3cGCNPOHxAjPHdBUiXyDccftx5BRVdmtbt36gK/V84bKr6Xs73FGu0jprUAOSRRsLZX/3dg==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/x-global": "12.3.2",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "eventemitter3": {
+                            "version": "5.0.1",
+                            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+                            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+                            "dev": true
+                        }
+                    }
+                },
+                "@polkadot/keyring": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.4.2.tgz",
+                    "integrity": "sha512-7iHhJuXaHrRTG6cJDbZE9G+c1ts1dujp0qbO4RfAPmT7YUvphHvAtCKueN9UKPz5+TYDL+rP/jDEaSKU8jl/qQ==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/util": "10.4.2",
+                        "@polkadot/util-crypto": "10.4.2"
+                    },
+                    "dependencies": {
+                        "@polkadot/util": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-bigint": "10.4.2",
+                                "@polkadot/x-global": "10.4.2",
+                                "@polkadot/x-textdecoder": "10.4.2",
+                                "@polkadot/x-textencoder": "10.4.2",
+                                "@types/bn.js": "^5.1.1",
+                                "bn.js": "^5.2.1"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/networks": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.4.2.tgz",
+                    "integrity": "sha512-FAh/znrEvWBiA/LbcT5GXHsCFUl//y9KqxLghSr/CreAmAergiJNT0MVUezC7Y36nkATgmsr4ylFwIxhVtuuCw==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/util": "10.4.2",
+                        "@substrate/ss58-registry": "^1.38.0"
+                    },
+                    "dependencies": {
+                        "@polkadot/util": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-bigint": "10.4.2",
+                                "@polkadot/x-global": "10.4.2",
+                                "@polkadot/x-textdecoder": "10.4.2",
+                                "@polkadot/x-textencoder": "10.4.2",
+                                "@types/bn.js": "^5.1.1",
+                                "bn.js": "^5.2.1"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/rpc-augment": {
+                    "version": "9.4.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-9.4.1.tgz",
+                    "integrity": "sha512-ZBI5YrVE5U23Zta+XrQt9qYyf0FHgalXvlCzytjNo/VpHhZ371yisBbOuoetyP14rnF+RWux3rgU4Y1c9LNN+Q==",
+                    "requires": {
+                        "@babel/runtime": "^7.19.0",
+                        "@polkadot/rpc-core": "9.4.1",
+                        "@polkadot/types": "9.4.1",
+                        "@polkadot/types-codec": "9.4.1",
+                        "@polkadot/util": "^10.1.8"
+                    },
+                    "dependencies": {
+                        "@polkadot/util": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-bigint": "10.4.2",
+                                "@polkadot/x-global": "10.4.2",
+                                "@polkadot/x-textdecoder": "10.4.2",
+                                "@polkadot/x-textencoder": "10.4.2",
+                                "@types/bn.js": "^5.1.1",
+                                "bn.js": "^5.2.1"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/rpc-core": {
+                    "version": "9.4.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-9.4.1.tgz",
+                    "integrity": "sha512-nGiebijY+DW7qmyB5O0iIlwVpI+m3olWJrMZT0gy7eUehwhsdjWNo3CjePb+EWtdlSjhpcxTwKCc4EaikWQCyQ==",
+                    "requires": {
+                        "@babel/runtime": "^7.19.0",
+                        "@polkadot/rpc-augment": "9.4.1",
+                        "@polkadot/rpc-provider": "9.4.1",
+                        "@polkadot/types": "9.4.1",
+                        "@polkadot/util": "^10.1.8",
+                        "rxjs": "^7.5.6"
+                    },
+                    "dependencies": {
+                        "@polkadot/rpc-provider": {
+                            "version": "9.4.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.4.1.tgz",
+                            "integrity": "sha512-JBq049KGpM6pDkgbxiADZG1cuTbBcfEJer466SVp54fGaF7ZfpWN6yb9pQNNkHvvx6rzPnxrTxWpqJXHlI+fmw==",
+                            "requires": {
+                                "@babel/runtime": "^7.19.0",
+                                "@polkadot/keyring": "^10.1.8",
+                                "@polkadot/types": "9.4.1",
+                                "@polkadot/types-support": "9.4.1",
+                                "@polkadot/util": "^10.1.8",
+                                "@polkadot/util-crypto": "^10.1.8",
+                                "@polkadot/x-fetch": "^10.1.8",
+                                "@polkadot/x-global": "^10.1.8",
+                                "@polkadot/x-ws": "^10.1.8",
+                                "@substrate/connect": "0.7.13",
+                                "eventemitter3": "^4.0.7",
+                                "mock-socket": "^9.1.5",
+                                "nock": "^13.2.9"
+                            }
+                        },
+                        "@polkadot/types-support": {
+                            "version": "9.4.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.4.1.tgz",
+                            "integrity": "sha512-5udvaZU/KvEDzhDTcU8Qv9WG/3mu6nwx7m7PqDDywzUo/MAy2zI4OT6JBHcvJIk8Qm3zVQkVftohR8CbF9FeSg==",
+                            "requires": {
+                                "@babel/runtime": "^7.19.0",
+                                "@polkadot/util": "^10.1.8"
+                            }
+                        },
+                        "@polkadot/util": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-bigint": "10.4.2",
+                                "@polkadot/x-global": "10.4.2",
+                                "@polkadot/x-textdecoder": "10.4.2",
+                                "@polkadot/x-textencoder": "10.4.2",
+                                "@types/bn.js": "^5.1.1",
+                                "bn.js": "^5.2.1"
+                            }
+                        },
+                        "@polkadot/x-fetch": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.4.2.tgz",
+                            "integrity": "sha512-Ubb64yaM4qwhogNP+4mZ3ibRghEg5UuCYRMNaCFoPgNAY8tQXuDKrHzeks3+frlmeH9YRd89o8wXLtWouwZIcw==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-global": "10.4.2",
+                                "@types/node-fetch": "^2.6.2",
+                                "node-fetch": "^3.3.0"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        },
+                        "@polkadot/x-ws": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.4.2.tgz",
+                            "integrity": "sha512-3gHSTXAWQu1EMcMVTF5QDKHhEHzKxhAArweEyDXE7VsgKUP/ixxw4hVZBrkX122iI5l5mjSiooRSnp/Zl3xqDQ==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-global": "10.4.2",
+                                "@types/websocket": "^1.0.5",
+                                "websocket": "^1.0.34"
+                            }
+                        },
+                        "@substrate/connect": {
+                            "version": "0.7.13",
+                            "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.13.tgz",
+                            "integrity": "sha512-mGvvxLVVm2Zziff8SpTybeIy+jq0LN81kPqDp/bGwtxAnRctbCsERChAu4Q5HN27cCjI1iNdzSz5ihF/DP5SdQ==",
+                            "requires": {
+                                "@substrate/connect-extension-protocol": "^1.0.1",
+                                "@substrate/smoldot-light": "0.6.33",
+                                "eventemitter3": "^4.0.7"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/rpc-provider": {
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.9.1.tgz",
+                    "integrity": "sha512-4QzT2QzD+320+eT6b79sGAA85Tt3Bb8fQvse4r5Mom2iiBd2SO81vOhxSAOaIe4GUsw25VzFJmsbe7+OObItdg==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/keyring": "^12.3.1",
+                        "@polkadot/types": "10.9.1",
+                        "@polkadot/types-support": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/util-crypto": "^12.3.1",
+                        "@polkadot/x-fetch": "^12.3.1",
+                        "@polkadot/x-global": "^12.3.1",
+                        "@polkadot/x-ws": "^12.3.1",
+                        "@substrate/connect": "0.7.26",
+                        "eventemitter3": "^5.0.1",
+                        "mock-socket": "^9.2.1",
+                        "nock": "^13.3.1",
+                        "tslib": "^2.5.3"
+                    },
+                    "dependencies": {
+                        "@polkadot/keyring": {
+                            "version": "12.3.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.3.2.tgz",
+                            "integrity": "sha512-NTdtDeI0DP9l/45hXynNABeP5VB8piw5YR+CbUxK2e36xpJWVXwbcOepzslg5ghE9rs8UKJb30Z/HqTU4sBY0Q==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/util": "12.3.2",
+                                "@polkadot/util-crypto": "12.3.2",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/networks": {
+                            "version": "12.3.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.3.2.tgz",
+                            "integrity": "sha512-uCkyybKoeEm1daKr0uT/9oNDHDDzCy2/ZdVl346hQqfdR1Ct3BaxMjxqvdmb5N8aCw0cBWSfgsxAYtw8ESmllQ==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/util": "12.3.2",
+                                "@substrate/ss58-registry": "^1.40.0",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/types": {
+                            "version": "10.9.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+                            "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/keyring": "^12.3.1",
+                                "@polkadot/types-augment": "10.9.1",
+                                "@polkadot/types-codec": "10.9.1",
+                                "@polkadot/types-create": "10.9.1",
+                                "@polkadot/util": "^12.3.1",
+                                "@polkadot/util-crypto": "^12.3.1",
+                                "rxjs": "^7.8.1",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/types-augment": {
+                            "version": "10.9.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+                            "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/types": "10.9.1",
+                                "@polkadot/types-codec": "10.9.1",
+                                "@polkadot/util": "^12.3.1",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/types-codec": {
+                            "version": "10.9.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+                            "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/util": "^12.3.1",
+                                "@polkadot/x-bigint": "^12.3.1",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/types-create": {
+                            "version": "10.9.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+                            "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/types-codec": "10.9.1",
+                                "@polkadot/util": "^12.3.1",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/util-crypto": {
+                            "version": "12.3.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.3.2.tgz",
+                            "integrity": "sha512-pTpx+YxolY0BDT4RcGmgeKbHHD/dI6Ll9xRsqmVdIjpcVVY20uDNTyXs81ZNtfKgyod1y9JQkfNv2Dz9iEpTkQ==",
+                            "dev": true,
+                            "requires": {
+                                "@noble/curves": "1.1.0",
+                                "@noble/hashes": "1.3.1",
+                                "@polkadot/networks": "12.3.2",
+                                "@polkadot/util": "12.3.2",
+                                "@polkadot/wasm-crypto": "^7.2.1",
+                                "@polkadot/wasm-util": "^7.2.1",
+                                "@polkadot/x-bigint": "12.3.2",
+                                "@polkadot/x-randomvalues": "12.3.2",
+                                "@scure/base": "1.1.1",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/x-bigint": {
+                            "version": "12.3.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+                            "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/x-global": "12.3.2",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "@polkadot/x-randomvalues": {
+                            "version": "12.3.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.3.2.tgz",
+                            "integrity": "sha512-ywjIs8CWpvOGmq+3cGCNPOHxAjPHdBUiXyDccftx5BRVdmtbt36gK/V84bKr6Xs73FGu0jprUAOSRRsLZX/3dg==",
+                            "dev": true,
+                            "requires": {
+                                "@polkadot/x-global": "12.3.2",
+                                "tslib": "^2.5.3"
+                            }
+                        },
+                        "eventemitter3": {
+                            "version": "5.0.1",
+                            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+                            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+                            "dev": true
+                        }
+                    }
+                },
+                "@polkadot/types": {
+                    "version": "9.4.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.4.1.tgz",
+                    "integrity": "sha512-vUPHqlBS5neNmI+8IgJxywCL3izdCgd3SrMKWM/xlxzhGh8zfBXaGiRu1sreEk4yuNCAMMWYYDp+eqecZ6wXGA==",
+                    "requires": {
+                        "@babel/runtime": "^7.19.0",
+                        "@polkadot/keyring": "^10.1.8",
+                        "@polkadot/types-augment": "9.4.1",
+                        "@polkadot/types-codec": "9.4.1",
+                        "@polkadot/types-create": "9.4.1",
+                        "@polkadot/util": "^10.1.8",
+                        "@polkadot/util-crypto": "^10.1.8",
+                        "rxjs": "^7.5.6"
+                    },
+                    "dependencies": {
+                        "@polkadot/util": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-bigint": "10.4.2",
+                                "@polkadot/x-global": "10.4.2",
+                                "@polkadot/x-textdecoder": "10.4.2",
+                                "@polkadot/x-textencoder": "10.4.2",
+                                "@types/bn.js": "^5.1.1",
+                                "bn.js": "^5.2.1"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/types-augment": {
+                    "version": "9.4.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.4.1.tgz",
+                    "integrity": "sha512-3GHoXSSUNVQF1iFJgTWoxo/VM5JLv8kJZjJR8T5mzPjqJQLa1zejkPqF7nvmJq39R/AarrNqg6R0xE6usZAtRw==",
+                    "requires": {
+                        "@babel/runtime": "^7.19.0",
+                        "@polkadot/types": "9.4.1",
+                        "@polkadot/types-codec": "9.4.1",
+                        "@polkadot/util": "^10.1.8"
+                    },
+                    "dependencies": {
+                        "@polkadot/util": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-bigint": "10.4.2",
+                                "@polkadot/x-global": "10.4.2",
+                                "@polkadot/x-textdecoder": "10.4.2",
+                                "@polkadot/x-textencoder": "10.4.2",
+                                "@types/bn.js": "^5.1.1",
+                                "bn.js": "^5.2.1"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/types-codec": {
+                    "version": "9.4.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.4.1.tgz",
+                    "integrity": "sha512-S1aFDDK4GL/9SEFYZ6ZAzCvh2QFO/mf3dbTYZLFD7JHQLcbAgTi5E6oz+hWYzsJYW5SzTDW4VdIPoAjY+28UEA==",
+                    "requires": {
+                        "@babel/runtime": "^7.19.0",
+                        "@polkadot/util": "^10.1.8",
+                        "@polkadot/x-bigint": "^10.1.8"
+                    },
+                    "dependencies": {
+                        "@polkadot/util": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-bigint": "10.4.2",
+                                "@polkadot/x-global": "10.4.2",
+                                "@polkadot/x-textdecoder": "10.4.2",
+                                "@polkadot/x-textencoder": "10.4.2",
+                                "@types/bn.js": "^5.1.1",
+                                "bn.js": "^5.2.1"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/types-create": {
+                    "version": "9.4.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.4.1.tgz",
+                    "integrity": "sha512-XDGrefz0L8vRl5wjEtiCK8i/kwdcMCqm8vgCmXyMOsZxWkObzK9bex/EhdM/8kMBtXn/b4uQn67ZU89dptMWXw==",
+                    "requires": {
+                        "@babel/runtime": "^7.19.0",
+                        "@polkadot/types-codec": "9.4.1",
+                        "@polkadot/util": "^10.1.8"
+                    },
+                    "dependencies": {
+                        "@polkadot/util": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-bigint": "10.4.2",
+                                "@polkadot/x-global": "10.4.2",
+                                "@polkadot/x-textdecoder": "10.4.2",
+                                "@polkadot/x-textencoder": "10.4.2",
+                                "@types/bn.js": "^5.1.1",
+                                "bn.js": "^5.2.1"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/types-known": {
+                    "version": "9.4.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-9.4.1.tgz",
+                    "integrity": "sha512-1WE+3IEaWaxRvASa6lQgE2bbIaqyesZsArd1QAlsWbOVlV/mSPeRXgBKwF+uDpWOXojZ+oKsOEnBf23BHGdIPg==",
+                    "requires": {
+                        "@babel/runtime": "^7.19.0",
+                        "@polkadot/networks": "^10.1.8",
+                        "@polkadot/types": "9.4.1",
+                        "@polkadot/types-codec": "9.4.1",
+                        "@polkadot/types-create": "9.4.1",
+                        "@polkadot/util": "^10.1.8"
+                    },
+                    "dependencies": {
+                        "@polkadot/util": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-bigint": "10.4.2",
+                                "@polkadot/x-global": "10.4.2",
+                                "@polkadot/x-textdecoder": "10.4.2",
+                                "@polkadot/x-textencoder": "10.4.2",
+                                "@types/bn.js": "^5.1.1",
+                                "bn.js": "^5.2.1"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/types-support": {
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.9.1.tgz",
+                    "integrity": "sha512-XsieuLDsszvMZQlleacQBfx07i/JkwQV/UxH9q8Hz7Okmaz9pEVEW1h3ka2/cPuC7a4l32JhaORBUYshBZNdJg==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/util-crypto": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.4.2.tgz",
+                    "integrity": "sha512-RxZvF7C4+EF3fzQv8hZOLrYCBq5+wA+2LWv98nECkroChY3C2ZZvyWDqn8+aonNULt4dCVTWDZM0QIY6y4LUAQ==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@noble/hashes": "1.2.0",
+                        "@noble/secp256k1": "1.7.1",
+                        "@polkadot/networks": "10.4.2",
+                        "@polkadot/util": "10.4.2",
+                        "@polkadot/wasm-crypto": "^6.4.1",
+                        "@polkadot/x-bigint": "10.4.2",
+                        "@polkadot/x-randomvalues": "10.4.2",
+                        "@scure/base": "1.1.1",
+                        "ed2curve": "^0.3.0",
+                        "tweetnacl": "^1.0.3"
+                    },
+                    "dependencies": {
+                        "@noble/hashes": {
+                            "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+                            "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ=="
+                        },
+                        "@polkadot/util": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+                            "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13",
+                                "@polkadot/x-bigint": "10.4.2",
+                                "@polkadot/x-global": "10.4.2",
+                                "@polkadot/x-textdecoder": "10.4.2",
+                                "@polkadot/x-textencoder": "10.4.2",
+                                "@types/bn.js": "^5.1.1",
+                                "bn.js": "^5.2.1"
+                            }
+                        },
+                        "@polkadot/wasm-crypto": {
+                            "version": "6.4.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-6.4.1.tgz",
+                            "integrity": "sha512-FH+dcDPdhSLJvwL0pMLtn/LIPd62QDPODZRCmDyw+pFjLOMaRBc7raomWUOqyRWJTnqVf/iscc2rLVLNMyt7ag==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.6",
+                                "@polkadot/wasm-bridge": "6.4.1",
+                                "@polkadot/wasm-crypto-asmjs": "6.4.1",
+                                "@polkadot/wasm-crypto-init": "6.4.1",
+                                "@polkadot/wasm-crypto-wasm": "6.4.1",
+                                "@polkadot/wasm-util": "6.4.1"
+                            },
+                            "dependencies": {
+                                "@polkadot/wasm-bridge": {
+                                    "version": "6.4.1",
+                                    "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-6.4.1.tgz",
+                                    "integrity": "sha512-QZDvz6dsUlbYsaMV5biZgZWkYH9BC5AfhT0f0/knv8+LrbAoQdP3Asbvddw8vyU9sbpuCHXrd4bDLBwUCRfrBQ==",
+                                    "requires": {
+                                        "@babel/runtime": "^7.20.6"
+                                    }
+                                },
+                                "@polkadot/wasm-crypto-init": {
+                                    "version": "6.4.1",
+                                    "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-6.4.1.tgz",
+                                    "integrity": "sha512-1ALagSi/nfkyFaH6JDYfy/QbicVbSn99K8PV9rctDUfxc7P06R7CoqbjGQ4OMPX6w1WYVPU7B4jPHGLYBlVuMw==",
+                                    "requires": {
+                                        "@babel/runtime": "^7.20.6",
+                                        "@polkadot/wasm-bridge": "6.4.1",
+                                        "@polkadot/wasm-crypto-asmjs": "6.4.1",
+                                        "@polkadot/wasm-crypto-wasm": "6.4.1"
+                                    }
+                                }
+                            }
+                        },
+                        "@polkadot/wasm-crypto-asmjs": {
+                            "version": "6.4.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-6.4.1.tgz",
+                            "integrity": "sha512-UxZTwuBZlnODGIQdCsE2Sn/jU0O2xrNQ/TkhRFELfkZXEXTNu4lw6NpaKq7Iey4L+wKd8h4lT3VPVkMcPBLOvA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.6"
+                            }
+                        },
+                        "@polkadot/wasm-crypto-wasm": {
+                            "version": "6.4.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-6.4.1.tgz",
+                            "integrity": "sha512-3VV9ZGzh0ZY3SmkkSw+0TRXxIpiO0nB8lFwlRgcwaCihwrvLfRnH9GI8WE12mKsHVjWTEVR3ogzILJxccAUjDA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.6",
+                                "@polkadot/wasm-util": "6.4.1"
+                            }
+                        },
+                        "@polkadot/wasm-util": {
+                            "version": "6.4.1",
+                            "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-6.4.1.tgz",
+                            "integrity": "sha512-Uwo+WpEsDmFExWC5kTNvsVhvqXMZEKf4gUHXFn4c6Xz4lmieRT5g+1bO1KJ21pl4msuIgdV3Bksfs/oiqMFqlw==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.6"
+                            }
+                        },
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/wasm-bridge": {
+                    "version": "7.2.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.2.1.tgz",
+                    "integrity": "sha512-uV/LHREDBGBbHrrv7HTki+Klw0PYZzFomagFWII4lp6Toj/VCvRh5WMzooVC+g/XsBGosAwrvBhoModabyHx+A==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/wasm-util": "7.2.1",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@polkadot/wasm-crypto": {
+                    "version": "7.2.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.2.1.tgz",
+                    "integrity": "sha512-SA2+33S9TAwGhniKgztVN6pxUKpGfN4Tre/eUZGUfpgRkT92wIUT2GpGWQE+fCCqGQgADrNiBcwt6XwdPqMQ4Q==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/wasm-bridge": "7.2.1",
+                        "@polkadot/wasm-crypto-asmjs": "7.2.1",
+                        "@polkadot/wasm-crypto-init": "7.2.1",
+                        "@polkadot/wasm-crypto-wasm": "7.2.1",
+                        "@polkadot/wasm-util": "7.2.1",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@polkadot/wasm-crypto-asmjs": {
+                    "version": "7.2.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.2.1.tgz",
+                    "integrity": "sha512-z/d21bmxyVfkzGsKef/FWswKX02x5lK97f4NPBZ9XBeiFkmzlXhdSnu58/+b1sKsRAGdW/Rn/rTNRDhW0GqCAg==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@polkadot/wasm-crypto-init": {
+                    "version": "7.2.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.2.1.tgz",
+                    "integrity": "sha512-GcEXtwN9LcSf32V9zSaYjHImFw16hCyo2Xzg4GLLDPPeaAAfbFr2oQMgwyDbvBrBjLKHVHjsPZyGhXae831amw==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/wasm-bridge": "7.2.1",
+                        "@polkadot/wasm-crypto-asmjs": "7.2.1",
+                        "@polkadot/wasm-crypto-wasm": "7.2.1",
+                        "@polkadot/wasm-util": "7.2.1",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@polkadot/wasm-crypto-wasm": {
+                    "version": "7.2.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.2.1.tgz",
+                    "integrity": "sha512-DqyXE4rSD0CVlLIw88B58+HHNyrvm+JAnYyuEDYZwCvzUWOCNos/DDg9wi/K39VAIsCCKDmwKqkkfIofuOj/lA==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/wasm-util": "7.2.1",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@polkadot/wasm-util": {
+                    "version": "7.2.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.2.1.tgz",
+                    "integrity": "sha512-FBSn/3aYJzhN0sYAYhHB8y9JL8mVgxLy4M1kUXYbyo+8GLRQEN5rns8Vcb8TAlIzBWgVTOOptYBvxo0oj0h7Og==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@polkadot/x-bigint": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.4.2.tgz",
+                    "integrity": "sha512-awRiox+/XSReLzimAU94fPldowiwnnMUkQJe8AebYhNocAj6SJU00GNoj6j6tAho6yleOwrTJXZaWFBaQVJQNg==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/x-global": "10.4.2"
+                    },
+                    "dependencies": {
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/x-fetch": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.3.2.tgz",
+                    "integrity": "sha512-3IEuZ5S+RI/t33NsdPLIIa5COfDCfpUW2sbaByEczn75aD1jLqJZSEDwiBniJ2osyNd4uUxBf6e5jw7LAZeZJg==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/x-global": "12.3.2",
+                        "node-fetch": "^3.3.1",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/x-global": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+                    "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/x-randomvalues": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.4.2.tgz",
+                    "integrity": "sha512-mf1Wbpe7pRZHO0V3V89isPLqZOy5XGX2bCqsfUWHgb1NvV1MMx5TjVjdaYyNlGTiOkAmJKlOHshcfPU2sYWpNg==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/x-global": "10.4.2"
+                    },
+                    "dependencies": {
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/x-textdecoder": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.4.2.tgz",
+                    "integrity": "sha512-d3ADduOKUTU+cliz839+KCFmi23pxTlabH7qh7Vs1GZQvXOELWdqFOqakdiAjtMn68n1KVF4O14Y+OUm7gp/zA==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/x-global": "10.4.2"
+                    },
+                    "dependencies": {
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/x-textencoder": {
+                    "version": "10.4.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.4.2.tgz",
+                    "integrity": "sha512-mxcQuA1exnyv74Kasl5vxBq01QwckG088lYjc3KwmND6+pPrW2OWagbxFX5VFoDLDAE+UJtnUHsjdWyOTDhpQA==",
+                    "requires": {
+                        "@babel/runtime": "^7.20.13",
+                        "@polkadot/x-global": "10.4.2"
+                    },
+                    "dependencies": {
+                        "@polkadot/x-global": {
+                            "version": "10.4.2",
+                            "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+                            "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
+                            "requires": {
+                                "@babel/runtime": "^7.20.13"
+                            }
+                        }
+                    }
+                },
+                "@polkadot/x-ws": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.3.2.tgz",
+                    "integrity": "sha512-yM9Z64pLNlHpJE43+Xtr+iUXmYpFFY5u5hrke2PJt13O48H8f9Vb9cRaIh94appLyICoS0aekGhDkGH+MCspBA==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/x-global": "12.3.2",
+                        "tslib": "^2.5.3",
+                        "ws": "^8.13.0"
+                    }
+                },
+                "@substrate/connect": {
+                    "version": "0.7.26",
+                    "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.26.tgz",
+                    "integrity": "sha512-uuGSiroGuKWj1+38n1kY5HReer5iL9bRwPCzuoLtqAOmI1fGI0hsSI2LlNQMAbfRgr7VRHXOk5MTuQf5ulsFRw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "@substrate/connect-extension-protocol": "^1.0.1",
+                        "eventemitter3": "^4.0.7",
+                        "smoldot": "1.0.4"
+                    }
+                },
+                "@substrate/smoldot-light": {
+                    "version": "0.6.33",
+                    "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.33.tgz",
+                    "integrity": "sha512-b1bgIcd6369Xa1Y2MelBD3xmyX2FeHnjq8xS0ohy5uC6bR1v6kEkEyCbcIJE1+GlwDzlfaNxbJjwJPIv8FaRYA==",
+                    "requires": {
+                        "pako": "^2.0.4",
+                        "ws": "^8.8.1"
+                    }
+                },
                 "typescript": {
                     "version": "4.5.4",
                     "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
@@ -16436,15 +21027,25 @@
                 "multiformats": "^9.5.4"
             }
         },
+        "@noble/curves": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
+            "integrity": "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==",
+            "dev": true,
+            "requires": {
+                "@noble/hashes": "1.3.1"
+            }
+        },
         "@noble/hashes": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
-            "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+            "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+            "dev": true
         },
         "@noble/secp256k1": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.0.tgz",
-            "integrity": "sha512-DWSsg8zMHOYMYBqIQi96BQuthZrp98LCeMNcUOaffCIVYQ5yxDbNikLF+H7jEnmNNmXbtVic46iCuVWzar+MgA=="
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+            "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -16473,485 +21074,607 @@
             }
         },
         "@polkadot/api": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-8.2.1.tgz",
-            "integrity": "sha512-zq1sOb1dPIyUwClx5NAqWlhB/b6t6eiSDJyZdSzvWz9XL1YWcd7/m7VtrTcMQbvC8EyMKW09Xiv5G2MEI3bhVw==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-10.9.1.tgz",
+            "integrity": "sha512-ND/2UqZBWvtt4PfV03OStTKg0mxmPk4UpMAgJKutdgsz/wP9CYJ1KbjwFgPNekL9JnzbKQsWyQNPVrcw7kQk8A==",
+            "dev": true,
             "requires": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/api-augment": "8.2.1",
-                "@polkadot/api-base": "8.2.1",
-                "@polkadot/api-derive": "8.2.1",
-                "@polkadot/keyring": "^9.0.1",
-                "@polkadot/rpc-augment": "8.2.1",
-                "@polkadot/rpc-core": "8.2.1",
-                "@polkadot/rpc-provider": "8.2.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-augment": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/types-create": "8.2.1",
-                "@polkadot/types-known": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "@polkadot/util-crypto": "^9.0.1",
-                "eventemitter3": "^4.0.7",
-                "rxjs": "^7.5.5"
+                "@polkadot/api-augment": "10.9.1",
+                "@polkadot/api-base": "10.9.1",
+                "@polkadot/api-derive": "10.9.1",
+                "@polkadot/keyring": "^12.3.1",
+                "@polkadot/rpc-augment": "10.9.1",
+                "@polkadot/rpc-core": "10.9.1",
+                "@polkadot/rpc-provider": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-augment": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/types-create": "10.9.1",
+                "@polkadot/types-known": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "eventemitter3": "^5.0.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
             },
             "dependencies": {
                 "@polkadot/rpc-provider": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-8.2.1.tgz",
-                    "integrity": "sha512-aGmwAA588me4DASe01wmkcY75ABVhcRlFvozIIDtvmlCk2/4uWk4RSLMcdbhedK+XQurh1w6W9jKAddAofCAIA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.9.1.tgz",
+                    "integrity": "sha512-4QzT2QzD+320+eT6b79sGAA85Tt3Bb8fQvse4r5Mom2iiBd2SO81vOhxSAOaIe4GUsw25VzFJmsbe7+OObItdg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/keyring": "^9.0.1",
-                        "@polkadot/types": "8.2.1",
-                        "@polkadot/types-support": "8.2.1",
-                        "@polkadot/util": "^9.0.1",
-                        "@polkadot/util-crypto": "^9.0.1",
-                        "@polkadot/x-fetch": "^9.0.1",
-                        "@polkadot/x-global": "^9.0.1",
-                        "@polkadot/x-ws": "^9.0.1",
-                        "@substrate/connect": "0.7.2",
-                        "eventemitter3": "^4.0.7",
-                        "mock-socket": "^9.1.3",
-                        "nock": "^13.2.4"
+                        "@polkadot/keyring": "^12.3.1",
+                        "@polkadot/types": "10.9.1",
+                        "@polkadot/types-support": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/util-crypto": "^12.3.1",
+                        "@polkadot/x-fetch": "^12.3.1",
+                        "@polkadot/x-global": "^12.3.1",
+                        "@polkadot/x-ws": "^12.3.1",
+                        "@substrate/connect": "0.7.26",
+                        "eventemitter3": "^5.0.1",
+                        "mock-socket": "^9.2.1",
+                        "nock": "^13.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.2.1.tgz",
-                    "integrity": "sha512-Qvgvxt5GNb9RRXDNIXB9Gu+E4Vw/9aRKw76mamWqFgtRONOJ8l6HgKgWvzsCZ/lBIKLi5NE/BKPIkOhZAWfDmA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+                    "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/keyring": "^9.0.1",
-                        "@polkadot/types-augment": "8.2.1",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/types-create": "8.2.1",
-                        "@polkadot/util": "^9.0.1",
-                        "@polkadot/util-crypto": "^9.0.1",
-                        "rxjs": "^7.5.5"
+                        "@polkadot/keyring": "^12.3.1",
+                        "@polkadot/types-augment": "10.9.1",
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/types-create": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/util-crypto": "^12.3.1",
+                        "rxjs": "^7.8.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-augment": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.2.1.tgz",
-                    "integrity": "sha512-+uMC4JTYTghhbwyvvdjUnLcV3HeUZOqscfVYPYPtwctblXZRZae77b8TD1H+NqgBhloJPC8I8uBVflRIb+HcpA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+                    "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/types": "8.2.1",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/types": "10.9.1",
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-codec": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.2.1.tgz",
-                    "integrity": "sha512-dG5QUCNVmRA8BuQQdxU+2DB4lp+kbO22rDimJMNCr7lOELCIkbo+GFNpWhPInIq+aLrTTAyyv0VguJ3ciQVFJA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+                    "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/x-bigint": "^12.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-create": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.2.1.tgz",
-                    "integrity": "sha512-pdzSZgozhe/2EXnnXlxEoBiFwcg19mZ+o0ICdM+cpHayume5C3DrJzIRhQpKu7ndUyEb+MorC5aZn9Cj8Kdp0Q==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+                    "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-support": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-8.2.1.tgz",
-                    "integrity": "sha512-vXvcbioDOVGcSpKIq4UrMVfbQPLsLEnhmn0BRGQotACfWGtBqRr1En1SIfSo5nJ/gyBjoq4AUsdUQII2Sa4Drw==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.9.1.tgz",
+                    "integrity": "sha512-XsieuLDsszvMZQlleacQBfx07i/JkwQV/UxH9q8Hz7Okmaz9pEVEW1h3ka2/cPuC7a4l32JhaORBUYshBZNdJg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/x-bigint": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+                    "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/x-global": "12.3.2",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/x-fetch": {
-                    "version": "9.7.2",
-                    "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-9.7.2.tgz",
-                    "integrity": "sha512-ysXpPNq2S+L98hKow3d59prU4QFRg5N86pMkJdONc4VxtKITVY2MfdLVCqfEOOFuuwCzE7Sfmx53I4XpDgbP7A==",
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.3.2.tgz",
+                    "integrity": "sha512-3IEuZ5S+RI/t33NsdPLIIa5COfDCfpUW2sbaByEczn75aD1jLqJZSEDwiBniJ2osyNd4uUxBf6e5jw7LAZeZJg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.18.6",
-                        "@polkadot/x-global": "9.7.2",
-                        "@types/node-fetch": "^2.6.2",
-                        "node-fetch": "^2.6.7"
+                        "@polkadot/x-global": "12.3.2",
+                        "node-fetch": "^3.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/x-global": {
-                    "version": "9.7.2",
-                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-9.7.2.tgz",
-                    "integrity": "sha512-3NN5JhjosaelaFWBJSlv9mb/gDAlt7RuZ8NKlOjB+LQHd9g6ZbnYi5wwjW+i/x/3E4IVbBx66uvWgNaw7IBrkg==",
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+                    "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.18.6"
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/x-ws": {
-                    "version": "9.7.2",
-                    "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-9.7.2.tgz",
-                    "integrity": "sha512-yF2qKL00SGivbima22jxoBNYCZFI8Ph7dmnVm7fDztVtO8Fc2x30Lj3a8+qsSOrynLyJHAh2bjjQxpPmDCB9tw==",
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.3.2.tgz",
+                    "integrity": "sha512-yM9Z64pLNlHpJE43+Xtr+iUXmYpFFY5u5hrke2PJt13O48H8f9Vb9cRaIh94appLyICoS0aekGhDkGH+MCspBA==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.18.6",
-                        "@polkadot/x-global": "9.7.2",
-                        "@types/websocket": "^1.0.5",
-                        "websocket": "^1.0.34"
+                        "@polkadot/x-global": "12.3.2",
+                        "tslib": "^2.5.3",
+                        "ws": "^8.13.0"
                     }
                 },
                 "@substrate/connect": {
-                    "version": "0.7.2",
-                    "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.2.tgz",
-                    "integrity": "sha512-8GWdrN7qbClYLa9LmETJnywT5fknEQeMw+QKvkUMvsHKegHD0Zkhi0K484mKxRN9RGwcPsKHPj1gMk8xlZuJ9g==",
+                    "version": "0.7.26",
+                    "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.26.tgz",
+                    "integrity": "sha512-uuGSiroGuKWj1+38n1kY5HReer5iL9bRwPCzuoLtqAOmI1fGI0hsSI2LlNQMAbfRgr7VRHXOk5MTuQf5ulsFRw==",
+                    "dev": true,
+                    "optional": true,
                     "requires": {
-                        "@substrate/connect-extension-protocol": "^1.0.0",
-                        "@substrate/smoldot-light": "0.6.15",
-                        "eventemitter3": "^4.0.7"
+                        "@substrate/connect-extension-protocol": "^1.0.1",
+                        "eventemitter3": "^4.0.7",
+                        "smoldot": "1.0.4"
+                    },
+                    "dependencies": {
+                        "eventemitter3": {
+                            "version": "4.0.7",
+                            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+                            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+                            "dev": true,
+                            "optional": true
+                        }
                     }
                 },
-                "@substrate/smoldot-light": {
-                    "version": "0.6.15",
-                    "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.15.tgz",
-                    "integrity": "sha512-c2tJCSp9Litsn/p8wY1FfEqIkJI8Peh89BU7T43bruWRO2SSgLVh0cIVbOCY4en90tIOX4W0CueRWFBRQz7BjQ==",
-                    "requires": {
-                        "buffer": "^6.0.1",
-                        "pako": "^2.0.4",
-                        "websocket": "^1.0.32"
-                    }
-                },
-                "node-fetch": {
-                    "version": "2.6.7",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-                    "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-                    "requires": {
-                        "whatwg-url": "^5.0.0"
-                    }
+                "eventemitter3": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+                    "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+                    "dev": true
                 }
             }
         },
         "@polkadot/api-augment": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-8.2.1.tgz",
-            "integrity": "sha512-kNS4Ff1KLL6FyR04s4CIR0wVi3I36ErvOUZnZqaHE3DRUBWSzmocAkXaHrwzYDs6nseoL98jtnEkBMRO50gJWw==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-10.9.1.tgz",
+            "integrity": "sha512-kRZZvCFVcN4hAH4dJ+Qzfdy27/4EEq3oLDf3ihj0LTVrAezSWcKPGE3EVFy+Mn6Lo4SUc7RVyoKvIUhSk2l4Dg==",
+            "dev": true,
             "requires": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/api-base": "8.2.1",
-                "@polkadot/rpc-augment": "8.2.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-augment": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/api-base": "10.9.1",
+                "@polkadot/rpc-augment": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-augment": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "dependencies": {
                 "@polkadot/types": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.2.1.tgz",
-                    "integrity": "sha512-Qvgvxt5GNb9RRXDNIXB9Gu+E4Vw/9aRKw76mamWqFgtRONOJ8l6HgKgWvzsCZ/lBIKLi5NE/BKPIkOhZAWfDmA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+                    "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/keyring": "^9.0.1",
-                        "@polkadot/types-augment": "8.2.1",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/types-create": "8.2.1",
-                        "@polkadot/util": "^9.0.1",
-                        "@polkadot/util-crypto": "^9.0.1",
-                        "rxjs": "^7.5.5"
+                        "@polkadot/keyring": "^12.3.1",
+                        "@polkadot/types-augment": "10.9.1",
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/types-create": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/util-crypto": "^12.3.1",
+                        "rxjs": "^7.8.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-augment": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.2.1.tgz",
-                    "integrity": "sha512-+uMC4JTYTghhbwyvvdjUnLcV3HeUZOqscfVYPYPtwctblXZRZae77b8TD1H+NqgBhloJPC8I8uBVflRIb+HcpA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+                    "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/types": "8.2.1",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/types": "10.9.1",
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-codec": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.2.1.tgz",
-                    "integrity": "sha512-dG5QUCNVmRA8BuQQdxU+2DB4lp+kbO22rDimJMNCr7lOELCIkbo+GFNpWhPInIq+aLrTTAyyv0VguJ3ciQVFJA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+                    "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/x-bigint": "^12.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-create": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.2.1.tgz",
-                    "integrity": "sha512-pdzSZgozhe/2EXnnXlxEoBiFwcg19mZ+o0ICdM+cpHayume5C3DrJzIRhQpKu7ndUyEb+MorC5aZn9Cj8Kdp0Q==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+                    "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/x-bigint": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+                    "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/x-global": "12.3.2",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/x-global": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+                    "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.5.3"
                     }
                 }
             }
         },
         "@polkadot/api-base": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-8.2.1.tgz",
-            "integrity": "sha512-z614lpNagsuFH47++CNOYaraET4lWRA2Y+d+CqMoWlCgAtKDuqraZfjF7SzYMGp67zSD+FYFSimReWPh5LMV/Q==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.9.1.tgz",
+            "integrity": "sha512-Q3m2KzlceMK2kX8bhnUZWk3RT6emmijeeFZZQgCePpEcrSeNjnqG4qjuTPgkveaOkUT8MAoDc5Avuzcc2jlW9g==",
+            "dev": true,
             "requires": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/rpc-core": "8.2.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "rxjs": "^7.5.5"
+                "@polkadot/rpc-core": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
             },
             "dependencies": {
                 "@polkadot/types": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.2.1.tgz",
-                    "integrity": "sha512-Qvgvxt5GNb9RRXDNIXB9Gu+E4Vw/9aRKw76mamWqFgtRONOJ8l6HgKgWvzsCZ/lBIKLi5NE/BKPIkOhZAWfDmA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+                    "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/keyring": "^9.0.1",
-                        "@polkadot/types-augment": "8.2.1",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/types-create": "8.2.1",
-                        "@polkadot/util": "^9.0.1",
-                        "@polkadot/util-crypto": "^9.0.1",
-                        "rxjs": "^7.5.5"
+                        "@polkadot/keyring": "^12.3.1",
+                        "@polkadot/types-augment": "10.9.1",
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/types-create": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/util-crypto": "^12.3.1",
+                        "rxjs": "^7.8.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-augment": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.2.1.tgz",
-                    "integrity": "sha512-+uMC4JTYTghhbwyvvdjUnLcV3HeUZOqscfVYPYPtwctblXZRZae77b8TD1H+NqgBhloJPC8I8uBVflRIb+HcpA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+                    "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/types": "8.2.1",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/types": "10.9.1",
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-codec": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.2.1.tgz",
-                    "integrity": "sha512-dG5QUCNVmRA8BuQQdxU+2DB4lp+kbO22rDimJMNCr7lOELCIkbo+GFNpWhPInIq+aLrTTAyyv0VguJ3ciQVFJA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+                    "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/x-bigint": "^12.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-create": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.2.1.tgz",
-                    "integrity": "sha512-pdzSZgozhe/2EXnnXlxEoBiFwcg19mZ+o0ICdM+cpHayume5C3DrJzIRhQpKu7ndUyEb+MorC5aZn9Cj8Kdp0Q==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+                    "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/util": "^9.0.1"
-                    }
-                }
-            }
-        },
-        "@polkadot/api-contract": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/api-contract/-/api-contract-8.2.1.tgz",
-            "integrity": "sha512-y0HXHg3+8iodcdlyeXSn/ZZ2tuGs0dz8ehp09u6asZLyenWME4mi1ERSg4+WspHcQxR99TgAqfOZpCfDo1Yi8A==",
-            "requires": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/api": "8.2.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/types-create": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "@polkadot/util-crypto": "^9.0.1",
-                "rxjs": "^7.5.5"
-            },
-            "dependencies": {
-                "@polkadot/types": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.2.1.tgz",
-                    "integrity": "sha512-Qvgvxt5GNb9RRXDNIXB9Gu+E4Vw/9aRKw76mamWqFgtRONOJ8l6HgKgWvzsCZ/lBIKLi5NE/BKPIkOhZAWfDmA==",
-                    "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/keyring": "^9.0.1",
-                        "@polkadot/types-augment": "8.2.1",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/types-create": "8.2.1",
-                        "@polkadot/util": "^9.0.1",
-                        "@polkadot/util-crypto": "^9.0.1",
-                        "rxjs": "^7.5.5"
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
-                "@polkadot/types-augment": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.2.1.tgz",
-                    "integrity": "sha512-+uMC4JTYTghhbwyvvdjUnLcV3HeUZOqscfVYPYPtwctblXZRZae77b8TD1H+NqgBhloJPC8I8uBVflRIb+HcpA==",
+                "@polkadot/x-bigint": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+                    "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/types": "8.2.1",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/x-global": "12.3.2",
+                        "tslib": "^2.5.3"
                     }
                 },
-                "@polkadot/types-codec": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.2.1.tgz",
-                    "integrity": "sha512-dG5QUCNVmRA8BuQQdxU+2DB4lp+kbO22rDimJMNCr7lOELCIkbo+GFNpWhPInIq+aLrTTAyyv0VguJ3ciQVFJA==",
+                "@polkadot/x-global": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+                    "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/util": "^9.0.1"
-                    }
-                },
-                "@polkadot/types-create": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.2.1.tgz",
-                    "integrity": "sha512-pdzSZgozhe/2EXnnXlxEoBiFwcg19mZ+o0ICdM+cpHayume5C3DrJzIRhQpKu7ndUyEb+MorC5aZn9Cj8Kdp0Q==",
-                    "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/util": "^9.0.1"
+                        "tslib": "^2.5.3"
                     }
                 }
             }
         },
         "@polkadot/api-derive": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-8.2.1.tgz",
-            "integrity": "sha512-rLM99VyZMqsbYZf0ZxEYvKQCKjggJitDklHyemaVP1E2czOI+sKAy5R+oTyOXsAEk5QD2Bh6bLT6eDuuSDvdrA==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-10.9.1.tgz",
+            "integrity": "sha512-mRud1UZCFIc4Z63qAoGSIHh/foyUYADfy1RQYCmPpeFKfIdCIrHpd7xFdJXTOMYOS0BwlM6u4qli/ZT4XigezQ==",
+            "dev": true,
             "requires": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/api": "8.2.1",
-                "@polkadot/api-augment": "8.2.1",
-                "@polkadot/api-base": "8.2.1",
-                "@polkadot/rpc-core": "8.2.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "@polkadot/util-crypto": "^9.0.1",
-                "rxjs": "^7.5.5"
+                "@polkadot/api": "10.9.1",
+                "@polkadot/api-augment": "10.9.1",
+                "@polkadot/api-base": "10.9.1",
+                "@polkadot/rpc-core": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "@polkadot/util-crypto": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
             },
             "dependencies": {
                 "@polkadot/types": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.2.1.tgz",
-                    "integrity": "sha512-Qvgvxt5GNb9RRXDNIXB9Gu+E4Vw/9aRKw76mamWqFgtRONOJ8l6HgKgWvzsCZ/lBIKLi5NE/BKPIkOhZAWfDmA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+                    "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/keyring": "^9.0.1",
-                        "@polkadot/types-augment": "8.2.1",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/types-create": "8.2.1",
-                        "@polkadot/util": "^9.0.1",
-                        "@polkadot/util-crypto": "^9.0.1",
-                        "rxjs": "^7.5.5"
+                        "@polkadot/keyring": "^12.3.1",
+                        "@polkadot/types-augment": "10.9.1",
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/types-create": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/util-crypto": "^12.3.1",
+                        "rxjs": "^7.8.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-augment": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.2.1.tgz",
-                    "integrity": "sha512-+uMC4JTYTghhbwyvvdjUnLcV3HeUZOqscfVYPYPtwctblXZRZae77b8TD1H+NqgBhloJPC8I8uBVflRIb+HcpA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+                    "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/types": "8.2.1",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/types": "10.9.1",
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-codec": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.2.1.tgz",
-                    "integrity": "sha512-dG5QUCNVmRA8BuQQdxU+2DB4lp+kbO22rDimJMNCr7lOELCIkbo+GFNpWhPInIq+aLrTTAyyv0VguJ3ciQVFJA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+                    "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/x-bigint": "^12.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-create": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.2.1.tgz",
-                    "integrity": "sha512-pdzSZgozhe/2EXnnXlxEoBiFwcg19mZ+o0ICdM+cpHayume5C3DrJzIRhQpKu7ndUyEb+MorC5aZn9Cj8Kdp0Q==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+                    "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/x-bigint": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+                    "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/x-global": "12.3.2",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/x-global": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+                    "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.5.3"
                     }
                 }
             }
         },
         "@polkadot/extension-dapp": {
-            "version": "0.44.6",
-            "resolved": "https://registry.npmjs.org/@polkadot/extension-dapp/-/extension-dapp-0.44.6.tgz",
-            "integrity": "sha512-PKpc50df5dzAdYp/Btr46hdAdsUatoEInp8sc4HvIrIFDHXHcFq6I73pPDeq627SxkZjBiRGVpks8KOl9b6x6A==",
+            "version": "0.46.5",
+            "resolved": "https://registry.npmjs.org/@polkadot/extension-dapp/-/extension-dapp-0.46.5.tgz",
+            "integrity": "sha512-9Efm3oorx6orq1eue+tTk5rxuGFFCUdRxiZbdQMKiVl3lZnwBn0M61ceE3xXcf/oIwAm8RhUpQdwcbZfupJRgw==",
             "dev": true,
             "requires": {
-                "@babel/runtime": "^7.18.9",
-                "@polkadot/extension-inject": "^0.44.6",
-                "@polkadot/util": "^10.1.5",
-                "@polkadot/util-crypto": "^10.1.5"
+                "@polkadot/extension-inject": "0.46.5",
+                "@polkadot/util": "^12.3.2",
+                "@polkadot/util-crypto": "^12.3.2",
+                "tslib": "^2.5.3"
             },
             "dependencies": {
-                "@noble/hashes": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
-                    "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==",
-                    "dev": true
-                },
-                "@noble/secp256k1": {
-                    "version": "1.7.0",
-                    "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
-                    "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==",
-                    "dev": true
-                },
-                "@polkadot/util": {
-                    "version": "10.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.2.1.tgz",
-                    "integrity": "sha512-ewGKSOp+VXKEeCvpCCP2Qqi/FVkewBF9vb/N8pRwuNQ2XE9k1lnsOZZeQemVBDhKsZz+h3IeNcWejaF6K3vYHQ==",
+                "@polkadot/extension-inject": {
+                    "version": "0.46.5",
+                    "resolved": "https://registry.npmjs.org/@polkadot/extension-inject/-/extension-inject-0.46.5.tgz",
+                    "integrity": "sha512-QcpkCMuv7iFbWjufkw14JRozpEYFyjP0H8KOJ8IsHGfPd2DPiismQ0NXr+AS7f6U+0I+Rhv9E4dnXxtJPROVMQ==",
                     "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.20.6",
-                        "@polkadot/x-bigint": "10.2.1",
-                        "@polkadot/x-global": "10.2.1",
-                        "@polkadot/x-textdecoder": "10.2.1",
-                        "@polkadot/x-textencoder": "10.2.1",
-                        "@types/bn.js": "^5.1.1",
-                        "bn.js": "^5.2.1"
+                        "@polkadot/api": "^10.9.1",
+                        "@polkadot/rpc-provider": "^10.9.1",
+                        "@polkadot/types": "^10.9.1",
+                        "@polkadot/util": "^12.3.2",
+                        "@polkadot/util-crypto": "^12.3.2",
+                        "@polkadot/x-global": "^12.3.2",
+                        "tslib": "^2.5.3"
                     }
                 },
-                "@polkadot/util-crypto": {
-                    "version": "10.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.2.1.tgz",
-                    "integrity": "sha512-UH1J4oD92gkLXMfVTLee3Y2vYadNyp1lmS4P2nZwQ0SOzGZ4rN7khD2CrB1cXS9WPq196Zb5oZdGLnPYnXHtjw==",
+                "@polkadot/rpc-provider": {
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.9.1.tgz",
+                    "integrity": "sha512-4QzT2QzD+320+eT6b79sGAA85Tt3Bb8fQvse4r5Mom2iiBd2SO81vOhxSAOaIe4GUsw25VzFJmsbe7+OObItdg==",
                     "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.20.6",
-                        "@noble/hashes": "1.1.3",
-                        "@noble/secp256k1": "1.7.0",
-                        "@polkadot/networks": "10.2.1",
-                        "@polkadot/util": "10.2.1",
-                        "@polkadot/wasm-crypto": "^6.4.1",
-                        "@polkadot/x-bigint": "10.2.1",
-                        "@polkadot/x-randomvalues": "10.2.1",
-                        "@scure/base": "1.1.1",
-                        "ed2curve": "^0.3.0",
-                        "tweetnacl": "^1.0.3"
+                        "@polkadot/keyring": "^12.3.1",
+                        "@polkadot/types": "10.9.1",
+                        "@polkadot/types-support": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/util-crypto": "^12.3.1",
+                        "@polkadot/x-fetch": "^12.3.1",
+                        "@polkadot/x-global": "^12.3.1",
+                        "@polkadot/x-ws": "^12.3.1",
+                        "@substrate/connect": "0.7.26",
+                        "eventemitter3": "^5.0.1",
+                        "mock-socket": "^9.2.1",
+                        "nock": "^13.3.1",
+                        "tslib": "^2.5.3"
+                    },
+                    "dependencies": {
+                        "eventemitter3": {
+                            "version": "5.0.1",
+                            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+                            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+                            "dev": true
+                        }
                     }
                 },
-                "@polkadot/x-textdecoder": {
-                    "version": "10.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.2.1.tgz",
-                    "integrity": "sha512-hpFmrdv/rrSM4UNaV8TJBgMtwXsYlNgBTSUmnKWwJIN3PhOUeYxl1qIbPchxGbJBc35WviJCZe7rlLja9JvFcw==",
+                "@polkadot/types": {
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+                    "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
                     "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.20.6",
-                        "@polkadot/x-global": "10.2.1"
+                        "@polkadot/keyring": "^12.3.1",
+                        "@polkadot/types-augment": "10.9.1",
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/types-create": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/util-crypto": "^12.3.1",
+                        "rxjs": "^7.8.1",
+                        "tslib": "^2.5.3"
                     }
                 },
-                "@polkadot/x-textencoder": {
-                    "version": "10.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.2.1.tgz",
-                    "integrity": "sha512-4gMyY6DCH34KA++bawu/zlUJ0/8+aZJsurwjRBbkdfOS2uLo0K+vJ5GBevAhl0VSznM36ptfh/MpkIBKK/6R0g==",
+                "@polkadot/types-augment": {
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+                    "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
                     "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.20.6",
-                        "@polkadot/x-global": "10.2.1"
+                        "@polkadot/types": "10.9.1",
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/types-codec": {
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+                    "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/x-bigint": "^12.3.1",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/types-create": {
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+                    "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/types-support": {
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.9.1.tgz",
+                    "integrity": "sha512-XsieuLDsszvMZQlleacQBfx07i/JkwQV/UxH9q8Hz7Okmaz9pEVEW1h3ka2/cPuC7a4l32JhaORBUYshBZNdJg==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/x-bigint": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+                    "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/x-global": "12.3.2",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/x-fetch": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.3.2.tgz",
+                    "integrity": "sha512-3IEuZ5S+RI/t33NsdPLIIa5COfDCfpUW2sbaByEczn75aD1jLqJZSEDwiBniJ2osyNd4uUxBf6e5jw7LAZeZJg==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/x-global": "12.3.2",
+                        "node-fetch": "^3.3.1",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/x-global": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+                    "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/x-ws": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.3.2.tgz",
+                    "integrity": "sha512-yM9Z64pLNlHpJE43+Xtr+iUXmYpFFY5u5hrke2PJt13O48H8f9Vb9cRaIh94appLyICoS0aekGhDkGH+MCspBA==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/x-global": "12.3.2",
+                        "tslib": "^2.5.3",
+                        "ws": "^8.13.0"
+                    }
+                },
+                "@substrate/connect": {
+                    "version": "0.7.26",
+                    "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.26.tgz",
+                    "integrity": "sha512-uuGSiroGuKWj1+38n1kY5HReer5iL9bRwPCzuoLtqAOmI1fGI0hsSI2LlNQMAbfRgr7VRHXOk5MTuQf5ulsFRw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "@substrate/connect-extension-protocol": "^1.0.1",
+                        "eventemitter3": "^4.0.7",
+                        "smoldot": "1.0.4"
                     }
                 }
             }
@@ -17039,19 +21762,21 @@
             }
         },
         "@polkadot/keyring": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-9.7.2.tgz",
-            "integrity": "sha512-qY5baU1qduwTE04Cyrqtf2pCpsIk7Z5vi45CD9U3cbkKXaJoNUqIpfKoL8Vh/yVJBwhclMdxV9E2rEJs8Iv4bg==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.3.2.tgz",
+            "integrity": "sha512-NTdtDeI0DP9l/45hXynNABeP5VB8piw5YR+CbUxK2e36xpJWVXwbcOepzslg5ghE9rs8UKJb30Z/HqTU4sBY0Q==",
+            "dev": true,
             "requires": {
-                "@babel/runtime": "^7.18.6",
-                "@polkadot/util": "9.7.2",
-                "@polkadot/util-crypto": "9.7.2"
+                "@polkadot/util": "12.3.2",
+                "@polkadot/util-crypto": "12.3.2",
+                "tslib": "^2.5.3"
             }
         },
         "@polkadot/networks": {
             "version": "10.2.1",
             "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.2.1.tgz",
             "integrity": "sha512-cDZIY4jBo2tlDdSXNbECpuWer0NWlPcJNhHHveTiu2idje2QyIBNxBlAPViNGpz+ScAR0EknEzmQKuHOcSKxzg==",
+            "dev": true,
             "requires": {
                 "@babel/runtime": "^7.20.6",
                 "@polkadot/util": "10.2.1",
@@ -17062,6 +21787,7 @@
                     "version": "10.2.1",
                     "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.2.1.tgz",
                     "integrity": "sha512-ewGKSOp+VXKEeCvpCCP2Qqi/FVkewBF9vb/N8pRwuNQ2XE9k1lnsOZZeQemVBDhKsZz+h3IeNcWejaF6K3vYHQ==",
+                    "dev": true,
                     "requires": {
                         "@babel/runtime": "^7.20.6",
                         "@polkadot/x-bigint": "10.2.1",
@@ -17076,6 +21802,7 @@
                     "version": "10.2.1",
                     "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.2.1.tgz",
                     "integrity": "sha512-hpFmrdv/rrSM4UNaV8TJBgMtwXsYlNgBTSUmnKWwJIN3PhOUeYxl1qIbPchxGbJBc35WviJCZe7rlLja9JvFcw==",
+                    "dev": true,
                     "requires": {
                         "@babel/runtime": "^7.20.6",
                         "@polkadot/x-global": "10.2.1"
@@ -17085,6 +21812,7 @@
                     "version": "10.2.1",
                     "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.2.1.tgz",
                     "integrity": "sha512-4gMyY6DCH34KA++bawu/zlUJ0/8+aZJsurwjRBbkdfOS2uLo0K+vJ5GBevAhl0VSznM36ptfh/MpkIBKK/6R0g==",
+                    "dev": true,
                     "requires": {
                         "@babel/runtime": "^7.20.6",
                         "@polkadot/x-global": "10.2.1"
@@ -17093,207 +21821,243 @@
             }
         },
         "@polkadot/rpc-augment": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-8.2.1.tgz",
-            "integrity": "sha512-Fr0wB275SjXqdhY3A4cazKCmOVIIIX3NQSiXiqpsFYMpSgmPPMNwgDPjxngJ7aI3lqMUGGC1sSD4vkSkDntfnQ==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-10.9.1.tgz",
+            "integrity": "sha512-MaLHkNlyqN20ZRYr6uNd1BZr1OsrnX9qLAmsl0mcrri1vPGRH6VHjfFH1RBLkikpWD82v17g0l2hLwdV1ZHMcw==",
+            "dev": true,
             "requires": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/rpc-core": "8.2.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/rpc-core": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "dependencies": {
                 "@polkadot/types": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.2.1.tgz",
-                    "integrity": "sha512-Qvgvxt5GNb9RRXDNIXB9Gu+E4Vw/9aRKw76mamWqFgtRONOJ8l6HgKgWvzsCZ/lBIKLi5NE/BKPIkOhZAWfDmA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+                    "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/keyring": "^9.0.1",
-                        "@polkadot/types-augment": "8.2.1",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/types-create": "8.2.1",
-                        "@polkadot/util": "^9.0.1",
-                        "@polkadot/util-crypto": "^9.0.1",
-                        "rxjs": "^7.5.5"
+                        "@polkadot/keyring": "^12.3.1",
+                        "@polkadot/types-augment": "10.9.1",
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/types-create": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/util-crypto": "^12.3.1",
+                        "rxjs": "^7.8.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-augment": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.2.1.tgz",
-                    "integrity": "sha512-+uMC4JTYTghhbwyvvdjUnLcV3HeUZOqscfVYPYPtwctblXZRZae77b8TD1H+NqgBhloJPC8I8uBVflRIb+HcpA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+                    "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/types": "8.2.1",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/types": "10.9.1",
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-codec": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.2.1.tgz",
-                    "integrity": "sha512-dG5QUCNVmRA8BuQQdxU+2DB4lp+kbO22rDimJMNCr7lOELCIkbo+GFNpWhPInIq+aLrTTAyyv0VguJ3ciQVFJA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+                    "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/x-bigint": "^12.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-create": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.2.1.tgz",
-                    "integrity": "sha512-pdzSZgozhe/2EXnnXlxEoBiFwcg19mZ+o0ICdM+cpHayume5C3DrJzIRhQpKu7ndUyEb+MorC5aZn9Cj8Kdp0Q==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+                    "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/x-bigint": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+                    "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/x-global": "12.3.2",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/x-global": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+                    "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.5.3"
                     }
                 }
             }
         },
         "@polkadot/rpc-core": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-8.2.1.tgz",
-            "integrity": "sha512-nRhUHQ5nkbbeFh/lV3OrCHJ/SAgV1KT7onPEVkSGG+OzuyY9yvGsDUbAtqfo+r2kBEDB6RhjV4Sx1HSeNHmQWg==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-10.9.1.tgz",
+            "integrity": "sha512-ZtA8B8SfXSAwVkBlCcKRHw0eSM7ec/sbiNOM5GasXPeRujUgT7lOwSH2GbUZSqe9RfRDMp6DvO9c2JoGc3LLWw==",
+            "dev": true,
             "requires": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/rpc-augment": "8.2.1",
-                "@polkadot/rpc-provider": "8.2.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/util": "^9.0.1",
-                "rxjs": "^7.5.5"
+                "@polkadot/rpc-augment": "10.9.1",
+                "@polkadot/rpc-provider": "10.9.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "rxjs": "^7.8.1",
+                "tslib": "^2.5.3"
             },
             "dependencies": {
                 "@polkadot/rpc-provider": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-8.2.1.tgz",
-                    "integrity": "sha512-aGmwAA588me4DASe01wmkcY75ABVhcRlFvozIIDtvmlCk2/4uWk4RSLMcdbhedK+XQurh1w6W9jKAddAofCAIA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.9.1.tgz",
+                    "integrity": "sha512-4QzT2QzD+320+eT6b79sGAA85Tt3Bb8fQvse4r5Mom2iiBd2SO81vOhxSAOaIe4GUsw25VzFJmsbe7+OObItdg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/keyring": "^9.0.1",
-                        "@polkadot/types": "8.2.1",
-                        "@polkadot/types-support": "8.2.1",
-                        "@polkadot/util": "^9.0.1",
-                        "@polkadot/util-crypto": "^9.0.1",
-                        "@polkadot/x-fetch": "^9.0.1",
-                        "@polkadot/x-global": "^9.0.1",
-                        "@polkadot/x-ws": "^9.0.1",
-                        "@substrate/connect": "0.7.2",
-                        "eventemitter3": "^4.0.7",
-                        "mock-socket": "^9.1.3",
-                        "nock": "^13.2.4"
+                        "@polkadot/keyring": "^12.3.1",
+                        "@polkadot/types": "10.9.1",
+                        "@polkadot/types-support": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/util-crypto": "^12.3.1",
+                        "@polkadot/x-fetch": "^12.3.1",
+                        "@polkadot/x-global": "^12.3.1",
+                        "@polkadot/x-ws": "^12.3.1",
+                        "@substrate/connect": "0.7.26",
+                        "eventemitter3": "^5.0.1",
+                        "mock-socket": "^9.2.1",
+                        "nock": "^13.3.1",
+                        "tslib": "^2.5.3"
+                    },
+                    "dependencies": {
+                        "eventemitter3": {
+                            "version": "5.0.1",
+                            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+                            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+                            "dev": true
+                        }
                     }
                 },
                 "@polkadot/types": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.2.1.tgz",
-                    "integrity": "sha512-Qvgvxt5GNb9RRXDNIXB9Gu+E4Vw/9aRKw76mamWqFgtRONOJ8l6HgKgWvzsCZ/lBIKLi5NE/BKPIkOhZAWfDmA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+                    "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/keyring": "^9.0.1",
-                        "@polkadot/types-augment": "8.2.1",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/types-create": "8.2.1",
-                        "@polkadot/util": "^9.0.1",
-                        "@polkadot/util-crypto": "^9.0.1",
-                        "rxjs": "^7.5.5"
+                        "@polkadot/keyring": "^12.3.1",
+                        "@polkadot/types-augment": "10.9.1",
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/types-create": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/util-crypto": "^12.3.1",
+                        "rxjs": "^7.8.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-augment": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.2.1.tgz",
-                    "integrity": "sha512-+uMC4JTYTghhbwyvvdjUnLcV3HeUZOqscfVYPYPtwctblXZRZae77b8TD1H+NqgBhloJPC8I8uBVflRIb+HcpA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+                    "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/types": "8.2.1",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/types": "10.9.1",
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-codec": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.2.1.tgz",
-                    "integrity": "sha512-dG5QUCNVmRA8BuQQdxU+2DB4lp+kbO22rDimJMNCr7lOELCIkbo+GFNpWhPInIq+aLrTTAyyv0VguJ3ciQVFJA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+                    "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/x-bigint": "^12.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-create": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.2.1.tgz",
-                    "integrity": "sha512-pdzSZgozhe/2EXnnXlxEoBiFwcg19mZ+o0ICdM+cpHayume5C3DrJzIRhQpKu7ndUyEb+MorC5aZn9Cj8Kdp0Q==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+                    "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-support": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-8.2.1.tgz",
-                    "integrity": "sha512-vXvcbioDOVGcSpKIq4UrMVfbQPLsLEnhmn0BRGQotACfWGtBqRr1En1SIfSo5nJ/gyBjoq4AUsdUQII2Sa4Drw==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.9.1.tgz",
+                    "integrity": "sha512-XsieuLDsszvMZQlleacQBfx07i/JkwQV/UxH9q8Hz7Okmaz9pEVEW1h3ka2/cPuC7a4l32JhaORBUYshBZNdJg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/x-bigint": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+                    "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/x-global": "12.3.2",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/x-fetch": {
-                    "version": "9.7.2",
-                    "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-9.7.2.tgz",
-                    "integrity": "sha512-ysXpPNq2S+L98hKow3d59prU4QFRg5N86pMkJdONc4VxtKITVY2MfdLVCqfEOOFuuwCzE7Sfmx53I4XpDgbP7A==",
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.3.2.tgz",
+                    "integrity": "sha512-3IEuZ5S+RI/t33NsdPLIIa5COfDCfpUW2sbaByEczn75aD1jLqJZSEDwiBniJ2osyNd4uUxBf6e5jw7LAZeZJg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.18.6",
-                        "@polkadot/x-global": "9.7.2",
-                        "@types/node-fetch": "^2.6.2",
-                        "node-fetch": "^2.6.7"
+                        "@polkadot/x-global": "12.3.2",
+                        "node-fetch": "^3.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/x-global": {
-                    "version": "9.7.2",
-                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-9.7.2.tgz",
-                    "integrity": "sha512-3NN5JhjosaelaFWBJSlv9mb/gDAlt7RuZ8NKlOjB+LQHd9g6ZbnYi5wwjW+i/x/3E4IVbBx66uvWgNaw7IBrkg==",
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+                    "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.18.6"
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/x-ws": {
-                    "version": "9.7.2",
-                    "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-9.7.2.tgz",
-                    "integrity": "sha512-yF2qKL00SGivbima22jxoBNYCZFI8Ph7dmnVm7fDztVtO8Fc2x30Lj3a8+qsSOrynLyJHAh2bjjQxpPmDCB9tw==",
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.3.2.tgz",
+                    "integrity": "sha512-yM9Z64pLNlHpJE43+Xtr+iUXmYpFFY5u5hrke2PJt13O48H8f9Vb9cRaIh94appLyICoS0aekGhDkGH+MCspBA==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.18.6",
-                        "@polkadot/x-global": "9.7.2",
-                        "@types/websocket": "^1.0.5",
-                        "websocket": "^1.0.34"
+                        "@polkadot/x-global": "12.3.2",
+                        "tslib": "^2.5.3",
+                        "ws": "^8.13.0"
                     }
                 },
                 "@substrate/connect": {
-                    "version": "0.7.2",
-                    "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.2.tgz",
-                    "integrity": "sha512-8GWdrN7qbClYLa9LmETJnywT5fknEQeMw+QKvkUMvsHKegHD0Zkhi0K484mKxRN9RGwcPsKHPj1gMk8xlZuJ9g==",
+                    "version": "0.7.26",
+                    "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.26.tgz",
+                    "integrity": "sha512-uuGSiroGuKWj1+38n1kY5HReer5iL9bRwPCzuoLtqAOmI1fGI0hsSI2LlNQMAbfRgr7VRHXOk5MTuQf5ulsFRw==",
+                    "dev": true,
+                    "optional": true,
                     "requires": {
-                        "@substrate/connect-extension-protocol": "^1.0.0",
-                        "@substrate/smoldot-light": "0.6.15",
-                        "eventemitter3": "^4.0.7"
-                    }
-                },
-                "@substrate/smoldot-light": {
-                    "version": "0.6.15",
-                    "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.15.tgz",
-                    "integrity": "sha512-c2tJCSp9Litsn/p8wY1FfEqIkJI8Peh89BU7T43bruWRO2SSgLVh0cIVbOCY4en90tIOX4W0CueRWFBRQz7BjQ==",
-                    "requires": {
-                        "buffer": "^6.0.1",
-                        "pako": "^2.0.4",
-                        "websocket": "^1.0.32"
-                    }
-                },
-                "node-fetch": {
-                    "version": "2.6.7",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-                    "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-                    "requires": {
-                        "whatwg-url": "^5.0.0"
+                        "@substrate/connect-extension-protocol": "^1.0.1",
+                        "eventemitter3": "^4.0.7",
+                        "smoldot": "1.0.4"
                     }
                 }
             }
@@ -17418,6 +22182,7 @@
             "version": "9.7.1",
             "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.7.1.tgz",
             "integrity": "sha512-MnRVHFsQvJm+SV1lCiL+uSOYXjHKpDiFvDlmxUVQYnDtgZIK3Q5deKGbM0Lrg393/QbZr13+MhPhnlKCgiaeUg==",
+            "dev": true,
             "requires": {
                 "@babel/runtime": "^7.20.1",
                 "@polkadot/keyring": "^10.1.11",
@@ -17432,17 +22197,20 @@
                 "@noble/hashes": {
                     "version": "1.1.3",
                     "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
-                    "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A=="
+                    "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==",
+                    "dev": true
                 },
                 "@noble/secp256k1": {
                     "version": "1.7.0",
                     "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
-                    "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw=="
+                    "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==",
+                    "dev": true
                 },
                 "@polkadot/keyring": {
                     "version": "10.2.1",
                     "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.2.1.tgz",
                     "integrity": "sha512-84/zzxDZANQ4AfsCT1vrjX3I23/mj9WUWl1F7q9ruK6UBFyGsl46Y3ABOopFHij9UXhppndhB65IeDnqoOKqxQ==",
+                    "dev": true,
                     "requires": {
                         "@babel/runtime": "^7.20.6",
                         "@polkadot/util": "10.2.1",
@@ -17453,6 +22221,7 @@
                     "version": "9.7.1",
                     "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.7.1.tgz",
                     "integrity": "sha512-rCzRrPxIUitrT2WxPi6FG9gLHyTzZ8SYHUb8Ha279YQQFxl6Lv6p33uzQJcUutQVmvaUAPJGGkAQLCbmXAFbnA==",
+                    "dev": true,
                     "requires": {
                         "@babel/runtime": "^7.20.1",
                         "@polkadot/types": "9.7.1",
@@ -17464,6 +22233,7 @@
                     "version": "9.7.1",
                     "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.7.1.tgz",
                     "integrity": "sha512-rzSUbDL7ytFVg7mnjV9zutLSDwTN7nEBSKYLtUK8vnGOG+nr8ds4IUcur0XK6VPj72Duz5ovvxi/JyUlE9+W3Q==",
+                    "dev": true,
                     "requires": {
                         "@babel/runtime": "^7.20.1",
                         "@polkadot/util": "^10.1.11",
@@ -17474,6 +22244,7 @@
                     "version": "9.7.1",
                     "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.7.1.tgz",
                     "integrity": "sha512-Bk1F3bHmK2yIeVj9dPP4v5TMvsPFMOquovFp2rTmW7gLGauiwQTS1WP356VtmSDbZWJ0H89nHpXdgYRqDDi5sg==",
+                    "dev": true,
                     "requires": {
                         "@babel/runtime": "^7.20.1",
                         "@polkadot/types-codec": "9.7.1",
@@ -17484,6 +22255,7 @@
                     "version": "10.2.1",
                     "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.2.1.tgz",
                     "integrity": "sha512-ewGKSOp+VXKEeCvpCCP2Qqi/FVkewBF9vb/N8pRwuNQ2XE9k1lnsOZZeQemVBDhKsZz+h3IeNcWejaF6K3vYHQ==",
+                    "dev": true,
                     "requires": {
                         "@babel/runtime": "^7.20.6",
                         "@polkadot/x-bigint": "10.2.1",
@@ -17498,6 +22270,7 @@
                     "version": "10.2.1",
                     "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.2.1.tgz",
                     "integrity": "sha512-UH1J4oD92gkLXMfVTLee3Y2vYadNyp1lmS4P2nZwQ0SOzGZ4rN7khD2CrB1cXS9WPq196Zb5oZdGLnPYnXHtjw==",
+                    "dev": true,
                     "requires": {
                         "@babel/runtime": "^7.20.6",
                         "@noble/hashes": "1.1.3",
@@ -17516,6 +22289,7 @@
                     "version": "10.2.1",
                     "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.2.1.tgz",
                     "integrity": "sha512-hpFmrdv/rrSM4UNaV8TJBgMtwXsYlNgBTSUmnKWwJIN3PhOUeYxl1qIbPchxGbJBc35WviJCZe7rlLja9JvFcw==",
+                    "dev": true,
                     "requires": {
                         "@babel/runtime": "^7.20.6",
                         "@polkadot/x-global": "10.2.1"
@@ -17525,6 +22299,7 @@
                     "version": "10.2.1",
                     "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.2.1.tgz",
                     "integrity": "sha512-4gMyY6DCH34KA++bawu/zlUJ0/8+aZJsurwjRBbkdfOS2uLo0K+vJ5GBevAhl0VSznM36ptfh/MpkIBKK/6R0g==",
+                    "dev": true,
                     "requires": {
                         "@babel/runtime": "^7.20.6",
                         "@polkadot/x-global": "10.2.1"
@@ -17736,71 +22511,97 @@
             }
         },
         "@polkadot/types-known": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-8.2.1.tgz",
-            "integrity": "sha512-9d+LOffogl7HOJ9ooiaOjfbZttF3LgjkVMTU1BQduu5Ln/o6Bk5ARCDeJuSEwYIegtqxrwpxlJabUuUT9xNmew==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-10.9.1.tgz",
+            "integrity": "sha512-zCMVWc4pJtkbMFPu72bD4IhvV/gkHXPX3C5uu92WdmCfnn0vEIEsMKWlVXVVvQQZKAqvs/awpqIfrUtEViOGEA==",
+            "dev": true,
             "requires": {
-                "@babel/runtime": "^7.17.9",
-                "@polkadot/networks": "^9.0.1",
-                "@polkadot/types": "8.2.1",
-                "@polkadot/types-codec": "8.2.1",
-                "@polkadot/types-create": "8.2.1",
-                "@polkadot/util": "^9.0.1"
+                "@polkadot/networks": "^12.3.1",
+                "@polkadot/types": "10.9.1",
+                "@polkadot/types-codec": "10.9.1",
+                "@polkadot/types-create": "10.9.1",
+                "@polkadot/util": "^12.3.1",
+                "tslib": "^2.5.3"
             },
             "dependencies": {
                 "@polkadot/networks": {
-                    "version": "9.7.2",
-                    "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-9.7.2.tgz",
-                    "integrity": "sha512-oMAdF8Y9CLBI0EUZBcycHcvbQQdbkJHevPJ/lwnZXJTaueXuav/Xm2yiFj5J3V8meIjLocURlMawgsAVItXOBQ==",
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.3.2.tgz",
+                    "integrity": "sha512-uCkyybKoeEm1daKr0uT/9oNDHDDzCy2/ZdVl346hQqfdR1Ct3BaxMjxqvdmb5N8aCw0cBWSfgsxAYtw8ESmllQ==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.18.6",
-                        "@polkadot/util": "9.7.2",
-                        "@substrate/ss58-registry": "^1.23.0"
+                        "@polkadot/util": "12.3.2",
+                        "@substrate/ss58-registry": "^1.40.0",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.2.1.tgz",
-                    "integrity": "sha512-Qvgvxt5GNb9RRXDNIXB9Gu+E4Vw/9aRKw76mamWqFgtRONOJ8l6HgKgWvzsCZ/lBIKLi5NE/BKPIkOhZAWfDmA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.9.1.tgz",
+                    "integrity": "sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/keyring": "^9.0.1",
-                        "@polkadot/types-augment": "8.2.1",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/types-create": "8.2.1",
-                        "@polkadot/util": "^9.0.1",
-                        "@polkadot/util-crypto": "^9.0.1",
-                        "rxjs": "^7.5.5"
+                        "@polkadot/keyring": "^12.3.1",
+                        "@polkadot/types-augment": "10.9.1",
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/types-create": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/util-crypto": "^12.3.1",
+                        "rxjs": "^7.8.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-augment": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.2.1.tgz",
-                    "integrity": "sha512-+uMC4JTYTghhbwyvvdjUnLcV3HeUZOqscfVYPYPtwctblXZRZae77b8TD1H+NqgBhloJPC8I8uBVflRIb+HcpA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.9.1.tgz",
+                    "integrity": "sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/types": "8.2.1",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/types": "10.9.1",
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-codec": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.2.1.tgz",
-                    "integrity": "sha512-dG5QUCNVmRA8BuQQdxU+2DB4lp+kbO22rDimJMNCr7lOELCIkbo+GFNpWhPInIq+aLrTTAyyv0VguJ3ciQVFJA==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.9.1.tgz",
+                    "integrity": "sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/util": "^12.3.1",
+                        "@polkadot/x-bigint": "^12.3.1",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/types-create": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.2.1.tgz",
-                    "integrity": "sha512-pdzSZgozhe/2EXnnXlxEoBiFwcg19mZ+o0ICdM+cpHayume5C3DrJzIRhQpKu7ndUyEb+MorC5aZn9Cj8Kdp0Q==",
+                    "version": "10.9.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.9.1.tgz",
+                    "integrity": "sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.17.9",
-                        "@polkadot/types-codec": "8.2.1",
-                        "@polkadot/util": "^9.0.1"
+                        "@polkadot/types-codec": "10.9.1",
+                        "@polkadot/util": "^12.3.1",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/x-bigint": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+                    "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/x-global": "12.3.2",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/x-global": {
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+                    "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.5.3"
                     }
                 }
             }
@@ -17853,91 +22654,159 @@
             }
         },
         "@polkadot/util": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-9.7.2.tgz",
-            "integrity": "sha512-ivTmA+KkPCq5i3O0Gk+dTds/hwdwlYCh89aKfeaG9ni3XHUbbuBgTqHneo648HqxwAwSAyiDiwE9EdXrzAdO4Q==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.3.2.tgz",
+            "integrity": "sha512-y/JShcGyOamCUiSIg++XZuLHt1ktSKBaSH2K5Nw5NXlgP0+7am+GZzqPB8fQ4qhYLruEOv+YRiz0GC1Zr9S+wg==",
             "requires": {
-                "@babel/runtime": "^7.18.6",
-                "@polkadot/x-bigint": "9.7.2",
-                "@polkadot/x-global": "9.7.2",
-                "@polkadot/x-textdecoder": "9.7.2",
-                "@polkadot/x-textencoder": "9.7.2",
-                "@types/bn.js": "^5.1.0",
+                "@polkadot/x-bigint": "12.3.2",
+                "@polkadot/x-global": "12.3.2",
+                "@polkadot/x-textdecoder": "12.3.2",
+                "@polkadot/x-textencoder": "12.3.2",
+                "@types/bn.js": "^5.1.1",
                 "bn.js": "^5.2.1",
-                "ip-regex": "^4.3.0"
+                "tslib": "^2.5.3"
             },
             "dependencies": {
                 "@polkadot/x-bigint": {
-                    "version": "9.7.2",
-                    "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-9.7.2.tgz",
-                    "integrity": "sha512-qi8/DTGypFSt5vvNOsYcEaqH72lymfyidGlsHlZ6e7nNASnEhk/NaOcINiTr1ds+fpu4dtKXWAIPZufujf2JeQ==",
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+                    "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
                     "requires": {
-                        "@babel/runtime": "^7.18.6",
-                        "@polkadot/x-global": "9.7.2"
+                        "@polkadot/x-global": "12.3.2",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/x-global": {
-                    "version": "9.7.2",
-                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-9.7.2.tgz",
-                    "integrity": "sha512-3NN5JhjosaelaFWBJSlv9mb/gDAlt7RuZ8NKlOjB+LQHd9g6ZbnYi5wwjW+i/x/3E4IVbBx66uvWgNaw7IBrkg==",
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+                    "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
                     "requires": {
-                        "@babel/runtime": "^7.18.6"
+                        "tslib": "^2.5.3"
                     }
                 }
             }
         },
         "@polkadot/util-crypto": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-9.7.2.tgz",
-            "integrity": "sha512-tfz6mJtPwoNteivKCmR+QklC4mr1/hGZRsDJLWKaFhanDinYZ3V2pJM1EbCI6WONLuuzlTxsDXjAffWzzRqlPA==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.3.2.tgz",
+            "integrity": "sha512-pTpx+YxolY0BDT4RcGmgeKbHHD/dI6Ll9xRsqmVdIjpcVVY20uDNTyXs81ZNtfKgyod1y9JQkfNv2Dz9iEpTkQ==",
+            "dev": true,
             "requires": {
-                "@babel/runtime": "^7.18.6",
-                "@noble/hashes": "1.1.2",
-                "@noble/secp256k1": "1.6.0",
-                "@polkadot/networks": "9.7.2",
-                "@polkadot/util": "9.7.2",
-                "@polkadot/wasm-crypto": "^6.2.2",
-                "@polkadot/x-bigint": "9.7.2",
-                "@polkadot/x-randomvalues": "9.7.2",
+                "@noble/curves": "1.1.0",
+                "@noble/hashes": "1.3.1",
+                "@polkadot/networks": "12.3.2",
+                "@polkadot/util": "12.3.2",
+                "@polkadot/wasm-crypto": "^7.2.1",
+                "@polkadot/wasm-util": "^7.2.1",
+                "@polkadot/x-bigint": "12.3.2",
+                "@polkadot/x-randomvalues": "12.3.2",
                 "@scure/base": "1.1.1",
-                "ed2curve": "^0.3.0",
-                "tweetnacl": "^1.0.3"
+                "tslib": "^2.5.3"
             },
             "dependencies": {
                 "@polkadot/networks": {
-                    "version": "9.7.2",
-                    "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-9.7.2.tgz",
-                    "integrity": "sha512-oMAdF8Y9CLBI0EUZBcycHcvbQQdbkJHevPJ/lwnZXJTaueXuav/Xm2yiFj5J3V8meIjLocURlMawgsAVItXOBQ==",
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.3.2.tgz",
+                    "integrity": "sha512-uCkyybKoeEm1daKr0uT/9oNDHDDzCy2/ZdVl346hQqfdR1Ct3BaxMjxqvdmb5N8aCw0cBWSfgsxAYtw8ESmllQ==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.18.6",
-                        "@polkadot/util": "9.7.2",
-                        "@substrate/ss58-registry": "^1.23.0"
+                        "@polkadot/util": "12.3.2",
+                        "@substrate/ss58-registry": "^1.40.0",
+                        "tslib": "^2.5.3"
+                    }
+                },
+                "@polkadot/wasm-bridge": {
+                    "version": "7.2.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.2.1.tgz",
+                    "integrity": "sha512-uV/LHREDBGBbHrrv7HTki+Klw0PYZzFomagFWII4lp6Toj/VCvRh5WMzooVC+g/XsBGosAwrvBhoModabyHx+A==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/wasm-util": "7.2.1",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@polkadot/wasm-crypto": {
+                    "version": "7.2.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.2.1.tgz",
+                    "integrity": "sha512-SA2+33S9TAwGhniKgztVN6pxUKpGfN4Tre/eUZGUfpgRkT92wIUT2GpGWQE+fCCqGQgADrNiBcwt6XwdPqMQ4Q==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/wasm-bridge": "7.2.1",
+                        "@polkadot/wasm-crypto-asmjs": "7.2.1",
+                        "@polkadot/wasm-crypto-init": "7.2.1",
+                        "@polkadot/wasm-crypto-wasm": "7.2.1",
+                        "@polkadot/wasm-util": "7.2.1",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@polkadot/wasm-crypto-asmjs": {
+                    "version": "7.2.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.2.1.tgz",
+                    "integrity": "sha512-z/d21bmxyVfkzGsKef/FWswKX02x5lK97f4NPBZ9XBeiFkmzlXhdSnu58/+b1sKsRAGdW/Rn/rTNRDhW0GqCAg==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@polkadot/wasm-crypto-init": {
+                    "version": "7.2.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.2.1.tgz",
+                    "integrity": "sha512-GcEXtwN9LcSf32V9zSaYjHImFw16hCyo2Xzg4GLLDPPeaAAfbFr2oQMgwyDbvBrBjLKHVHjsPZyGhXae831amw==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/wasm-bridge": "7.2.1",
+                        "@polkadot/wasm-crypto-asmjs": "7.2.1",
+                        "@polkadot/wasm-crypto-wasm": "7.2.1",
+                        "@polkadot/wasm-util": "7.2.1",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@polkadot/wasm-crypto-wasm": {
+                    "version": "7.2.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.2.1.tgz",
+                    "integrity": "sha512-DqyXE4rSD0CVlLIw88B58+HHNyrvm+JAnYyuEDYZwCvzUWOCNos/DDg9wi/K39VAIsCCKDmwKqkkfIofuOj/lA==",
+                    "dev": true,
+                    "requires": {
+                        "@polkadot/wasm-util": "7.2.1",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@polkadot/wasm-util": {
+                    "version": "7.2.1",
+                    "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.2.1.tgz",
+                    "integrity": "sha512-FBSn/3aYJzhN0sYAYhHB8y9JL8mVgxLy4M1kUXYbyo+8GLRQEN5rns8Vcb8TAlIzBWgVTOOptYBvxo0oj0h7Og==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.5.0"
                     }
                 },
                 "@polkadot/x-bigint": {
-                    "version": "9.7.2",
-                    "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-9.7.2.tgz",
-                    "integrity": "sha512-qi8/DTGypFSt5vvNOsYcEaqH72lymfyidGlsHlZ6e7nNASnEhk/NaOcINiTr1ds+fpu4dtKXWAIPZufujf2JeQ==",
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.3.2.tgz",
+                    "integrity": "sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.18.6",
-                        "@polkadot/x-global": "9.7.2"
+                        "@polkadot/x-global": "12.3.2",
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/x-global": {
-                    "version": "9.7.2",
-                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-9.7.2.tgz",
-                    "integrity": "sha512-3NN5JhjosaelaFWBJSlv9mb/gDAlt7RuZ8NKlOjB+LQHd9g6ZbnYi5wwjW+i/x/3E4IVbBx66uvWgNaw7IBrkg==",
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+                    "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.18.6"
+                        "tslib": "^2.5.3"
                     }
                 },
                 "@polkadot/x-randomvalues": {
-                    "version": "9.7.2",
-                    "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-9.7.2.tgz",
-                    "integrity": "sha512-819slnXNpoVtqdhjI19ao7w5m+Zwx11VfwCZkFQypVv3b/1UEoKG/baJA9dVI6yMvhnBN//i8mLgNy3IXWbVVw==",
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.3.2.tgz",
+                    "integrity": "sha512-ywjIs8CWpvOGmq+3cGCNPOHxAjPHdBUiXyDccftx5BRVdmtbt36gK/V84bKr6Xs73FGu0jprUAOSRRsLZX/3dg==",
+                    "dev": true,
                     "requires": {
-                        "@babel/runtime": "^7.18.6",
-                        "@polkadot/x-global": "9.7.2"
+                        "@polkadot/x-global": "12.3.2",
+                        "tslib": "^2.5.3"
                     }
                 }
             }
@@ -18003,6 +22872,7 @@
             "version": "10.2.1",
             "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.2.1.tgz",
             "integrity": "sha512-asFroI2skC4gYv0oIqqb84DqCCxhNUTSCKobEg57WdXoT4TKrN9Uetg2AMSIHRiX/9lP3EPMhUjM1VVGobTQRQ==",
+            "dev": true,
             "requires": {
                 "@babel/runtime": "^7.20.6",
                 "@polkadot/x-global": "10.2.1"
@@ -18038,39 +22908,39 @@
             }
         },
         "@polkadot/x-textdecoder": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-9.7.2.tgz",
-            "integrity": "sha512-hhrMNZwJBmusdpqjDRpOHZoMB4hpyJt9Gu9Bi9is7/D/vq/hpxq8z7s6NxrbRyXJf1SIk6NMK0jf5XjRLdKdbw==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.3.2.tgz",
+            "integrity": "sha512-lY5bfA5xArJRWEJlYOlQQMJeTjWD8s0yMhchirVgf5xj8Id9vPGeUoneH+VFDEwgXxrqBvDFJ4smN4T/r6a/fg==",
             "requires": {
-                "@babel/runtime": "^7.18.6",
-                "@polkadot/x-global": "9.7.2"
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
             },
             "dependencies": {
                 "@polkadot/x-global": {
-                    "version": "9.7.2",
-                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-9.7.2.tgz",
-                    "integrity": "sha512-3NN5JhjosaelaFWBJSlv9mb/gDAlt7RuZ8NKlOjB+LQHd9g6ZbnYi5wwjW+i/x/3E4IVbBx66uvWgNaw7IBrkg==",
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+                    "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
                     "requires": {
-                        "@babel/runtime": "^7.18.6"
+                        "tslib": "^2.5.3"
                     }
                 }
             }
         },
         "@polkadot/x-textencoder": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-9.7.2.tgz",
-            "integrity": "sha512-GHbSdbMPixDAOnJ9cvL/x9sPNeHegPoDSqCAzY5H6/zHc/fNn0vUu0To9VpPgPhp/Jb9dbc0h8YqEyvOcOlphw==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.3.2.tgz",
+            "integrity": "sha512-iP3qEBiHzBckQ9zeY7ZHRWuu7mCEg5SMpOugs6UODRk8sx6KHzGQYlghBbWLit0uppPDVE0ifEwZ2n73djJHWQ==",
             "requires": {
-                "@babel/runtime": "^7.18.6",
-                "@polkadot/x-global": "9.7.2"
+                "@polkadot/x-global": "12.3.2",
+                "tslib": "^2.5.3"
             },
             "dependencies": {
                 "@polkadot/x-global": {
-                    "version": "9.7.2",
-                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-9.7.2.tgz",
-                    "integrity": "sha512-3NN5JhjosaelaFWBJSlv9mb/gDAlt7RuZ8NKlOjB+LQHd9g6ZbnYi5wwjW+i/x/3E4IVbBx66uvWgNaw7IBrkg==",
+                    "version": "12.3.2",
+                    "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.3.2.tgz",
+                    "integrity": "sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==",
                     "requires": {
-                        "@babel/runtime": "^7.18.6"
+                        "tslib": "^2.5.3"
                     }
                 }
             }
@@ -18203,9 +23073,9 @@
             }
         },
         "@substrate/ss58-registry": {
-            "version": "1.35.0",
-            "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.35.0.tgz",
-            "integrity": "sha512-cIY3J7RlT4mfPNFwd2mv1q9vTp/shImw2gN2y2outMhOcagH/HG+W8/JohpifjxPC/1pbQ0Z8nxfL5Td3EchcA=="
+            "version": "1.41.0",
+            "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.41.0.tgz",
+            "integrity": "sha512-TLz5VkEaJRNFzf1Oiix9gqknKer3aKbLfjK9XHBFCIhdxlQpI+S6lZGu3wT4DHAGXPakYfXb8+9ZIOtWLcQ/2Q=="
         },
         "@tsconfig/node10": {
             "version": "1.0.9",
@@ -19754,8 +24624,7 @@
         "data-uri-to-buffer": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-            "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-            "dev": true
+            "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
         },
         "debug": {
             "version": "4.3.4",
@@ -20523,7 +25392,6 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
             "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-            "dev": true,
             "requires": {
                 "node-domexception": "^1.0.0",
                 "web-streams-polyfill": "^3.0.3"
@@ -20611,7 +25479,6 @@
             "version": "4.0.10",
             "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
             "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-            "dev": true,
             "requires": {
                 "fetch-blob": "^3.1.2"
             }
@@ -20856,7 +25723,8 @@
         "ip-regex": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-            "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
+            "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+            "dev": true
         },
         "is-arrayish": {
             "version": "0.2.1",
@@ -22788,9 +27656,9 @@
             "dev": true
         },
         "mock-socket": {
-            "version": "9.1.5",
-            "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.1.5.tgz",
-            "integrity": "sha512-3DeNIcsQixWHHKk6NdoBhWI4t1VMj5/HzfnI1rE/pLl5qKx7+gd4DNA07ehTaZ6MoUU053si6Hd+YtiM/tQZfg=="
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.2.1.tgz",
+            "integrity": "sha512-aw9F9T9G2zpGipLLhSNh6ZpgUyUl4frcVmRN08uE1NWPWg43Wx6+sGPDbQ7E5iFZZDJW5b5bypMeAEHqTbIFag=="
         },
         "ms": {
             "version": "2.1.2",
@@ -22833,9 +27701,9 @@
             "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
         },
         "nock": {
-            "version": "13.2.9",
-            "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.9.tgz",
-            "integrity": "sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==",
+            "version": "13.3.1",
+            "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.1.tgz",
+            "integrity": "sha512-vHnopocZuI93p2ccivFyGuUfzjq2fxNyNurp7816mlT5V5HF4SzXu8lvLrVzBbNqzs+ODooZ6OksuSUNM7Njkw==",
             "requires": {
                 "debug": "^4.1.0",
                 "json-stringify-safe": "^5.0.1",
@@ -22846,14 +27714,12 @@
         "node-domexception": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-            "dev": true
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
         },
         "node-fetch": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-            "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
-            "dev": true,
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+            "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
             "requires": {
                 "data-uri-to-buffer": "^4.0.0",
                 "fetch-blob": "^3.1.4",
@@ -23440,9 +28306,9 @@
             }
         },
         "rxjs": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.6.0.tgz",
-            "integrity": "sha512-DDa7d8TFNUalGC9VqXvQ1euWNN7sc63TrUCuM9J998+ViviahMIjKSOU7rfcgFOF+FCD71BhDRv4hrFz+ImDLQ==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
             "requires": {
                 "tslib": "^2.1.0"
             }
@@ -23536,6 +28402,17 @@
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true
+        },
+        "smoldot": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-1.0.4.tgz",
+            "integrity": "sha512-N3TazI1C4GGrseFH/piWyZCCCRJTRx2QhDfrUKRT4SzILlW5m8ayZ3QTKICcz1C/536T9cbHHJyP7afxI6Mi1A==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "pako": "^2.0.4",
+                "ws": "^8.8.1"
+            }
         },
         "source-map": {
             "version": "0.6.1",
@@ -23926,7 +28803,8 @@
         "tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "dev": true
         },
         "ts-jest": {
             "version": "28.0.8",
@@ -24049,9 +28927,9 @@
             }
         },
         "tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
         },
         "tslint": {
             "version": "6.1.3",
@@ -24305,13 +29183,13 @@
         "web-streams-polyfill": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-            "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-            "dev": true
+            "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
         },
         "webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "dev": true
         },
         "webpack": {
             "version": "5.75.0",
@@ -24450,6 +29328,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dev": true,
             "requires": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -24549,10 +29428,9 @@
             }
         },
         "ws": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-            "dev": true,
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
             "requires": {}
         },
         "y18n": {

--- a/packages/content-addressable-storage/package.json
+++ b/packages/content-addressable-storage/package.json
@@ -48,8 +48,8 @@
         "@cere-ddc-sdk/core": "1.7.6-rc.1",
         "@cere-ddc-sdk/proto": "1.7.6-rc.1",
         "@cere-ddc-sdk/smart-contract": "1.7.6-rc.1",
-        "@polkadot/util": "~9.7.2",
-        "@polkadot/util-crypto": "~9.7.2",
+        "@polkadot/util": "^10.1.8",
+        "@polkadot/util-crypto": "^10.1.8",
         "nanoid": "3.3.3",
         "varint": "^6.0.0"
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,10 +44,9 @@
         "clean": "rimraf dist package"
     },
     "dependencies": {
-        "@polkadot/keyring": "~9.7.2",
-        "@polkadot/util": "~9.7.2",
-        "@polkadot/util-crypto": "~9.7.2",
-        "@polkadot/wasm-crypto": "~6.4.1"
+        "@polkadot/util": "^10.1.8",
+        "@polkadot/keyring": "^10.1.8",
+        "@polkadot/util-crypto": "^10.1.8"
     },
     "devDependencies": {
         "@multiformats/blake2": "^1.0.10",

--- a/packages/core/src/crypto/signature/PolkadotDappScheme.ts
+++ b/packages/core/src/crypto/signature/PolkadotDappScheme.ts
@@ -1,59 +1,50 @@
-import {
-  SignerPayloadRaw,
-  SignerResult,
-} from "@polkadot/types/types/extrinsic";
-import { SchemeInterface, SchemeName } from "./Scheme.interface";
-import { assertSafeMessage } from "./Scheme";
-import { hexToU8a, u8aToHex } from "@polkadot/util";
-import { InjectedAccount } from "@polkadot/extension-inject/types";
-import { waitReady } from "@polkadot/wasm-crypto";
-import { decodeAddress } from "@polkadot/util-crypto";
-import { web3Enable, web3FromAddress } from "@polkadot/extension-dapp";
+import {SignerPayloadRaw, SignerResult} from '@polkadot/types/types/extrinsic';
+import {SchemeInterface, SchemeName} from './Scheme.interface';
+import {assertSafeMessage} from './Scheme';
+import {hexToU8a, u8aToHex} from '@polkadot/util';
+import {InjectedAccount} from '@polkadot/extension-inject/types';
+import {cryptoWaitReady} from '@polkadot/util-crypto';
+import {decodeAddress} from '@polkadot/util-crypto';
+import {web3Enable, web3FromAddress} from '@polkadot/extension-dapp';
 
 /**
  * Browser only
  */
 export class PolkadotDappScheme implements SchemeInterface {
-  name: SchemeName = "sr25519";
+    name: SchemeName = 'sr25519';
 
-  private constructor(
-    public publicKey: Uint8Array,
-    public address: string,
-    public signRaw: (raw: SignerPayloadRaw) => Promise<SignerResult>
-  ) {}
+    private constructor(
+        public publicKey: Uint8Array,
+        public address: string,
+        public signRaw: (raw: SignerPayloadRaw) => Promise<SignerResult>,
+    ) {}
 
-  static async createScheme(
-    account: InjectedAccount
-  ): Promise<PolkadotDappScheme> {
-    await web3Enable('ddc');
-    await waitReady();
-    let injector = await web3FromAddress(account.address);
-    let signRaw = injector.signer.signRaw;
+    static async createScheme(account: InjectedAccount): Promise<PolkadotDappScheme> {
+        await web3Enable('ddc');
+        await cryptoWaitReady();
+        let injector = await web3FromAddress(account.address);
+        let signRaw = injector.signer.signRaw;
 
-    if (!signRaw) {
-      throw Error("Failed to initialize scheme");
+        if (!signRaw) {
+            throw Error('Failed to initialize scheme');
+        }
+
+        return new PolkadotDappScheme(decodeAddress(account.address), account.address, signRaw);
     }
 
-    return new PolkadotDappScheme(
-      decodeAddress(account.address),
-      account.address,
-      signRaw
-    );
-  }
+    get publicKeyHex(): string {
+        return u8aToHex(this.publicKey);
+    }
 
-  get publicKeyHex(): string {
-    return u8aToHex(this.publicKey);
-  }
+    async sign(data: Uint8Array): Promise<Uint8Array> {
+        assertSafeMessage(data);
 
-  async sign(data: Uint8Array): Promise<Uint8Array> {
-    assertSafeMessage(data);
+        const {signature} = await this.signRaw({
+            address: this.address,
+            data: u8aToHex(data),
+            type: 'bytes',
+        });
 
-    const { signature } = await this.signRaw({
-      address: this.address,
-      data: u8aToHex(data),
-      type: "bytes",
-    });
-
-    return hexToU8a(signature);
-  }
+        return hexToU8a(signature);
+    }
 }

--- a/packages/core/src/crypto/signature/Scheme.ts
+++ b/packages/core/src/crypto/signature/Scheme.ts
@@ -1,8 +1,8 @@
-import {Keyring} from "@polkadot/keyring";
-import {KeyringPair} from "@polkadot/keyring/types";
-import {u8aToHex} from "@polkadot/util";
-import {waitReady} from "@polkadot/wasm-crypto";
-import {SchemeInterface, SchemeName} from "./Scheme.interface";
+import {Keyring} from '@polkadot/keyring';
+import {KeyringPair} from '@polkadot/keyring/types';
+import {u8aToHex} from '@polkadot/util';
+import {cryptoWaitReady} from '@polkadot/util-crypto';
+import {SchemeInterface, SchemeName} from './Scheme.interface';
 
 export class Scheme implements SchemeInterface {
     private readonly keyringPair: KeyringPair;
@@ -16,18 +16,18 @@ export class Scheme implements SchemeInterface {
     }
 
     static async createScheme(schemeName: SchemeName, secretPhrase: string): Promise<Scheme> {
-        if (schemeName != "sr25519" && schemeName != "ed25519") {
+        if (schemeName != 'sr25519' && schemeName != 'ed25519') {
             throw new Error(`Unsupported scheme name='${schemeName}'`);
         }
 
-        await waitReady();
+        await cryptoWaitReady();
 
         const keyring = new Keyring({type: schemeName});
         let keyringPair;
         try {
             keyringPair = keyring.addFromMnemonic(secretPhrase);
         } catch (err) {
-            throw new Error(`Couldn't create scheme with current secretPhrase`)
+            throw new Error(`Couldn't create scheme with current secretPhrase`);
         }
         return new Scheme(keyringPair, schemeName);
     }
@@ -51,6 +51,6 @@ export function assertSafeMessage(data: Uint8Array) {
     // Encoded extrinsics start with the pallet index; reserve up to 48 pallets.
     // Make ASCII "0" the smallest first valid byte.
     if (data[0] < 48) {
-        throw new Error("data unsafe to sign")
+        throw new Error('data unsafe to sign');
     }
 }

--- a/packages/ddc-client/package.json
+++ b/packages/ddc-client/package.json
@@ -50,8 +50,8 @@
         "@cere-ddc-sdk/file-storage": "1.7.6-rc.1",
         "@cere-ddc-sdk/key-value-storage": "1.7.6-rc.1",
         "@cere-ddc-sdk/smart-contract": "1.7.6-rc.1",
-        "@polkadot/util": "~9.7.2",
-        "@polkadot/util-crypto": "~9.7.2"
+        "@polkadot/util": "^10.1.8",
+        "@polkadot/util-crypto": "^10.1.8"
     },
     "devDependencies": {
         "@polkadot/extension-inject": "0.44.6",

--- a/packages/smart-contract/package.json
+++ b/packages/smart-contract/package.json
@@ -44,8 +44,8 @@
         "clean": "rimraf dist package"
     },
     "devDependencies": {
-        "@polkadot/extension-dapp": "^0.44.1",
-        "@polkadot/extension-inject": "^0.44.1",
+        "@polkadot/extension-dapp": "^0.46.5",
+        "@polkadot/extension-inject": "^0.46.5",
         "@types/lodash": "^4.14.182",
         "@types/node": "^16.0.0",
         "clean-publish": "^4.0.1",
@@ -56,11 +56,10 @@
         "typescript": "4.5.4"
     },
     "dependencies": {
-        "@polkadot/api": "8.2.1",
-        "@polkadot/api-contract": "8.2.1",
-        "@polkadot/keyring": "~9.7.2",
-        "@polkadot/util-crypto": "~9.7.2",
-        "@polkadot/wasm-crypto": "~6.4.1",
-        "@polkadot/types": "~9.7.1"
+        "@polkadot/api": "9.4.1",
+        "@polkadot/api-contract": "9.4.1",
+        "@polkadot/keyring": "^10.1.8",
+        "@polkadot/util-crypto": "^10.1.8",
+        "@polkadot/types": "9.4.1"
     }
 }

--- a/packages/smart-contract/src/SmartContract.ts
+++ b/packages/smart-contract/src/SmartContract.ts
@@ -1,19 +1,18 @@
-import {BucketCreatedEvent} from "./event/BucketCreatedEvent";
-import {SmartContractOptions, TESTNET} from "./options/SmartContractOptions";
-import {ApiPromise, WsProvider} from "@polkadot/api";
-import {ContractPromise} from "@polkadot/api-contract";
+import {BucketCreatedEvent} from './event/BucketCreatedEvent';
+import {SmartContractOptions, TESTNET} from './options/SmartContractOptions';
+import {ApiPromise, WsProvider} from '@polkadot/api';
+import {ContractPromise} from '@polkadot/api-contract';
 import {Keyring} from '@polkadot/keyring';
-import {AddressOrPair, SubmittableExtrinsic, SubmittableResultSubscription} from "@polkadot/api/submittable/types";
-import {Callback, ISubmittableResult } from "@polkadot/types/types";
+import {AddressOrPair, SubmittableExtrinsic, SubmittableResultSubscription} from '@polkadot/api/submittable/types';
+import {Callback, ISubmittableResult} from '@polkadot/types/types';
 import {cryptoWaitReady, isAddress} from '@polkadot/util-crypto';
-import {find, get} from "lodash";
-import {NodeStatus} from "./model/NodeStatus";
-import {cereTypes} from "./types/cere_types";
-import {BucketStatus} from "./model/BucketStatus";
-import {BucketStatusList} from "./model/BucketStatusList";
-import {ApiTypes} from "@polkadot/api/types";
-import {BucketParams, initDefaultBucketParams} from "./options/BucketParams";
-import {waitReady} from "@polkadot/wasm-crypto";
+import {find, get} from 'lodash';
+import {NodeStatus} from './model/NodeStatus';
+import {cereTypes} from './types/cere_types';
+import {BucketStatus} from './model/BucketStatus';
+import {BucketStatusList} from './model/BucketStatusList';
+import {ApiTypes} from '@polkadot/api/types';
+import {BucketParams, initDefaultBucketParams} from './options/BucketParams';
 import {CdnClusterGetResult, CdnNodeGetResult, ClusterGetResult} from './types/smart-contract-responses';
 
 const CERE = 10_000_000_000n;
@@ -26,7 +25,7 @@ const txOptions = {
 const txOptionsPay = {
     value: 10n * CERE,
     gasLimit: -1, //100_000n * MGAS,
-}
+};
 
 export class SmartContract {
     readonly options: SmartContractOptions;
@@ -36,7 +35,10 @@ export class SmartContract {
 
     contract!: ContractPromise;
 
-    signAndSend: (tx: SubmittableExtrinsic<any>, statusCb: Callback<ISubmittableResult>) => SubmittableResultSubscription<ApiTypes>;
+    signAndSend: (
+        tx: SubmittableExtrinsic<any>,
+        statusCb: Callback<ISubmittableResult>,
+    ) => SubmittableResultSubscription<ApiTypes>;
 
     constructor(secretPhraseOrAddress: string, options: SmartContractOptions = TESTNET) {
         const keyring = new Keyring({type: 'sr25519'});
@@ -52,13 +54,16 @@ export class SmartContract {
         this.options = options;
     }
 
-    static async buildAndConnect(secretPhraseOrAddress: string, options: SmartContractOptions = TESTNET): Promise<SmartContract> {
-        await waitReady();
+    static async buildAndConnect(
+        secretPhraseOrAddress: string,
+        options: SmartContractOptions = TESTNET,
+    ): Promise<SmartContract> {
+        await cryptoWaitReady();
+
         return new SmartContract(secretPhraseOrAddress, options).connect();
     }
 
     async connect(): Promise<SmartContract> {
-        await cryptoWaitReady();
         const provider = new WsProvider(this.options.rpcUrl);
         this.api = await ApiPromise.create({provider, types: cereTypes});
         await this.api.isReady;
@@ -70,9 +75,18 @@ export class SmartContract {
         return await this.contract.api.disconnect();
     }
 
-    async bucketCreate(owner: string, clusterId: bigint, bucketParams: BucketParams = new BucketParams()): Promise<BucketCreatedEvent> {
+    async bucketCreate(
+        owner: string,
+        clusterId: bigint,
+        bucketParams: BucketParams = new BucketParams(),
+    ): Promise<BucketCreatedEvent> {
         const createBucketParams = initDefaultBucketParams(bucketParams);
-        const tx = await this.contract.tx.bucketCreate(txOptionsPay, JSON.stringify(createBucketParams), clusterId, owner);
+        const tx = await this.contract.tx.bucketCreate(
+            txOptionsPay,
+            JSON.stringify(createBucketParams),
+            clusterId,
+            owner,
+        );
         const result = await this.sendTx(tx);
         const events = (result as any).contractEvents || [];
         const bucketId = SmartContract.findCreatedBucketId(events);
@@ -90,8 +104,13 @@ export class SmartContract {
     }
 
     async bucketList(offset: bigint, limit: bigint, filterOwnerId?: string): Promise<BucketStatusList> {
-        const {result, output} =
-            await this.contract.query.bucketList(this.address, txOptions, offset, limit, filterOwnerId);
+        const {result, output} = await this.contract.query.bucketList(
+            this.address,
+            txOptions,
+            offset,
+            limit,
+            filterOwnerId,
+        );
         if (!result.isOk) throw result.asErr;
 
         const [statuses, length] = (output as any).toJSON();
@@ -127,7 +146,7 @@ export class SmartContract {
         const tx = await this.contract.tx.accountBond(txOptions, value * CERE);
         const result = await this.sendTx(tx);
         if (result.dispatchError) {
-            throw new Error("Unable to deposit account");
+            throw new Error('Unable to deposit account');
         }
     }
 
@@ -135,13 +154,13 @@ export class SmartContract {
         const tx = await this.contract.tx.accountDeposit({...txOptions, value: value * CERE});
         const result = await this.sendTx(tx);
         if (result.dispatchError) {
-            throw new Error("Unable to deposit account");
+            throw new Error('Unable to deposit account');
         }
     }
 
     async bucketAllocIntoCluster(bucketId: bigint, resource: bigint) {
         if (resource <= 0) {
-            throw new Error("Invalid bucket size")
+            throw new Error('Invalid bucket size');
         }
 
         const tx = await this.contract.tx.bucketAllocIntoCluster(txOptions, bucketId, resource);
@@ -167,10 +186,10 @@ export class SmartContract {
     }
 
     private static findCreatedBucketId(events: Array<any>): string {
-        const eventName = "BucketCreated";
+        const eventName = 'BucketCreated';
 
-        const event = find(events, ["event.identifier", eventName]);
-        const id = get(event, "args[0]");
+        const event = find(events, ['event.identifier', eventName]);
+        const id = get(event, 'args[0]');
         return id && id.toString();
     }
 }


### PR DESCRIPTION
- Updated all `@polkadot/*` packages to `v9.4.1`
- Updated related polkadot/common packages to appropriate version
- Removed excessive usage of `@polkadot/wasm-crypto` package