### PR TITLE
Support latest storage node API types changes

### DIFF
--- a/packages/ddc/protos/cns_api.proto
+++ b/packages/ddc/protos/cns_api.proto
@@ -9,32 +9,47 @@ import "google/api/annotations.proto";
 service CnsApi {
   rpc Put(PutRequest) returns (PutResponse) {
     option (google.api.http) = {
-      post: "/v1/cns/{BucketId}"
+      post: "/v1/cns/{bucketId}"
       body: "*"
     };
   }
 
   rpc Get(GetRequest) returns (GetResponse) {
     option (google.api.http) = {
-      get: "/v1/cns/{BucketId}/{Name}"
+      get: "/v1/cns/{bucketId}/{name}"
     };
   }
 }
 
 message PutRequest {
-  uint32 BucketId = 1;
-  string Name = 2;
-  string Cid = 3;
+  uint64 bucketId = 1;
+  Record record = 2;
 }
 
 message PutResponse {}
 
 message GetRequest {
-  // either bucketId or bucketName should be provided
-  uint32 BucketId = 1;
-  string Name = 3;
+  uint64 bucketId = 1;
+  string name = 2;
 }
 
 message GetResponse {
-  string Cid = 1;
+  Record record = 1;
+}
+
+message Record {
+  Signature signature = 1; // signature of a CnsRecord serialised to protobuf (excluding Signature itself) by a client that have an access to a bucket so requester can verify the validity of the CNS record
+  bytes cid = 2;
+  string name = 3;
+
+  message Signature {
+    Algorithm algorithm = 1;
+    bytes signer = 2;
+    bytes value = 3;
+
+    enum Algorithm {
+      ED_25519 = 0;
+      SR_25519 = 1;
+    }
+  }
 }

--- a/packages/ddc/protos/dag_api.proto
+++ b/packages/ddc/protos/dag_api.proto
@@ -25,18 +25,17 @@ service DagApi {
 }
 
 message PutRequest {
-  uint32 BucketId = 1;
+  uint64 BucketId = 1;
   Node Node = 2;
 }
 
 message PutResponse {
-  string Cid = 1;
+  bytes Cid = 1;
 }
 
 message GetRequest {
-  uint32 BucketId = 1;
-  string Cid = 2;
-
+  uint64 BucketId = 1;
+  bytes Cid = 2;
   optional string Path = 3;
 }
 
