### PR TITLE
Read found pieces content on client side

### DIFF
--- a/packages/content-addressable-storage/src/ContentAddressableStorage.ts
+++ b/packages/content-addressable-storage/src/ContentAddressableStorage.ts
@@ -379,9 +379,9 @@ export class ContentAddressableStorage {
         }
 
         const {searchedPieces} = PbSearchResult.fromBinary(protoResponse.body);
-        const piecePromises = searchedPieces.map(({cid}) =>
+        const piecePromises = searchedPieces.map(({cid, signedPiece}) =>
             skipData
-                ? this.toPiece(PbPiece.fromBinary(new Uint8Array()), cid) // Create piece with empty content
+                ? this.toPiece(PbPiece.fromBinary(signedPiece?.piece || new Uint8Array([])), cid)
                 : this.read(query.bucketId, cid),
         );
 

--- a/packages/content-addressable-storage/src/ContentAddressableStorage.ts
+++ b/packages/content-addressable-storage/src/ContentAddressableStorage.ts
@@ -337,15 +337,15 @@ export class ContentAddressableStorage {
     async search(query: Query, options: SearchOptions = {}): Promise<SearchResult> {
         const route = await this.router.getSearchRoute(query.bucketId);
         const session = this.useSession(options.session || route.searchSessionId);
-
+        const skipData = query.skipData;
         const cdnNodeUrl = route.searchNodeUrl;
 
         const pbQuery: PbQuery = {
             bucketId: Number(query.bucketId),
             tags: query.tags,
-            skipData: query.skipData,
+            skipData: true, // Always skip data - will be loaded with regular reads
         };
-        // @ts-ignore
+
         const queryAsBytes = PbQuery.toBinary(pbQuery);
         const queryBase58 = base58Encode(queryAsBytes);
 
@@ -378,41 +378,14 @@ export class ContentAddressableStorage {
             );
         }
 
-        const pbSearchResult = await new Promise<PbSearchResult>((resolve) => {
-            try {
-                // @ts-ignore
-                resolve(PbSearchResult.fromBinary(protoResponse.body));
-            } catch (e) {
-                throw new Error(
-                    `Can't parse search response body to SearchResult.\n${u8aToString(protoResponse.body)}`,
-                );
-            }
-        });
-
-        const pieces = pbSearchResult.searchedPieces
-            .filter((p) => !!p.signedPiece)
-            .map(({signedPiece, cid}) => this.toPiece(PbPiece.fromBinary(signedPiece!.piece), cid));
-
-        await Promise.all(
-            pieces.map(async (piece) => {
-                /**
-                 * Send collection point ack if possible
-                 */
-                await this.collectionPoint?.acknowledgePiece(piece, route, {
-                    bucketId: query.bucketId,
-                });
-
-                await this.ack({
-                    piece,
-                    session,
-                    response,
-                    nodeUrl: cdnNodeUrl,
-                    payload: protoResponse,
-                });
-            }),
+        const {searchedPieces} = PbSearchResult.fromBinary(protoResponse.body);
+        const piecePromises = searchedPieces.map(({cid}) =>
+            skipData
+                ? this.toPiece(PbPiece.fromBinary(new Uint8Array()), cid) // Create piece with empty content
+                : this.read(query.bucketId, cid),
         );
 
-        return new SearchResult(pieces);
+        return new SearchResult(await Promise.all(piecePromises));
     }
 
     async storeEncrypted(

--- a/packages/content-addressable-storage/src/collectionPoint/CollectionPoint.ts
+++ b/packages/content-addressable-storage/src/collectionPoint/CollectionPoint.ts
@@ -95,32 +95,15 @@ export class CollectionPoint {
             throw new Error('Cannot calculate processed bytes length');
         }
 
-        const isSearchResult = route.operation === RouteOperation.SEARCH;
-
-        /**
-         * Use search worker address in case of search result
-         */
-        const workerAddress = isSearchResult ? route.searchWorkerAddress : route.getWorkerAddress(cid);
-
-        /**
-         * Use search seassionId in case of search result
-         */
-        const sessionId = isSearchResult ? route.searchSessionId : route.getSessionId(cid);
-
-        /**
-         * Search result pieces are separate jobs so always last
-         */
-        const isLast = isSearchResult || route.isLastPiece(cid);
-
         const signedAck = await this.signAck({
             cid,
             bytesProcessed,
-            workerAddress,
-            sessionId,
+            workerAddress: route.getWorkerAddress(cid),
+            sessionId: route.getSessionId(cid),
             timestamp: Date.now(),
             opCode: route.operation,
             requestId: route.requestId,
-            ackCode: isLast ? AckCode.FINAL : AckCode.NEXT,
+            ackCode: route.isLastPiece(cid) ? AckCode.FINAL : AckCode.NEXT,
         });
 
         return this.request('acknowledgment', signedAck);


### PR DESCRIPTION
Instead of requesting search result with content we always use `skipData` option and read found pieces data using `read` method