### PR TITLE
Calculate bytes of full read and store request body

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.9.0-rc.8",
+    "version": "1.9.0-rc.9",
     "command": {
         "publish": {
             "directory": "{workspaceRoot}/{projectRoot}/package"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17194,12 +17194,12 @@
         },
         "packages/content-addressable-storage": {
             "name": "@cere-ddc-sdk/content-addressable-storage",
-            "version": "1.9.0-rc.8",
+            "version": "1.9.0-rc.9",
             "license": "Apache-2.0",
             "dependencies": {
-                "@cere-ddc-sdk/core": "1.9.0-rc.8",
-                "@cere-ddc-sdk/proto": "1.9.0-rc.8",
-                "@cere-ddc-sdk/smart-contract": "1.9.0-rc.8",
+                "@cere-ddc-sdk/core": "1.9.0-rc.9",
+                "@cere-ddc-sdk/proto": "1.9.0-rc.9",
+                "@cere-ddc-sdk/smart-contract": "1.9.0-rc.9",
                 "@polkadot/util": "^10.1.8",
                 "@polkadot/util-crypto": "^10.1.8",
                 "uuid": "^9.0.1",
@@ -17227,7 +17227,7 @@
         },
         "packages/core": {
             "name": "@cere-ddc-sdk/core",
-            "version": "1.9.0-rc.8",
+            "version": "1.9.0-rc.9",
             "license": "Apache-2.0",
             "dependencies": {
                 "@polkadot/keyring": "^10.1.8",
@@ -17245,14 +17245,14 @@
         },
         "packages/ddc-client": {
             "name": "@cere-ddc-sdk/ddc-client",
-            "version": "1.9.0-rc.8",
+            "version": "1.9.0-rc.9",
             "license": "Apache-2.0",
             "dependencies": {
-                "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.8",
-                "@cere-ddc-sdk/core": "1.9.0-rc.8",
-                "@cere-ddc-sdk/file-storage": "1.9.0-rc.8",
-                "@cere-ddc-sdk/key-value-storage": "1.9.0-rc.8",
-                "@cere-ddc-sdk/smart-contract": "1.9.0-rc.8",
+                "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.9",
+                "@cere-ddc-sdk/core": "1.9.0-rc.9",
+                "@cere-ddc-sdk/file-storage": "1.9.0-rc.9",
+                "@cere-ddc-sdk/key-value-storage": "1.9.0-rc.9",
+                "@cere-ddc-sdk/smart-contract": "1.9.0-rc.9",
                 "@polkadot/util": "^10.1.8",
                 "@polkadot/util-crypto": "^10.1.8"
             },
@@ -17266,10 +17266,10 @@
         },
         "packages/file-storage": {
             "name": "@cere-ddc-sdk/file-storage",
-            "version": "1.9.0-rc.8",
+            "version": "1.9.0-rc.9",
             "license": "Apache-2.0",
             "dependencies": {
-                "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.8"
+                "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.9"
             },
             "devDependencies": {
                 "@types/node": "^16.0.0",
@@ -17278,10 +17278,10 @@
         },
         "packages/key-value-storage": {
             "name": "@cere-ddc-sdk/key-value-storage",
-            "version": "1.9.0-rc.8",
+            "version": "1.9.0-rc.9",
             "license": "Apache-2.0",
             "dependencies": {
-                "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.8"
+                "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.9"
             },
             "devDependencies": {
                 "@types/node": "^16.0.0",
@@ -17290,7 +17290,7 @@
         },
         "packages/proto": {
             "name": "@cere-ddc-sdk/proto",
-            "version": "1.9.0-rc.8",
+            "version": "1.9.0-rc.9",
             "license": "Apache-2.0",
             "dependencies": {
                 "@protobuf-ts/runtime": "^2.2.2"
@@ -17302,7 +17302,7 @@
         },
         "packages/smart-contract": {
             "name": "@cere-ddc-sdk/smart-contract",
-            "version": "1.9.0-rc.8",
+            "version": "1.9.0-rc.9",
             "license": "Apache-2.0",
             "dependencies": {
                 "@polkadot/api": "9.4.1",
@@ -18347,9 +18347,9 @@
         "@cere-ddc-sdk/content-addressable-storage": {
             "version": "file:packages/content-addressable-storage",
             "requires": {
-                "@cere-ddc-sdk/core": "1.9.0-rc.8",
-                "@cere-ddc-sdk/proto": "1.9.0-rc.8",
-                "@cere-ddc-sdk/smart-contract": "1.9.0-rc.8",
+                "@cere-ddc-sdk/core": "1.9.0-rc.9",
+                "@cere-ddc-sdk/proto": "1.9.0-rc.9",
+                "@cere-ddc-sdk/smart-contract": "1.9.0-rc.9",
                 "@polkadot/util": "^10.1.8",
                 "@polkadot/util-crypto": "^10.1.8",
                 "@types/node": "^16.0.0",
@@ -18385,11 +18385,11 @@
         "@cere-ddc-sdk/ddc-client": {
             "version": "file:packages/ddc-client",
             "requires": {
-                "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.8",
-                "@cere-ddc-sdk/core": "1.9.0-rc.8",
-                "@cere-ddc-sdk/file-storage": "1.9.0-rc.8",
-                "@cere-ddc-sdk/key-value-storage": "1.9.0-rc.8",
-                "@cere-ddc-sdk/smart-contract": "1.9.0-rc.8",
+                "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.9",
+                "@cere-ddc-sdk/core": "1.9.0-rc.9",
+                "@cere-ddc-sdk/file-storage": "1.9.0-rc.9",
+                "@cere-ddc-sdk/key-value-storage": "1.9.0-rc.9",
+                "@cere-ddc-sdk/smart-contract": "1.9.0-rc.9",
                 "@polkadot/extension-inject": "0.44.9",
                 "@polkadot/util": "^10.1.8",
                 "@polkadot/util-crypto": "^10.1.8",
@@ -18402,7 +18402,7 @@
         "@cere-ddc-sdk/file-storage": {
             "version": "file:packages/file-storage",
             "requires": {
-                "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.8",
+                "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.9",
                 "@types/node": "^16.0.0",
                 "rimraf": "^3.0.2"
             }
@@ -18410,7 +18410,7 @@
         "@cere-ddc-sdk/key-value-storage": {
             "version": "file:packages/key-value-storage",
             "requires": {
-                "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.8",
+                "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.9",
                 "@types/node": "^16.0.0",
                 "rimraf": "^3.0.2"
             }

--- a/packages/content-addressable-storage/package.json
+++ b/packages/content-addressable-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@cere-ddc-sdk/content-addressable-storage",
     "description": "Content-addressable storage client",
-    "version": "1.9.0-rc.8",
+    "version": "1.9.0-rc.9",
     "type": "module",
     "repository": {
         "type": "git",
@@ -44,9 +44,9 @@
         "clean": "rimraf dist package"
     },
     "dependencies": {
-        "@cere-ddc-sdk/core": "1.9.0-rc.8",
-        "@cere-ddc-sdk/proto": "1.9.0-rc.8",
-        "@cere-ddc-sdk/smart-contract": "1.9.0-rc.8",
+        "@cere-ddc-sdk/core": "1.9.0-rc.9",
+        "@cere-ddc-sdk/proto": "1.9.0-rc.9",
+        "@cere-ddc-sdk/smart-contract": "1.9.0-rc.9",
         "@polkadot/util": "^10.1.8",
         "@polkadot/util-crypto": "^10.1.8",
         "uuid": "^9.0.1",

--- a/packages/content-addressable-storage/src/collectionPoint/CollectionPoint.ts
+++ b/packages/content-addressable-storage/src/collectionPoint/CollectionPoint.ts
@@ -87,9 +87,9 @@ export class CollectionPoint {
         }
 
         const bytesProcessed =
-            options.bucketId === undefined
-                ? options.bytesProcessed
-                : PbPiece.toBinary(piece.toProto(options.bucketId)).byteLength;
+            !options.bytesProcessed && options.bucketId !== undefined
+                ? PbPiece.toBinary(piece.toProto(options.bucketId)).byteLength
+                : options.bytesProcessed;
 
         if (!bytesProcessed) {
             throw new Error('Cannot calculate processed bytes length');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@cere-ddc-sdk/core",
     "description": "Core with common logic",
-    "version": "1.9.0-rc.8",
+    "version": "1.9.0-rc.9",
     "type": "module",
     "repository": {
         "type": "git",

--- a/packages/ddc-client/package.json
+++ b/packages/ddc-client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@cere-ddc-sdk/ddc-client",
     "description": "DDC client",
-    "version": "1.9.0-rc.8",
+    "version": "1.9.0-rc.9",
     "type": "module",
     "repository": {
         "type": "git",
@@ -44,11 +44,11 @@
         "clean": "rimraf dist package"
     },
     "dependencies": {
-        "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.8",
-        "@cere-ddc-sdk/core": "1.9.0-rc.8",
-        "@cere-ddc-sdk/file-storage": "1.9.0-rc.8",
-        "@cere-ddc-sdk/key-value-storage": "1.9.0-rc.8",
-        "@cere-ddc-sdk/smart-contract": "1.9.0-rc.8",
+        "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.9",
+        "@cere-ddc-sdk/core": "1.9.0-rc.9",
+        "@cere-ddc-sdk/file-storage": "1.9.0-rc.9",
+        "@cere-ddc-sdk/key-value-storage": "1.9.0-rc.9",
+        "@cere-ddc-sdk/smart-contract": "1.9.0-rc.9",
         "@polkadot/util": "^10.1.8",
         "@polkadot/util-crypto": "^10.1.8"
     },

--- a/packages/file-storage/package.json
+++ b/packages/file-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@cere-ddc-sdk/file-storage",
     "description": "File storage client",
-    "version": "1.9.0-rc.8",
+    "version": "1.9.0-rc.9",
     "type": "module",
     "repository": {
         "type": "git",
@@ -43,7 +43,7 @@
         "clean": "rimraf dist package"
     },
     "dependencies": {
-        "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.8"
+        "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.9"
     },
     "devDependencies": {
         "@types/node": "^16.0.0",

--- a/packages/key-value-storage/package.json
+++ b/packages/key-value-storage/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@cere-ddc-sdk/key-value-storage",
     "description": "Key-value storage client",
-    "version": "1.9.0-rc.8",
+    "version": "1.9.0-rc.9",
     "type": "module",
     "repository": {
         "type": "git",
@@ -31,7 +31,7 @@
         "clean": "rimraf dist package"
     },
     "dependencies": {
-        "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.8"
+        "@cere-ddc-sdk/content-addressable-storage": "1.9.0-rc.9"
     },
     "devDependencies": {
         "@types/node": "^16.0.0",

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@cere-ddc-sdk/proto",
     "description": "Storage protocol buffer models",
-    "version": "1.9.0-rc.8",
+    "version": "1.9.0-rc.9",
     "type": "module",
     "main": "./dist/index.cjs",
     "types": "./dist/types",

--- a/packages/smart-contract/package.json
+++ b/packages/smart-contract/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@cere-ddc-sdk/smart-contract",
     "description": "Smart contract client",
-    "version": "1.9.0-rc.8",
+    "version": "1.9.0-rc.9",
     "type": "module",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Calculate `bytesProcessed`  using the following rules:
- Read request: response body length
- Store request: request body length

Previously only piece data size was used for both cases