@@ -52,7 +51,7 @@ message Node {
 
 message Link {
   // CID of the target object
-  string Cid = 1;
+  bytes Cid = 1;
   // UTF-8 string name
   string Name = 2;
   // cumulative size of target object

--- a/packages/ddc/protos/file_api.proto
+++ b/packages/ddc/protos/file_api.proto
@@ -12,8 +12,8 @@ service FileApi {
 
 message PutRawPieceRequest {
   message Metadata {
-    optional bytes cid = 1;
-    string bucketId = 2;
+    uint64 bucketId = 1;
+    optional bytes cid = 2;
     optional uint64 offset = 3; // starting offset of the piece inside a file. Should be set only if isMultipart = true
     bool isMultipart = 4; // whether the piece is part of a file or not
   }
@@ -34,8 +34,8 @@ message PutRawPieceResponse {
 }
 
 message PutMultiPartPieceRequest {
-  optional bytes cid = 1; // root hash of the file hash tree
-  string bucketId = 2; // bucket where file is stored
+  uint64 bucketId = 1; // bucket where file is stored
+  optional bytes cid = 2; // root hash of the file hash tree
   uint64 totalSize = 3; // size of the multi-part piece (large file total size)
   uint64 partSize = 4; // size of the raw piece (large file part size)
   repeated bytes partHashes = 5; // ordered list of the raw piece hashes
@@ -47,8 +47,8 @@ message PutMultiPartPieceResponse {
 }
 
 message GetFileRequest {
-  bytes cid = 1; // CID of either raw or multi-part piece
-  string bucketId = 2;
+  uint64 bucketId = 1;
+  bytes cid = 2; // CID of either raw or multi-part piece
   optional Range range = 3; // indicates part of the file to be returned (return whole file if range is missing)
 
   message Range {

--- a/packages/ddc/src/CnsApi/CnsApi.ts
+++ b/packages/ddc/src/CnsApi/CnsApi.ts
@@ -17,6 +17,6 @@ export class CnsApi {
     async getCid(request: GetRequest) {
         const {response} = await this.api.get(request);
 
-        return response.cid;
+        return response.record;
     }
 }

--- a/packages/ddc/src/DagNode.ts
+++ b/packages/ddc/src/DagNode.ts
@@ -1,7 +1,7 @@
 import * as dag from './DagApi';
 import {Cid} from './Cid';
 
-export class Link implements dag.Link {
+export class Link implements Omit<dag.Link, 'cid'> {
     constructor(public cid: string, public size: number, public name = '') {}
 }
 
@@ -9,7 +9,7 @@ export class Tag implements dag.Tag {
     constructor(public key: string, public value: string) {}
 }
 
-export class DagNode implements dag.Node {
+export class DagNode {
     public data: Buffer;
 
     constructor(data: Uint8Array | string | Buffer, public links: Link[] = [], public tags: Tag[] = []) {
@@ -20,7 +20,9 @@ export class DagNode implements dag.Node {
 export class DagNodeResponse extends DagNode {
     protected cidObject: Cid;
 
-    constructor(cid: string | Uint8Array, data: Uint8Array, readonly links: Link[] = [], readonly tags: Tag[] = []) {
+    constructor(cid: string | Uint8Array, data: Uint8Array, dagLinks: dag.Link[] = [], tags: dag.Tag[] = []) {
+        const links = dagLinks.map((link) => ({...link, cid: new Cid(link.cid).toString()}));
+
         super(new Uint8Array(data), links, tags);
 
         this.cidObject = new Cid(cid);
@@ -30,3 +32,11 @@ export class DagNodeResponse extends DagNode {
         return this.cidObject.toString();
     }
 }
+
+export const mapDagNodeToAPI = (node: DagNode): dag.Node => ({
+    ...node,
+    links: node.links.map((link) => ({
+        ...link,
+        cid: new Cid(link.cid).toBytes(),
+    })),
+});

--- a/packages/ddc/src/grpc/cns_api.ts
+++ b/packages/ddc/src/grpc/cns_api.ts
@@ -17,17 +17,13 @@ import { MessageType } from "@protobuf-ts/runtime";
  */
 export interface PutRequest {
     /**
-     * @generated from protobuf field: uint32 BucketId = 1 [json_name = "BucketId"];
+     * @generated from protobuf field: uint64 bucketId = 1;
      */
     bucketId: number;
     /**
-     * @generated from protobuf field: string Name = 2 [json_name = "Name"];
+     * @generated from protobuf field: cns.Record record = 2;
      */
-    name: string;
-    /**
-     * @generated from protobuf field: string Cid = 3 [json_name = "Cid"];
-     */
-    cid: string;
+    record?: Record;
 }
 /**
  * @generated from protobuf message cns.PutResponse
@@ -39,13 +35,11 @@ export interface PutResponse {
  */
 export interface GetRequest {
     /**
-     * either bucketId or bucketName should be provided
-     *
-     * @generated from protobuf field: uint32 BucketId = 1 [json_name = "BucketId"];
+     * @generated from protobuf field: uint64 bucketId = 1;
      */
     bucketId: number;
     /**
-     * @generated from protobuf field: string Name = 3 [json_name = "Name"];
+     * @generated from protobuf field: string name = 2;
      */
     name: string;
 }
@@ -54,21 +48,67 @@ export interface GetRequest {
  */
 export interface GetResponse {
     /**
-     * @generated from protobuf field: string Cid = 1 [json_name = "Cid"];
+     * @generated from protobuf field: cns.Record record = 1;
      */
-    cid: string;
+    record?: Record;
+}
+/**
+ * @generated from protobuf message cns.Record
+ */
+export interface Record {
+    /**
+     * @generated from protobuf field: cns.Record.Signature signature = 1;
+     */
+    signature?: Record_Signature; // signature of a CnsRecord serialised to protobuf (excluding Signature itself) by a client that have an access to a bucket so requester can verify the validity of the CNS record
+    /**
+     * @generated from protobuf field: bytes cid = 2;
+     */
+    cid: Uint8Array;
+    /**
+     * @generated from protobuf field: string name = 3;
+     */
+    name: string;
+}
+/**
+ * @generated from protobuf message cns.Record.Signature
+ */
+export interface Record_Signature {
+    /**
+     * @generated from protobuf field: cns.Record.Signature.Algorithm algorithm = 1;
+     */
+    algorithm: Record_Signature_Algorithm;
+    /**
+     * @generated from protobuf field: bytes signer = 2;
+     */
+    signer: Uint8Array;
+    /**
+     * @generated from protobuf field: bytes value = 3;
+     */
+    value: Uint8Array;
+}
+/**
+ * @generated from protobuf enum cns.Record.Signature.Algorithm
+ */
+export enum Record_Signature_Algorithm {
+    /**
+     * @generated from protobuf enum value: ED_25519 = 0;
+     */
+    ED_25519 = 0,
+    /**
+     * @generated from protobuf enum value: SR_25519 = 1;
+     */
+    SR_25519 = 1
 }
 // @generated message type with reflection information, may provide speed optimized methods
 class PutRequest$Type extends MessageType<PutRequest> {
     constructor() {
         super("cns.PutRequest", [
-            { no: 1, name: "BucketId", kind: "scalar", jsonName: "BucketId", T: 13 /*ScalarType.UINT32*/ },
-            { no: 2, name: "Name", kind: "scalar", jsonName: "Name", T: 9 /*ScalarType.STRING*/ },
-            { no: 3, name: "Cid", kind: "scalar", jsonName: "Cid", T: 9 /*ScalarType.STRING*/ }
+            { no: 1, name: "bucketId", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
+            { no: 2, name: "record", kind: "message", T: () => Record }
         ]);
     }
     create(value?: PartialMessage<PutRequest>): PutRequest {
-        const message = { bucketId: 0, name: "", cid: "" };
+        const message = { bucketId: 0 };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<PutRequest>(this, message, value);
@@ -79,14 +119,11 @@ class PutRequest$Type extends MessageType<PutRequest> {
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* uint32 BucketId = 1 [json_name = "BucketId"];*/ 1:
-                    message.bucketId = reader.uint32();
+                case /* uint64 bucketId */ 1:
+                    message.bucketId = reader.uint64().toNumber();
                     break;
-                case /* string Name = 2 [json_name = "Name"];*/ 2:
-                    message.name = reader.string();
-                    break;
-                case /* string Cid = 3 [json_name = "Cid"];*/ 3:
-                    message.cid = reader.string();
+                case /* cns.Record record */ 2:
+                    message.record = Record.internalBinaryRead(reader, reader.uint32(), options, message.record);
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -100,15 +137,12 @@ class PutRequest$Type extends MessageType<PutRequest> {
         return message;
     }
     internalBinaryWrite(message: PutRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* uint32 BucketId = 1 [json_name = "BucketId"]; */
+        /* uint64 bucketId = 1; */
         if (message.bucketId !== 0)
-            writer.tag(1, WireType.Varint).uint32(message.bucketId);
-        /* string Name = 2 [json_name = "Name"]; */
-        if (message.name !== "")
-            writer.tag(2, WireType.LengthDelimited).string(message.name);
-        /* string Cid = 3 [json_name = "Cid"]; */
-        if (message.cid !== "")
-            writer.tag(3, WireType.LengthDelimited).string(message.cid);
+            writer.tag(1, WireType.Varint).uint64(message.bucketId);
+        /* cns.Record record = 2; */
+        if (message.record)
+            Record.internalBinaryWrite(message.record, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -149,8 +183,8 @@ export const PutResponse = new PutResponse$Type();
 class GetRequest$Type extends MessageType<GetRequest> {
     constructor() {
         super("cns.GetRequest", [
-            { no: 1, name: "BucketId", kind: "scalar", jsonName: "BucketId", T: 13 /*ScalarType.UINT32*/ },
-            { no: 3, name: "Name", kind: "scalar", jsonName: "Name", T: 9 /*ScalarType.STRING*/ }
+            { no: 1, name: "bucketId", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
+            { no: 2, name: "name", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<GetRequest>): GetRequest {
@@ -165,10 +199,10 @@ class GetRequest$Type extends MessageType<GetRequest> {
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* uint32 BucketId = 1 [json_name = "BucketId"];*/ 1:
-                    message.bucketId = reader.uint32();
+                case /* uint64 bucketId */ 1:
+                    message.bucketId = reader.uint64().toNumber();
                     break;
-                case /* string Name = 3 [json_name = "Name"];*/ 3:
+                case /* string name */ 2:
                     message.name = reader.string();
                     break;
                 default:
@@ -183,12 +217,12 @@ class GetRequest$Type extends MessageType<GetRequest> {
         return message;
     }
     internalBinaryWrite(message: GetRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* uint32 BucketId = 1 [json_name = "BucketId"]; */
+        /* uint64 bucketId = 1; */
         if (message.bucketId !== 0)
-            writer.tag(1, WireType.Varint).uint32(message.bucketId);
-        /* string Name = 3 [json_name = "Name"]; */
+            writer.tag(1, WireType.Varint).uint64(message.bucketId);
+        /* string name = 2; */
         if (message.name !== "")
-            writer.tag(3, WireType.LengthDelimited).string(message.name);
+            writer.tag(2, WireType.LengthDelimited).string(message.name);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -203,11 +237,11 @@ export const GetRequest = new GetRequest$Type();
 class GetResponse$Type extends MessageType<GetResponse> {
     constructor() {
         super("cns.GetResponse", [
-            { no: 1, name: "Cid", kind: "scalar", jsonName: "Cid", T: 9 /*ScalarType.STRING*/ }
+            { no: 1, name: "record", kind: "message", T: () => Record }
         ]);
     }
     create(value?: PartialMessage<GetResponse>): GetResponse {
-        const message = { cid: "" };
+        const message = {};
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<GetResponse>(this, message, value);
@@ -218,8 +252,8 @@ class GetResponse$Type extends MessageType<GetResponse> {
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* string Cid = 1 [json_name = "Cid"];*/ 1:
-                    message.cid = reader.string();
+                case /* cns.Record record */ 1:
+                    message.record = Record.internalBinaryRead(reader, reader.uint32(), options, message.record);
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -233,9 +267,9 @@ class GetResponse$Type extends MessageType<GetResponse> {
         return message;
     }
     internalBinaryWrite(message: GetResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* string Cid = 1 [json_name = "Cid"]; */
-        if (message.cid !== "")
-            writer.tag(1, WireType.LengthDelimited).string(message.cid);
+        /* cns.Record record = 1; */
+        if (message.record)
+            Record.internalBinaryWrite(message.record, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -246,10 +280,132 @@ class GetResponse$Type extends MessageType<GetResponse> {
  * @generated MessageType for protobuf message cns.GetResponse
  */
 export const GetResponse = new GetResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class Record$Type extends MessageType<Record> {
+    constructor() {
+        super("cns.Record", [
+            { no: 1, name: "signature", kind: "message", T: () => Record_Signature },
+            { no: 2, name: "cid", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "name", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<Record>): Record {
+        const message = { cid: new Uint8Array(0), name: "" };
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<Record>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Record): Record {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* cns.Record.Signature signature */ 1:
+                    message.signature = Record_Signature.internalBinaryRead(reader, reader.uint32(), options, message.signature);
+                    break;
+                case /* bytes cid */ 2:
+                    message.cid = reader.bytes();
+                    break;
+                case /* string name */ 3:
+                    message.name = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: Record, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* cns.Record.Signature signature = 1; */
+        if (message.signature)
+            Record_Signature.internalBinaryWrite(message.signature, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        /* bytes cid = 2; */
+        if (message.cid.length)
+            writer.tag(2, WireType.LengthDelimited).bytes(message.cid);
+        /* string name = 3; */
+        if (message.name !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.name);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message cns.Record
+ */
+export const Record = new Record$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class Record_Signature$Type extends MessageType<Record_Signature> {
+    constructor() {
+        super("cns.Record.Signature", [
+            { no: 1, name: "algorithm", kind: "enum", T: () => ["cns.Record.Signature.Algorithm", Record_Signature_Algorithm] },
+            { no: 2, name: "signer", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "value", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
+        ]);
+    }
+    create(value?: PartialMessage<Record_Signature>): Record_Signature {
+        const message = { algorithm: 0, signer: new Uint8Array(0), value: new Uint8Array(0) };
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<Record_Signature>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Record_Signature): Record_Signature {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* cns.Record.Signature.Algorithm algorithm */ 1:
+                    message.algorithm = reader.int32();
+                    break;
+                case /* bytes signer */ 2:
+                    message.signer = reader.bytes();
+                    break;
+                case /* bytes value */ 3:
+                    message.value = reader.bytes();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: Record_Signature, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* cns.Record.Signature.Algorithm algorithm = 1; */
+        if (message.algorithm !== 0)
+            writer.tag(1, WireType.Varint).int32(message.algorithm);
+        /* bytes signer = 2; */
+        if (message.signer.length)
+            writer.tag(2, WireType.LengthDelimited).bytes(message.signer);
+        /* bytes value = 3; */
+        if (message.value.length)
+            writer.tag(3, WireType.LengthDelimited).bytes(message.value);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message cns.Record.Signature
+ */
+export const Record_Signature = new Record_Signature$Type();
 /**
  * @generated ServiceType for protobuf service cns.CnsApi
  */
 export const CnsApi = new ServiceType("cns.CnsApi", [
-    { name: "Put", options: { "google.api.http": { post: "/v1/cns/{BucketId}", body: "*" } }, I: PutRequest, O: PutResponse },
-    { name: "Get", options: { "google.api.http": { get: "/v1/cns/{BucketId}/{Name}" } }, I: GetRequest, O: GetResponse }
+    { name: "Put", options: { "google.api.http": { post: "/v1/cns/{bucketId}", body: "*" } }, I: PutRequest, O: PutResponse },
+    { name: "Get", options: { "google.api.http": { get: "/v1/cns/{bucketId}/{name}" } }, I: GetRequest, O: GetResponse }
 ]);

--- a/packages/ddc/src/grpc/dag_api.ts
+++ b/packages/ddc/src/grpc/dag_api.ts
@@ -17,7 +17,7 @@ import { MessageType } from "@protobuf-ts/runtime";
  */
 export interface PutRequest {
     /**
-     * @generated from protobuf field: uint32 BucketId = 1 [json_name = "BucketId"];
+     * @generated from protobuf field: uint64 BucketId = 1 [json_name = "BucketId"];
      */
     bucketId: number;
     /**
@@ -30,22 +30,22 @@ export interface PutRequest {
  */
 export interface PutResponse {
     /**
-     * @generated from protobuf field: string Cid = 1 [json_name = "Cid"];
+     * @generated from protobuf field: bytes Cid = 1 [json_name = "Cid"];
      */
-    cid: string;
+    cid: Uint8Array;
 }
 /**
  * @generated from protobuf message dag.GetRequest
  */
 export interface GetRequest {
     /**
-     * @generated from protobuf field: uint32 BucketId = 1 [json_name = "BucketId"];
+     * @generated from protobuf field: uint64 BucketId = 1 [json_name = "BucketId"];
      */
     bucketId: number;
     /**
-     * @generated from protobuf field: string Cid = 2 [json_name = "Cid"];
+     * @generated from protobuf field: bytes Cid = 2 [json_name = "Cid"];
      */
-    cid: string;
+    cid: Uint8Array;
     /**
      * @generated from protobuf field: optional string Path = 3 [json_name = "Path"];
      */
@@ -84,9 +84,9 @@ export interface Link {
     /**
      * CID of the target object
      *
-     * @generated from protobuf field: string Cid = 1 [json_name = "Cid"];
+     * @generated from protobuf field: bytes Cid = 1 [json_name = "Cid"];
      */
-    cid: string;
+    cid: Uint8Array;
     /**
      * UTF-8 string name
      *
@@ -117,7 +117,7 @@ export interface Tag {
 class PutRequest$Type extends MessageType<PutRequest> {
     constructor() {
         super("dag.PutRequest", [
-            { no: 1, name: "BucketId", kind: "scalar", jsonName: "BucketId", T: 13 /*ScalarType.UINT32*/ },
+            { no: 1, name: "BucketId", kind: "scalar", jsonName: "BucketId", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
             { no: 2, name: "Node", kind: "message", jsonName: "Node", T: () => Node }
         ]);
     }
@@ -133,8 +133,8 @@ class PutRequest$Type extends MessageType<PutRequest> {
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* uint32 BucketId = 1 [json_name = "BucketId"];*/ 1:
-                    message.bucketId = reader.uint32();
+                case /* uint64 BucketId = 1 [json_name = "BucketId"];*/ 1:
+                    message.bucketId = reader.uint64().toNumber();
                     break;
                 case /* dag.Node Node = 2 [json_name = "Node"];*/ 2:
                     message.node = Node.internalBinaryRead(reader, reader.uint32(), options, message.node);
@@ -151,9 +151,9 @@ class PutRequest$Type extends MessageType<PutRequest> {
         return message;
     }
     internalBinaryWrite(message: PutRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* uint32 BucketId = 1 [json_name = "BucketId"]; */
+        /* uint64 BucketId = 1 [json_name = "BucketId"]; */
         if (message.bucketId !== 0)
-            writer.tag(1, WireType.Varint).uint32(message.bucketId);
+            writer.tag(1, WireType.Varint).uint64(message.bucketId);
         /* dag.Node Node = 2 [json_name = "Node"]; */
         if (message.node)
             Node.internalBinaryWrite(message.node, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
@@ -171,11 +171,11 @@ export const PutRequest = new PutRequest$Type();
 class PutResponse$Type extends MessageType<PutResponse> {
     constructor() {
         super("dag.PutResponse", [
-            { no: 1, name: "Cid", kind: "scalar", jsonName: "Cid", T: 9 /*ScalarType.STRING*/ }
+            { no: 1, name: "Cid", kind: "scalar", jsonName: "Cid", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
     create(value?: PartialMessage<PutResponse>): PutResponse {
-        const message = { cid: "" };
+        const message = { cid: new Uint8Array(0) };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<PutResponse>(this, message, value);
@@ -186,8 +186,8 @@ class PutResponse$Type extends MessageType<PutResponse> {
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* string Cid = 1 [json_name = "Cid"];*/ 1:
-                    message.cid = reader.string();
+                case /* bytes Cid = 1 [json_name = "Cid"];*/ 1:
+                    message.cid = reader.bytes();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -201,9 +201,9 @@ class PutResponse$Type extends MessageType<PutResponse> {
         return message;
     }
     internalBinaryWrite(message: PutResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* string Cid = 1 [json_name = "Cid"]; */
-        if (message.cid !== "")
-            writer.tag(1, WireType.LengthDelimited).string(message.cid);
+        /* bytes Cid = 1 [json_name = "Cid"]; */
+        if (message.cid.length)
+            writer.tag(1, WireType.LengthDelimited).bytes(message.cid);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -218,13 +218,13 @@ export const PutResponse = new PutResponse$Type();
 class GetRequest$Type extends MessageType<GetRequest> {
     constructor() {
         super("dag.GetRequest", [
-            { no: 1, name: "BucketId", kind: "scalar", jsonName: "BucketId", T: 13 /*ScalarType.UINT32*/ },
-            { no: 2, name: "Cid", kind: "scalar", jsonName: "Cid", T: 9 /*ScalarType.STRING*/ },
+            { no: 1, name: "BucketId", kind: "scalar", jsonName: "BucketId", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
+            { no: 2, name: "Cid", kind: "scalar", jsonName: "Cid", T: 12 /*ScalarType.BYTES*/ },
             { no: 3, name: "Path", kind: "scalar", jsonName: "Path", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<GetRequest>): GetRequest {
-        const message = { bucketId: 0, cid: "" };
+        const message = { bucketId: 0, cid: new Uint8Array(0) };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<GetRequest>(this, message, value);
@@ -235,11 +235,11 @@ class GetRequest$Type extends MessageType<GetRequest> {
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* uint32 BucketId = 1 [json_name = "BucketId"];*/ 1:
-                    message.bucketId = reader.uint32();
+                case /* uint64 BucketId = 1 [json_name = "BucketId"];*/ 1:
+                    message.bucketId = reader.uint64().toNumber();
                     break;
-                case /* string Cid = 2 [json_name = "Cid"];*/ 2:
-                    message.cid = reader.string();
+                case /* bytes Cid = 2 [json_name = "Cid"];*/ 2:
+                    message.cid = reader.bytes();
                     break;
                 case /* optional string Path = 3 [json_name = "Path"];*/ 3:
                     message.path = reader.string();
@@ -256,12 +256,12 @@ class GetRequest$Type extends MessageType<GetRequest> {
         return message;
     }
     internalBinaryWrite(message: GetRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* uint32 BucketId = 1 [json_name = "BucketId"]; */
+        /* uint64 BucketId = 1 [json_name = "BucketId"]; */
         if (message.bucketId !== 0)
-            writer.tag(1, WireType.Varint).uint32(message.bucketId);
-        /* string Cid = 2 [json_name = "Cid"]; */
-        if (message.cid !== "")
-            writer.tag(2, WireType.LengthDelimited).string(message.cid);
+            writer.tag(1, WireType.Varint).uint64(message.bucketId);
+        /* bytes Cid = 2 [json_name = "Cid"]; */
+        if (message.cid.length)
+            writer.tag(2, WireType.LengthDelimited).bytes(message.cid);
         /* optional string Path = 3 [json_name = "Path"]; */
         if (message.path !== undefined)
             writer.tag(3, WireType.LengthDelimited).string(message.path);
@@ -387,13 +387,13 @@ export const Node = new Node$Type();
 class Link$Type extends MessageType<Link> {
     constructor() {
         super("dag.Link", [
-            { no: 1, name: "Cid", kind: "scalar", jsonName: "Cid", T: 9 /*ScalarType.STRING*/ },
+            { no: 1, name: "Cid", kind: "scalar", jsonName: "Cid", T: 12 /*ScalarType.BYTES*/ },
             { no: 2, name: "Name", kind: "scalar", jsonName: "Name", T: 9 /*ScalarType.STRING*/ },
             { no: 3, name: "Size", kind: "scalar", jsonName: "Size", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ }
         ]);
     }
     create(value?: PartialMessage<Link>): Link {
-        const message = { cid: "", name: "", size: 0 };
+        const message = { cid: new Uint8Array(0), name: "", size: 0 };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<Link>(this, message, value);
@@ -404,8 +404,8 @@ class Link$Type extends MessageType<Link> {
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* string Cid = 1 [json_name = "Cid"];*/ 1:
-                    message.cid = reader.string();
+                case /* bytes Cid = 1 [json_name = "Cid"];*/ 1:
+                    message.cid = reader.bytes();
                     break;
                 case /* string Name = 2 [json_name = "Name"];*/ 2:
                     message.name = reader.string();
@@ -425,9 +425,9 @@ class Link$Type extends MessageType<Link> {
         return message;
     }
     internalBinaryWrite(message: Link, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* string Cid = 1 [json_name = "Cid"]; */
-        if (message.cid !== "")
-            writer.tag(1, WireType.LengthDelimited).string(message.cid);
+        /* bytes Cid = 1 [json_name = "Cid"]; */
+        if (message.cid.length)
+            writer.tag(1, WireType.LengthDelimited).bytes(message.cid);
         /* string Name = 2 [json_name = "Name"]; */
         if (message.name !== "")
             writer.tag(2, WireType.LengthDelimited).string(message.name);

--- a/packages/ddc/src/grpc/file_api.ts
+++ b/packages/ddc/src/grpc/file_api.ts
@@ -40,13 +40,13 @@ export interface PutRawPieceRequest {
  */
 export interface PutRawPieceRequest_Metadata {
     /**
-     * @generated from protobuf field: optional bytes cid = 1;
+     * @generated from protobuf field: uint64 bucketId = 1;
+     */
+    bucketId: number;
+    /**
+     * @generated from protobuf field: optional bytes cid = 2;
      */
     cid?: Uint8Array;
-    /**
-     * @generated from protobuf field: string bucketId = 2;
-     */
-    bucketId: string;
     /**
      * @generated from protobuf field: optional uint64 offset = 3;
      */
@@ -79,13 +79,13 @@ export interface PutRawPieceResponse {
  */
 export interface PutMultiPartPieceRequest {
     /**
-     * @generated from protobuf field: optional bytes cid = 1;
+     * @generated from protobuf field: uint64 bucketId = 1;
+     */
+    bucketId: number; // bucket where file is stored
+    /**
+     * @generated from protobuf field: optional bytes cid = 2;
      */
     cid?: Uint8Array; // root hash of the file hash tree
-    /**
-     * @generated from protobuf field: string bucketId = 2;
-     */
-    bucketId: string; // bucket where file is stored
     /**
      * @generated from protobuf field: uint64 totalSize = 3;
      */
@@ -113,13 +113,13 @@ export interface PutMultiPartPieceResponse {
  */
 export interface GetFileRequest {
     /**
-     * @generated from protobuf field: bytes cid = 1;
+     * @generated from protobuf field: uint64 bucketId = 1;
+     */
+    bucketId: number;
+    /**
+     * @generated from protobuf field: bytes cid = 2;
      */
     cid: Uint8Array; // CID of either raw or multi-part piece
-    /**
-     * @generated from protobuf field: string bucketId = 2;
-     */
-    bucketId: string;
     /**
      * @generated from protobuf field: optional file.GetFileRequest.Range range = 3;
      */
@@ -234,14 +234,14 @@ export const PutRawPieceRequest = new PutRawPieceRequest$Type();
 class PutRawPieceRequest_Metadata$Type extends MessageType<PutRawPieceRequest_Metadata> {
     constructor() {
         super("file.PutRawPieceRequest.Metadata", [
-            { no: 1, name: "cid", kind: "scalar", opt: true, T: 12 /*ScalarType.BYTES*/ },
-            { no: 2, name: "bucketId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 1, name: "bucketId", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
+            { no: 2, name: "cid", kind: "scalar", opt: true, T: 12 /*ScalarType.BYTES*/ },
             { no: 3, name: "offset", kind: "scalar", opt: true, T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
             { no: 4, name: "isMultipart", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
     create(value?: PartialMessage<PutRawPieceRequest_Metadata>): PutRawPieceRequest_Metadata {
-        const message = { bucketId: "", isMultipart: false };
+        const message = { bucketId: 0, isMultipart: false };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<PutRawPieceRequest_Metadata>(this, message, value);
@@ -252,11 +252,11 @@ class PutRawPieceRequest_Metadata$Type extends MessageType<PutRawPieceRequest_Me
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* optional bytes cid */ 1:
-                    message.cid = reader.bytes();
+                case /* uint64 bucketId */ 1:
+                    message.bucketId = reader.uint64().toNumber();
                     break;
-                case /* string bucketId */ 2:
-                    message.bucketId = reader.string();
+                case /* optional bytes cid */ 2:
+                    message.cid = reader.bytes();
                     break;
                 case /* optional uint64 offset */ 3:
                     message.offset = reader.uint64().toNumber();
@@ -276,12 +276,12 @@ class PutRawPieceRequest_Metadata$Type extends MessageType<PutRawPieceRequest_Me
         return message;
     }
     internalBinaryWrite(message: PutRawPieceRequest_Metadata, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* optional bytes cid = 1; */
+        /* uint64 bucketId = 1; */
+        if (message.bucketId !== 0)
+            writer.tag(1, WireType.Varint).uint64(message.bucketId);
+        /* optional bytes cid = 2; */
         if (message.cid !== undefined)
-            writer.tag(1, WireType.LengthDelimited).bytes(message.cid);
-        /* string bucketId = 2; */
-        if (message.bucketId !== "")
-            writer.tag(2, WireType.LengthDelimited).string(message.bucketId);
+            writer.tag(2, WireType.LengthDelimited).bytes(message.cid);
         /* optional uint64 offset = 3; */
         if (message.offset !== undefined)
             writer.tag(3, WireType.Varint).uint64(message.offset);
@@ -396,15 +396,15 @@ export const PutRawPieceResponse = new PutRawPieceResponse$Type();
 class PutMultiPartPieceRequest$Type extends MessageType<PutMultiPartPieceRequest> {
     constructor() {
         super("file.PutMultiPartPieceRequest", [
-            { no: 1, name: "cid", kind: "scalar", opt: true, T: 12 /*ScalarType.BYTES*/ },
-            { no: 2, name: "bucketId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 1, name: "bucketId", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
+            { no: 2, name: "cid", kind: "scalar", opt: true, T: 12 /*ScalarType.BYTES*/ },
             { no: 3, name: "totalSize", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
             { no: 4, name: "partSize", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
             { no: 5, name: "partHashes", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
     create(value?: PartialMessage<PutMultiPartPieceRequest>): PutMultiPartPieceRequest {
-        const message = { bucketId: "", totalSize: 0, partSize: 0, partHashes: [] };
+        const message = { bucketId: 0, totalSize: 0, partSize: 0, partHashes: [] };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<PutMultiPartPieceRequest>(this, message, value);
@@ -415,11 +415,11 @@ class PutMultiPartPieceRequest$Type extends MessageType<PutMultiPartPieceRequest
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* optional bytes cid */ 1:
-                    message.cid = reader.bytes();
+                case /* uint64 bucketId */ 1:
+                    message.bucketId = reader.uint64().toNumber();
                     break;
-                case /* string bucketId */ 2:
-                    message.bucketId = reader.string();
+                case /* optional bytes cid */ 2:
+                    message.cid = reader.bytes();
                     break;
                 case /* uint64 totalSize */ 3:
                     message.totalSize = reader.uint64().toNumber();
@@ -442,12 +442,12 @@ class PutMultiPartPieceRequest$Type extends MessageType<PutMultiPartPieceRequest
         return message;
     }
     internalBinaryWrite(message: PutMultiPartPieceRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* optional bytes cid = 1; */
+        /* uint64 bucketId = 1; */
+        if (message.bucketId !== 0)
+            writer.tag(1, WireType.Varint).uint64(message.bucketId);
+        /* optional bytes cid = 2; */
         if (message.cid !== undefined)
-            writer.tag(1, WireType.LengthDelimited).bytes(message.cid);
-        /* string bucketId = 2; */
-        if (message.bucketId !== "")
-            writer.tag(2, WireType.LengthDelimited).string(message.bucketId);
+            writer.tag(2, WireType.LengthDelimited).bytes(message.cid);
         /* uint64 totalSize = 3; */
         if (message.totalSize !== 0)
             writer.tag(3, WireType.Varint).uint64(message.totalSize);
@@ -518,13 +518,13 @@ export const PutMultiPartPieceResponse = new PutMultiPartPieceResponse$Type();
 class GetFileRequest$Type extends MessageType<GetFileRequest> {
     constructor() {
         super("file.GetFileRequest", [
-            { no: 1, name: "cid", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
-            { no: 2, name: "bucketId", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 1, name: "bucketId", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
+            { no: 2, name: "cid", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 3, name: "range", kind: "message", T: () => GetFileRequest_Range }
         ]);
     }
     create(value?: PartialMessage<GetFileRequest>): GetFileRequest {
-        const message = { cid: new Uint8Array(0), bucketId: "" };
+        const message = { bucketId: 0, cid: new Uint8Array(0) };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<GetFileRequest>(this, message, value);
@@ -535,11 +535,11 @@ class GetFileRequest$Type extends MessageType<GetFileRequest> {
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* bytes cid */ 1:
-                    message.cid = reader.bytes();
+                case /* uint64 bucketId */ 1:
+                    message.bucketId = reader.uint64().toNumber();
                     break;
-                case /* string bucketId */ 2:
-                    message.bucketId = reader.string();
+                case /* bytes cid */ 2:
+                    message.cid = reader.bytes();
                     break;
                 case /* optional file.GetFileRequest.Range range */ 3:
                     message.range = GetFileRequest_Range.internalBinaryRead(reader, reader.uint32(), options, message.range);
@@ -556,12 +556,12 @@ class GetFileRequest$Type extends MessageType<GetFileRequest> {
         return message;
     }
     internalBinaryWrite(message: GetFileRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* bytes cid = 1; */
+        /* uint64 bucketId = 1; */
+        if (message.bucketId !== 0)
+            writer.tag(1, WireType.Varint).uint64(message.bucketId);
+        /* bytes cid = 2; */
         if (message.cid.length)
-            writer.tag(1, WireType.LengthDelimited).bytes(message.cid);
-        /* string bucketId = 2; */
-        if (message.bucketId !== "")
-            writer.tag(2, WireType.LengthDelimited).string(message.bucketId);
+            writer.tag(2, WireType.LengthDelimited).bytes(message.cid);
         /* optional file.GetFileRequest.Range range = 3; */
         if (message.range)
             GetFileRequest_Range.internalBinaryWrite(message.range, writer.tag(3, WireType.LengthDelimited).fork(), options).join();

--- a/packages/ddc/src/index.ts
+++ b/packages/ddc/src/index.ts
@@ -11,8 +11,8 @@ export * from './RpcTransport';
  */
 export * from './Router';
 export * from './Piece';
-export * from './DagNode';
 export * from './StorageNode';
+export {DagNode, DagNodeResponse, Link, Tag} from './DagNode';
 
 /**
  * Constants

--- a/tests/v2/DdcApis.spec.ts
+++ b/tests/v2/DdcApis.spec.ts
@@ -13,7 +13,7 @@ describe('DDC APIs', () => {
     const storeRawPiece = async (chunks: Content, mutipartOffset?: number) => {
         return fileApi.putRawPiece(
             {
-                bucketId: bucketId.toString(), // TODO: Inconsistent bucketId type
+                bucketId,
                 isMultipart: mutipartOffset !== undefined,
                 offset: mutipartOffset,
             },
@@ -22,7 +22,7 @@ describe('DDC APIs', () => {
     };
 
     describe('Dag Api', () => {
-        let nodeCid: string;
+        let nodeCid: Uint8Array;
         const nodeData = randomBytes(10);
 
         test('Create node', async () => {
@@ -35,7 +35,7 @@ describe('DDC APIs', () => {
                 },
             });
 
-            expect(nodeCid).toEqual(expect.any(String));
+            expect(nodeCid).toEqual(expect.any(Uint8Array));
         });
 
         test('Read node', async () => {
@@ -44,7 +44,6 @@ describe('DDC APIs', () => {
             const node = await dagApi.getNode({
                 cid: nodeCid,
                 bucketId,
-                path: '',
             });
 
             expect(node?.data).toEqual(nodeData);
@@ -53,13 +52,15 @@ describe('DDC APIs', () => {
 
     describe.skip('Cns Api', () => {
         const alias = 'test-cid-alias';
-        const testCid = 'test-cid';
+        const testCid = new Uint8Array(randomBytes(32));
 
         test('Create alias', async () => {
             await cnsApi.assignName({
                 bucketId,
-                cid: testCid,
-                name: alias,
+                record: {
+                    cid: testCid,
+                    name: alias,
+                },
             });
         });
 
@@ -93,8 +94,8 @@ describe('DDC APIs', () => {
                 expect(smallPieceCid).toBeDefined();
 
                 const contentStream = fileApi.getFile({
+                    bucketId,
                     cid: smallPieceCid,
-                    bucketId: bucketId.toString(), // TODO: Inconsistent bucketId type
                 });
 
                 const content = await streamToU8a(contentStream);
@@ -113,8 +114,8 @@ describe('DDC APIs', () => {
                 expect(largePieceCid).toBeDefined();
 
                 const contentStream = fileApi.getFile({
+                    bucketId,
                     cid: largePieceCid,
-                    bucketId: bucketId.toString(), // TODO: Inconsistent bucketId type
                 });
 
                 const content = await streamToU8a(contentStream);
@@ -127,8 +128,8 @@ describe('DDC APIs', () => {
 
                 const rangeSize = 10 * DDC_BLOCK_SIZE;
                 const contentStream = fileApi.getFile({
+                    bucketId,
                     cid: largePieceCid,
-                    bucketId: bucketId.toString(), // TODO: Inconsistent bucketId type
                     range: {
                         start: 0,
                         end: rangeSize - 1,
@@ -166,7 +167,7 @@ describe('DDC APIs', () => {
                 const partHashes = rawPieceCids.map((cid) => cid.slice(-32));
 
                 multipartPieceCid = await fileApi.putMultipartPiece({
-                    bucketId: bucketId.toString(), // TODO: Inconsistent bucketId type
+                    bucketId,
                     partHashes,
                     partSize,
                     totalSize,
@@ -180,8 +181,8 @@ describe('DDC APIs', () => {
                 expect(multipartPieceCid).toBeDefined();
 
                 const contentStream = fileApi.getFile({
+                    bucketId,
                     cid: multipartPieceCid,
-                    bucketId: bucketId.toString(), // TODO: Inconsistent bucketId type
                 });
 
                 const content = await streamToU8a(contentStream);
@@ -194,8 +195,8 @@ describe('DDC APIs', () => {
 
                 const rangeSize = 10 * DDC_BLOCK_SIZE;
                 const contentStream = fileApi.getFile({
+                    bucketId,
                     cid: multipartPieceCid,
-                    bucketId: bucketId.toString(), // TODO: Inconsistent bucketId type,
                     range: {
                         start: 0,
                         end: rangeSize - 1,


### PR DESCRIPTION
These API changes suported
- CIDs are always of `bytes` type (`Uint8Array`)
- Bucket IDs are always of `uint64` type (`number`)