### PR TITLE
Smart Contract calls batch

### DIFF
--- a/packages/smart-contract/src/SmartContract.ts
+++ b/packages/smart-contract/src/SmartContract.ts
@@ -78,14 +78,6 @@ export class SmartContract extends SmartContractBase {
         }
     }
 
-    toUnits(tokens: bigint) {
-        const api = this.contract.api as ApiPromise;
-        const [decimals] = api.registry.chainDecimals;
-        const multiplier = 10n ** BigInt(decimals);
-
-        return tokens * multiplier;
-    }
-
     async accountGet(accountAddress: AccountId) {
         const account = await this.queryOne<Account>(this.contract.query.accountGet, accountAddress);
 

--- a/packages/smart-contract/src/SmartContract.ts
+++ b/packages/smart-contract/src/SmartContract.ts
@@ -132,7 +132,7 @@ export class SmartContract extends SmartContractBase {
 
         const params = JSON.stringify(bucketParams);
         const {contractEvents} = await this.submit(this.contract.tx.bucketCreate, params, clusterId, ownerAddress);
-        const {bucketId} = this.getContractEventArgs(contractEvents, 'BucketCreated');
+        const {bucketId} = this.pullContractEventArgs(contractEvents, 'BucketCreated');
 
         return BigInt(bucketId);
     }
@@ -168,7 +168,7 @@ export class SmartContract extends SmartContractBase {
             rentPerMonth,
         );
 
-        return this.getContractEventArgs(contractEvents, 'NodeCreated').nodeKey;
+        return this.pullContractEventArgs(contractEvents, 'NodeCreated').nodeKey;
     }
 
     async nodeRemove(nodeKey: NodeKey) {
@@ -180,7 +180,7 @@ export class SmartContract extends SmartContractBase {
 
         const {contractEvents} = await this.submit(this.contract.tx.cdnNodeCreate, cdnNodeKey, params);
 
-        return this.getContractEventArgs(contractEvents, 'CdnNodeCreated').cdnNodeKey;
+        return this.pullContractEventArgs(contractEvents, 'CdnNodeCreated').cdnNodeKey;
     }
 
     async cdnNodeRemove(nodeKey: NodeKey) {
@@ -192,7 +192,7 @@ export class SmartContract extends SmartContractBase {
 
         const {contractEvents} = await this.submit(this.contract.tx.clusterCreate, params, resourcePerVNode);
 
-        return this.getContractEventArgs(contractEvents, 'ClusterCreated').clusterId;
+        return this.pullContractEventArgs(contractEvents, 'ClusterCreated').clusterId;
     }
 
     async clusterAddNode(clusterId: ClusterId, nodeKey: NodeKey, vNodes: VNodeId[]) {

--- a/packages/smart-contract/src/SmartContractBase.ts
+++ b/packages/smart-contract/src/SmartContractBase.ts
@@ -7,9 +7,10 @@ import {ContractEvent, ContractEventArgs, Offset, toJs} from './types';
 import {Bytes} from '@polkadot/types';
 import {ApiPromise} from '@polkadot/api';
 
+const MGAS = 1_000_000n;
 const defaultOptions: ContractOptions = {
-    gasLimit: 10_000_000_000,
     storageDepositLimit: null,
+    gasLimit: 200_000n * MGAS,
 };
 
 const dryRunOptions: ContractOptions = {
@@ -65,11 +66,12 @@ export class SmartContractBase {
         this.address = isKeyringPair(this.account) ? this.account.address : this.account.toString();
     }
 
-    protected estimateGasLimit() {
+    toUnits(tokens: bigint) {
         const api = this.contract.api as ApiPromise;
-        const {maxBlock} = api.consts.system.blockWeights.toJSON() as any;
+        const [decimals] = api.registry.chainDecimals;
+        const multiplier = 10n ** BigInt(decimals);
 
-        return Number(maxBlock);
+        return tokens * multiplier;
     }
 
     protected async query<T extends unknown>(query: ContractQuery<'promise'>, ...params: unknown[]) {

--- a/packages/smart-contract/src/SmartContractBase.ts
+++ b/packages/smart-contract/src/SmartContractBase.ts
@@ -1,17 +1,20 @@
 import {ContractPromise} from '@polkadot/api-contract';
 import {isKeyringPair} from '@polkadot/api/util';
-import {SubmittableResultValue, Signer, AddressOrPair} from '@polkadot/api/types';
+import {SubmittableResultValue, Signer, AddressOrPair, SubmittableExtrinsic} from '@polkadot/api/types';
 import {ContractQuery, ContractTx} from '@polkadot/api-contract/base/types';
 import {DecodedEvent, ContractOptions} from '@polkadot/api-contract/types';
 import {ContractEvent, ContractEventArgs, Offset, toJs} from './types';
+import {Bytes} from '@polkadot/types';
+import {ApiPromise} from '@polkadot/api';
 
 const defaultOptions: ContractOptions = {
-    gasLimit: -1,
+    storageDepositLimit: null,
 };
 
 const dryRunOptions: ContractOptions = {
     ...defaultOptions,
 
+    gasLimit: -1,
     storageDepositLimit: null,
 };
 
@@ -49,6 +52,9 @@ const drainList = async <T extends unknown>(
 };
 
 export class SmartContractBase {
+    private currentBatch?: SubmittableExtrinsic<'promise'>[];
+    private currentBatchPromise?: Promise<Required<SubmitResult>>;
+
     protected readonly address: string;
 
     constructor(
@@ -57,6 +63,13 @@ export class SmartContractBase {
         protected readonly signer?: Signer,
     ) {
         this.address = isKeyringPair(this.account) ? this.account.address : this.account.toString();
+    }
+
+    protected get gasLimit() {
+        const api = this.contract.api as ApiPromise;
+        const {maxBlock} = api.consts.system.blockWeights.toJSON() as any;
+
+        return Number(maxBlock);
     }
 
     protected async query<T extends unknown>(query: ContractQuery<'promise'>, ...params: unknown[]) {
@@ -85,13 +98,50 @@ export class SmartContractBase {
     }
 
     protected async submitWithOptions(tx: ContractTx<'promise'>, options: ContractOptions, ...params: unknown[]) {
-        const extrinsic = tx({...defaultOptions, ...options}, ...params);
+        const batchPromise = this.currentBatchPromise;
+        const batch = this.currentBatch;
 
+        // const {weight} = await tx(dryRunOptions, ...params).paymentInfo(this.account);
+        const extrinsic = tx({gasLimit: 100_000_000_000, ...options}, ...params);
+
+        if (batch && batchPromise) {
+            batch.push(extrinsic);
+
+            return batchPromise;
+        }
+
+        return this.signAndSend(extrinsic);
+    }
+
+    protected submit(tx: ContractTx<'promise'>, ...params: unknown[]) {
+        return this.submitWithOptions(tx, defaultOptions, ...params);
+    }
+
+    protected getContractEventArgs<T extends ContractEvent>(contractEvents: DecodedEvent[], eventName: T) {
+        const result = contractEvents.find(({event}) => event.identifier === eventName);
+
+        if (!result) {
+            throw new Error(`Event ${eventName} has not been emited`);
+        }
+
+        const args: ContractEventArgs<T> = result.event.args.reduce<any>(
+            (args, {name}, index) => ({...args, [name]: toJs(result.args[index])}),
+            {},
+        );
+
+        return args;
+    }
+
+    protected async signAndSend(extrinsic: SubmittableExtrinsic<'promise'>) {
         return new Promise<Required<SubmitResult>>((resolve, reject) =>
             extrinsic
-                .signAndSend(this.account, {signer: this.signer}, (result) => {
-                    const {status, dispatchError} = result;
-                    const {events = [], contractEvents = []} = result as SubmitResult;
+                .signAndSend(this.account, {signer: this.signer, nonce: -1}, (result) => {
+                    const {status, dispatchError, events = []} = result;
+                    const contractEvents = result.filterRecords('contracts', 'ContractEmitted').map((record) => {
+                        const [, data] = record.event.data;
+
+                        return this.contract.abi.decodeEvent(data as Bytes);
+                    });
 
                     if (status.isFinalized) {
                         return resolve({events, contractEvents});
@@ -115,22 +165,28 @@ export class SmartContractBase {
         );
     }
 
-    protected submit(tx: ContractTx<'promise'>, ...params: unknown[]) {
-        return this.submitWithOptions(tx, dryRunOptions, ...params);
-    }
+    async batch<T extends readonly Promise<any>[]>(builder: () => T | void) {
+        let resolveBatch!: (params: any) => any;
+        let rejectBatch!: (params: any) => any;
 
-    protected getContractEventArgs<T extends ContractEvent>(contractEvents: DecodedEvent[], eventName: T) {
-        const result = contractEvents.find(({event}) => event.identifier === eventName);
+        this.currentBatch = [];
+        this.currentBatchPromise = new Promise((resolve, reject) => {
+            resolveBatch = resolve;
+            rejectBatch = reject;
+        });
 
-        if (!result) {
-            throw new Error(`Event ${eventName} has not been emited`);
-        }
+        const batchPromise = this.currentBatchPromise;
+        const promises = builder() || ([] as any);
 
-        const args: ContractEventArgs<T> = result.event.args.reduce<any>(
-            (args, {name}, index) => ({...args, [name]: toJs(result.args[index])}),
-            {},
-        );
+        this.signAndSend(this.contract.api.tx.utility.batch([...this.currentBatch]))
+            .then(resolveBatch)
+            .catch(rejectBatch);
 
-        return args;
+        this.currentBatchPromise = undefined;
+        this.currentBatch = undefined;
+
+        await batchPromise;
+
+        return Promise.all(promises);
     }
 }

--- a/tests/SmartContract.spec.ts
+++ b/tests/SmartContract.spec.ts
@@ -349,6 +349,9 @@ describe('Smart Contract', () => {
 
         test('create CDN and Storage node', async () => {
             [storageNodeKey, cdnNodeKey] = await adminContract.batch(() => [createStorageNode(), createCdnNode()]);
+
+            expect(storageNodeKey).toEqual(expect.any(String));
+            expect(cdnNodeKey).toEqual(expect.any(String));
         });
 
         test('set CDN and storage nodes status', async () => {
@@ -356,6 +359,12 @@ describe('Smart Contract', () => {
                 adminContract.clusterSetNodeStatus(clusterId, storageNodeKey, NodeStatusInCluster.ACTIVE),
                 adminContract.clusterSetCdnNodeStatus(clusterId, cdnNodeKey, NodeStatusInCluster.ACTIVE),
             ]);
+
+            const {node} = await adminContract.nodeGet(storageNodeKey);
+            const {cdnNode} = await adminContract.cdnNodeGet(cdnNodeKey);
+
+            expect(node.statusInCluster).toEqual(NodeStatusInCluster.ACTIVE);
+            expect(cdnNode.statusInCluster).toEqual(NodeStatusInCluster.ACTIVE);
         });
 
         test('Remove nodes', async () => {

--- a/tests/SmartContract.spec.ts
+++ b/tests/SmartContract.spec.ts
@@ -333,4 +333,38 @@ describe('Smart Contract', () => {
             await expect(promise).rejects.toThrowError('Inability to pay some fees');
         });
     });
+
+    describe('Batch transactions', () => {
+        let clusterId: number;
+        let storageNodeKey: string;
+        let cdnNodeKey: string;
+
+        beforeAll(async () => {
+            clusterId = await adminContract.clusterCreate();
+        });
+
+        afterAll(async () => {
+            await adminContract.clusterRemove(clusterId);
+        });
+
+        test('create CDN and Storage node', async () => {
+            [storageNodeKey, cdnNodeKey] = await adminContract.batch(() => [createStorageNode(), createCdnNode()]);
+        });
+
+        test('set CDN and storage nodes status', async () => {
+            await adminContract.batch(() => [
+                adminContract.clusterSetNodeStatus(clusterId, storageNodeKey, NodeStatusInCluster.ACTIVE),
+                adminContract.clusterSetCdnNodeStatus(clusterId, cdnNodeKey, NodeStatusInCluster.ACTIVE),
+            ]);
+        });
+
+        test('Remove nodes', async () => {
+            await adminContract.batch(() => [
+                adminContract.clusterRemoveNode(clusterId, storageNodeKey),
+                adminContract.clusterRemoveCdnNode(clusterId, cdnNodeKey),
+                adminContract.nodeRemove(storageNodeKey),
+                adminContract.cdnNodeRemove(cdnNodeKey),
+            ]);
+        });
+    });
 });


### PR DESCRIPTION
Added `batch` method which allows to batch smart contract calls into a single transaction.
The method accepts a single parameter - `builder`. It is a synchronous function in which all SC calls will be batched.

```ts
await contract.batch(() => {
    contract.clusterSetNodeStatus(clusterId, storageNodeKey, NodeStatusInCluster.ACTIVE),
    contract.clusterSetCdnNodeStatus(clusterId, cdnNodeKey, NodeStatusInCluster.ACTIVE),
});
```

The limitation is that only the calls which were called during the builder synchronise execution will be added to the batch.

The builder can optionally return an array of promises, which will be resolved with `Promise.all` under the hood:

```ts
const [nodeKey, cdnNodeKey] = await contract.batch(() => [
    contract.nodeCreate(...),
    contract.cdnNodeCreate(...)
]);
```