### PR TITLE
Smart Contract hasPermission method fix

### DIFF
--- a/packages/smart-contract/src/SmartContract.ts
+++ b/packages/smart-contract/src/SmartContract.ts
@@ -318,7 +318,6 @@ export class SmartContract extends SmartContractBase {
     }
 
     async hasPermission(accountId: AccountId, permission: Permission) {
-        const result = await this.submit(this.contract.tx.hasPermission, accountId, permission);
-        return Boolean(result);
+        return this.query(this.contract.query.hasPermission, accountId, permission);
     }
 }

--- a/packages/smart-contract/src/types/contractTypes.ts
+++ b/packages/smart-contract/src/types/contractTypes.ts
@@ -31,12 +31,13 @@ export enum NodeStatusInCluster {
     OFFLINE = 'OFFLINE',
 }
 
-export enum Permission {
-    CLUSTER_MANAGER_TRUSTED_BY = 'ClusterManagerTrustedBy',
-    SET_EXCHANGE_RATE = 'SetExchangeRate',
-    SUPER_ADMIN = 'SuperAdmin',
-    VALIDATOR = 'Validator',
-}
+export type Permission =
+    | 'SetExchangeRate'
+    | 'SuperAdmin'
+    | 'Validator'
+    | {
+          ClusterManagerTrustedBy: AccountId;
+      };
 
 export type BucketParams = {
     replication: number;

--- a/tests/SmartContract.spec.ts
+++ b/tests/SmartContract.spec.ts
@@ -64,12 +64,18 @@ describe('Smart Contract', () => {
         });
 
         test('has trusted manager permission', async () => {
+            const hasPermission = await adminContract.hasPermission(user.address, {
+                ClusterManagerTrustedBy: admin.address,
+            });
+
+            expect(hasPermission).toBe(false);
+
             await adminContract.grantTrustedManagerPermission(user.address);
-            const hasCMPermission = await adminContract.hasPermission(
-                user.address,
-                Permission.CLUSTER_MANAGER_TRUSTED_BY,
-            );
-            expect(hasCMPermission).toEqual(true);
+            const nextHasPermission = await adminContract.hasPermission(user.address, {
+                ClusterManagerTrustedBy: admin.address,
+            });
+
+            expect(nextHasPermission).toEqual(true);
         });
 
         test('create storage node', async () => {


### PR DESCRIPTION
Change permission type from `enum` to `union` to emulate `Rust` enum.