### PR TITLE
Add configuration presets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20519,7 +20519,6 @@
             "version": "2.0.0-rc.4",
             "license": "Apache-2.0",
             "dependencies": {
-                "@cere-ddc-sdk/core": "2.0.0-rc.4",
                 "@cere-ddc-sdk/ddc": "2.0.0-rc.4",
                 "@cere-ddc-sdk/file-storage": "2.0.0-rc.4",
                 "@cere-ddc-sdk/smart-contract": "2.0.0-rc.4"
@@ -21864,7 +21863,6 @@
         "@cere-ddc-sdk/ddc-client": {
             "version": "file:packages/ddc-client",
             "requires": {
-                "@cere-ddc-sdk/core": "2.0.0-rc.4",
                 "@cere-ddc-sdk/ddc": "2.0.0-rc.4",
                 "@cere-ddc-sdk/file-storage": "2.0.0-rc.4",
                 "@cere-ddc-sdk/smart-contract": "2.0.0-rc.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,7 @@
     "description": "Core with common logic",
     "version": "2.0.0-rc.4",
     "type": "module",
+    "private": true,
     "repository": {
         "type": "git",
         "directory": "packages/core",

--- a/packages/ddc-client/README.md
+++ b/packages/ddc-client/README.md
@@ -1,5 +1,7 @@
 # @cere-ddc-sdk/ddc-client
 
+> After the major update `v2.0.0` the documentation below is outdated and no longer relevant. It will be updated before the final release.
+
 ## Introduction
 
 `DEK` is a data encryption key used to encrypt the data.
@@ -17,7 +19,7 @@ data on any level. Similar to directory based access.
 pieces).
 
 ```typescript
-type Data = ReadableStream<Uint8Array> | string | Uint8Array
+type Data = ReadableStream<Uint8Array> | string | Uint8Array;
 
 export class File {
     data: Data;
@@ -38,7 +40,7 @@ export class ClientOptions {
     clusterAddress: string | number; // Cluster ID or CDN URL
     fileOptions?: FileOptions = new FileStorageConfig();
     smartContract?: SmartContractOptions = TESTNET;
-    scheme?: SchemeName | SchemeInterface = "sr25519";
+    scheme?: SchemeName | SchemeInterface = 'sr25519';
     cipher?: CipherInterface = new NaclCipher();
     cidBuilder?: CidBuilder = new CidBuilder();
 }
@@ -76,8 +78,8 @@ export class ReadOptions {
 Initialize DDC client and connect to blockchain.
 
 ```typescript
-import {mnemonicGenerate} from "@polkadot/util-crypto";
-import {DdcClient} from "@cere-ddc-sdk/ddc-client";
+import {mnemonicGenerate} from '@polkadot/util-crypto';
+import {DdcClient} from '@cere-ddc-sdk/ddc-client';
 
 const options = {clusterAddress: 2n};
 const secretPhrase = mnemonicGenerate();
@@ -91,8 +93,8 @@ Create bucket in storage cluster in required `storageClusterId`, deposit to acco
 ```typescript
 const createBucket = async (balance: bigint, resource: bigint, storageClusterId: bigint) => {
     const bucketCreatedEvent = await ddcClient.createBucket(balance, resource, storageClusterId, {replication: 3});
-    console.log("Successfully created bucket. Id: " + bucketCreatedEvent.bucketId);
-}
+    console.log('Successfully created bucket. Id: ' + bucketCreatedEvent.bucketId);
+};
 ```
 
 ### Account Deposit
@@ -102,8 +104,8 @@ Add tokens to account.
 ```typescript
 const accountDeposit = async (balance: bigint) => {
     await ddcClient.accountDeposit(balance);
-    console.log("Successfully added tokens to account.");
-}
+    console.log('Successfully added tokens to account.');
+};
 ```
 
 ### Bucket allocation into cluster
@@ -114,7 +116,7 @@ Increase bucket size.
 const bucketAllocIntoCluster = async (bucketId: bigint, resource: bigint) => {
     await ddcClient.bucketAllocIntoCluster(bucketId, resource);
     console.log(`Successfully increased bucket size to ${resource}.`);
-}
+};
 ```
 
 ### Get bucket status
@@ -124,8 +126,8 @@ Get bucket status by id from blockchain.
 ```typescript
 const getBucket = async (bucketId: bigint) => {
     const bucketStatus = await ddcClient.bucketGet(bucketId);
-    console.log("Successfully got bucket status. Status: " + bucketStatus);
-}
+    console.log('Successfully got bucket status. Status: ' + bucketStatus);
+};
 ```
 
 ### Get bucket status
@@ -135,61 +137,37 @@ Get bucket statuses with limitations.
 ```typescript
 const getBucket = async (limit: bigint) => {
     const bucketStatuses = await ddcClient.bucketList(0, limit);
-    console.log("Successfully got bucket statuses. Statuses: " + bucketStatuses);
-}
+    console.log('Successfully got bucket statuses. Statuses: ' + bucketStatuses);
+};
 ```
 
-[### Grant bucket permission
-
-Give write access to bucket for user by public key.
-
-```typescript
-const grantBucketPermission = async (bucketId: bigint) => {
-    const partnerPublicKeyHex = "0xkldaf3a8as2109..."
-    const permissionGrantedEvent = await ddcClient.grantBucketPermission(bucketId, partnerPublicKeyHex, Permission.WRITE)
-    console.log("Successfully granted read permission to the bucket. Event: " + permissionGrantedEvent);
-}
-```
-
-### Revoke bucket permission
-
-Revoke write to bucket permissions for user by public key.
-
-```typescript
-import {Permission} from "@cere-ddc-sdk/smart-contract";
-
-const revokeBucketPermission = async (bucketId: bigint) => {
-    const partnerPublicKeyHex = "0xkldaf3a8as2109...";
-    const permissionRevokedEvent = await ddcClient.revokeBucketPermission(bucketId, partnerPublicKeyHex, Permission.WRITE)
-    console.log("Successfully revoked read permission to the bucket. Event: " + permissionRevokedEvent);
-}
-```]: #
+[### Grant bucket permission Give write access to bucket for user by public key. ```typescript const grantBucketPermission = async (bucketId: bigint) => { const partnerPublicKeyHex = "0xkldaf3a8as2109..." const permissionGrantedEvent = await ddcClient.grantBucketPermission(bucketId, partnerPublicKeyHex, Permission.WRITE) console.log("Successfully granted read permission to the bucket. Event: " + permissionGrantedEvent); } ``` ### Revoke bucket permission Revoke write to bucket permissions for user by public key. ```typescript import {Permission} from "@cere-ddc-sdk/smart-contract"; const revokeBucketPermission = async (bucketId: bigint) => { const partnerPublicKeyHex = "0xkldaf3a8as2109..."; const permissionRevokedEvent = await ddcClient.revokeBucketPermission(bucketId, partnerPublicKeyHex, Permission.WRITE) console.log("Successfully revoked read permission to the bucket. Event: " + permissionRevokedEvent); } ```]: #
 
 ### Store unencrypted data
 
 Store data as piece in DDC so anyone can read it nad able to search by tag `type=photo`.
 
 ```typescript
-import {Tag, Piece} from "@cere-ddc-sdk/core";
+import {Tag, Piece} from '@cere-ddc-sdk/core';
 
 const storeUnencryptedData = async (bucketId: bigint, data: Uint8Array) => {
-    const pieceArray = new Piece(data, [new Tag("type", "photo")]);
+    const pieceArray = new Piece(data, [new Tag('type', 'photo')]);
     const ddcUri = await ddcClient.store(bucketId, pieceArray, {encrypt: false});
-    console.log("Successfully uploaded unencrypted piece. DDC URI: " + ddcUri.toString());
-}
+    console.log('Successfully uploaded unencrypted piece. DDC URI: ' + ddcUri.toString());
+};
 ```
 
 Store data as group of pieces(file) in DDC so anyone can read it nad able to search by tag `type=photo`.
 
 ```typescript
-import {File} from "@cere-ddc-sdk/ddc-client";
-import {Tag} from "@cere-ddc-sdk/core";
+import {File} from '@cere-ddc-sdk/ddc-client';
+import {Tag} from '@cere-ddc-sdk/core';
 
 const storeUnencryptedData = async (bucketId: bigint, data: Uint8Array) => {
-    const pieceArray = new File(data, [new Tag("type", "photo")]);
+    const pieceArray = new File(data, [new Tag('type', 'photo')]);
     const ddcUri = await ddcClient.store(bucketId, pieceArray, {encrypt: false});
-    console.log("Successfully uploaded unencrypted piece. DDC URI: " + ddcUri.toString());
-}
+    console.log('Successfully uploaded unencrypted piece. DDC URI: ' + ddcUri.toString());
+};
 ```
 
 ### Store encrypted data
@@ -197,13 +175,13 @@ const storeUnencryptedData = async (bucketId: bigint, data: Uint8Array) => {
 Store encrypted data as piece in DDC, so only users with DEK can read it.
 
 ```typescript
-import {Tag, Piece} from "@cere-ddc-sdk/core";
+import {Tag, Piece} from '@cere-ddc-sdk/core';
 
 const storeUnencryptedData = async (bucketId: bigint, data: Uint8Array) => {
-    const pieceArray = new Piece(data, [new Tag("type", "photo")]);
+    const pieceArray = new Piece(data, [new Tag('type', 'photo')]);
     const ddcUri = await ddcClient.store(bucketId, pieceArray, {encrypt: true});
-    console.log("Successfully uploaded encrypted piece. DDC URI: " + ddcUri.toString());
-}
+    console.log('Successfully uploaded encrypted piece. DDC URI: ' + ddcUri.toString());
+};
 ```
 
 ### Share data
@@ -212,11 +190,11 @@ Give DEK to encrypted data for other user by encryption public key.
 
 ```typescript
 const shareData = async (bucketId: bigint) => {
-    const partnerPublicKeyHex = "0xkldaf3a8as2109...";
+    const partnerPublicKeyHex = '0xkldaf3a8as2109...';
 
-    const edekUri = await ddcClient.shareData(bucketId, "/photos", partnerPublicKeyHex);
-    console.log("Successfully shared data (uploaded EDEK). CID: " + edekUri.cid);
-}
+    const edekUri = await ddcClient.shareData(bucketId, '/photos', partnerPublicKeyHex);
+    console.log('Successfully shared data (uploaded EDEK). CID: ' + edekUri.cid);
+};
 ```
 
 ### Read data
@@ -224,13 +202,13 @@ const shareData = async (bucketId: bigint) => {
 Download data from DDC storage. Downloads File or Piece, depends on `protocol` in DDC Uri.
 
 ```typescript
-import {Piece} from "@cere-ddc-sdk/content-addressable-storage";
-import {DdcUri, File} from "@cere-ddc-sdk/ddc-client";
+import {Piece} from '@cere-ddc-sdk/content-addressable-storage';
+import {DdcUri, File} from '@cere-ddc-sdk/ddc-client';
 
 const readData = async (ddcUri: DdcUri) => {
     const pieceOrFile: Piece | File = await ddcClient.read(ddcUri);
-    console.log("Successfully read data. CID: " + pieceOrFile.cid || pieceOrFile.headCid);
-}
+    console.log('Successfully read data. CID: ' + pieceOrFile.cid || pieceOrFile.headCid);
+};
 ```
 
 ### Search pieces (metadata only)
@@ -240,9 +218,9 @@ Search data by tags without loading data.
 ```typescript
 const searchDataMetadataOnly = async (bucketId: bigint) => {
     const skipData = true;
-    const pieces = await ddcClient.search(new Query(bucketId, [new Tag("type", "photo")], skipData));
-    console.log("Successfully searched metadata. CIDS: " + pieces.map(e => e.cid));
-}
+    const pieces = await ddcClient.search(new Query(bucketId, [new Tag('type', 'photo')], skipData));
+    console.log('Successfully searched metadata. CIDS: ' + pieces.map((e) => e.cid));
+};
 ```
 
 ### Search pieces (load data)
@@ -252,9 +230,9 @@ Search data by required tags with loading data.
 ```typescript
 const searchDataLoadData = async () => {
     const skipData = false;
-    const pieces = await ddcClient.search(new Query(bucketId, [new Tag("type", "video")]), skipData);
-    console.log("Successfully searched pieces. CIDS: " + pieces.map(e => e.cid));
-}
+    const pieces = await ddcClient.search(new Query(bucketId, [new Tag('type', 'video')]), skipData);
+    console.log('Successfully searched pieces. CIDS: ' + pieces.map((e) => e.cid));
+};
 ```
 
 ### Disconnect

--- a/packages/ddc-client/package.json
+++ b/packages/ddc-client/package.json
@@ -29,7 +29,6 @@
         "clean": "rimraf dist package"
     },
     "dependencies": {
-        "@cere-ddc-sdk/core": "2.0.0-rc.4",
         "@cere-ddc-sdk/ddc": "2.0.0-rc.4",
         "@cere-ddc-sdk/file-storage": "2.0.0-rc.4",
         "@cere-ddc-sdk/smart-contract": "2.0.0-rc.4"

--- a/packages/ddc-client/src/DdcClient.ts
+++ b/packages/ddc-client/src/DdcClient.ts
@@ -1,17 +1,5 @@
 import {SmartContract, SmartContractOptions} from '@cere-ddc-sdk/smart-contract';
-import {
-    DagNode,
-    DagNodeResponse,
-    Router,
-    RouterConfig,
-    RouterOperation,
-    Signer,
-    UriSigner,
-    DagNodeStoreOptions,
-} from '@cere-ddc-sdk/ddc';
 import {FileStorage, File, FileStoreOptions, FileResponse, FileReadOptions} from '@cere-ddc-sdk/file-storage';
-
-import {DagNodeUri, DdcEntity, DdcUri, FileUri} from './DdcUri';
 
 import {
     BucketParams,
@@ -24,6 +12,20 @@ import {
     Offset,
 } from '@cere-ddc-sdk/smart-contract/types';
 
+import {
+    DagNode,
+    DagNodeResponse,
+    Router,
+    RouterConfig,
+    RouterOperation,
+    Signer,
+    UriSigner,
+    DagNodeStoreOptions,
+} from '@cere-ddc-sdk/ddc';
+
+import {DagNodeUri, DdcEntity, DdcUri, FileUri} from './DdcUri';
+import {TESTNET} from './presets';
+
 const MAX_BUCKET_SIZE = 5n;
 
 export type DdcClientConfig = Omit<RouterConfig, 'signer'> & {
@@ -34,19 +36,19 @@ export {FileStoreOptions, DagNodeStoreOptions};
 
 export class DdcClient {
     protected constructor(
-        readonly smartContract: SmartContract,
         private signer: Signer,
+        readonly smartContract: SmartContract,
         private fileStorage: FileStorage,
         private router: Router,
     ) {}
 
-    static async create(config: DdcClientConfig, uriOrSigner: Signer | string) {
+    static async create(uriOrSigner: Signer | string, config: DdcClientConfig = TESTNET) {
         const signer = typeof uriOrSigner === 'string' ? new UriSigner(uriOrSigner) : uriOrSigner;
         const contract = await SmartContract.buildAndConnect(signer, config.smartContract);
         const router = new Router({signer, nodes: config.nodes});
         const fs = new FileStorage(router);
 
-        return new DdcClient(contract, signer, fs, router);
+        return new DdcClient(signer, contract, fs, router);
     }
 
     async disconnect() {

--- a/packages/ddc-client/src/index.ts
+++ b/packages/ddc-client/src/index.ts
@@ -1,6 +1,8 @@
 export * from './DdcClient';
 export * from './DdcUri';
 
-export {TESTNET, DEVNET, STAGENET, MAINNET, type SmartContractOptions} from '@cere-ddc-sdk/smart-contract';
+export {type SmartContractOptions} from '@cere-ddc-sdk/smart-contract';
 export {KB, MB, DagNode, Tag, Link, DagNodeResponse, DagNodeStoreOptions} from '@cere-ddc-sdk/ddc';
 export {File, FileResponse, FileStoreOptions, FileReadOptions, FileContent} from '@cere-ddc-sdk/file-storage';
+
+export * from './presets';

--- a/packages/ddc-client/src/presets.ts
+++ b/packages/ddc-client/src/presets.ts
@@ -1,0 +1,29 @@
+import * as sc from '@cere-ddc-sdk/smart-contract';
+
+import type {DdcClientConfig} from './DdcClient';
+
+export const MAINNET: DdcClientConfig = {
+    smartContract: sc.MAINNET,
+    nodes: [],
+};
+
+export const DEVNET: DdcClientConfig = {
+    smartContract: sc.DEVNET,
+    nodes: [],
+};
+
+export const TESTNET: DdcClientConfig = {
+    smartContract: sc.TESTNET,
+    nodes: [
+        {rpcHost: '154.12.245.141:9090'},
+        {rpcHost: '154.12.245.141:9091'},
+        {rpcHost: '154.12.245.139:9090'},
+        {rpcHost: '154.12.245.139:9091'},
+        {rpcHost: '154.12.245.135:9090'},
+        {rpcHost: '154.12.245.135:9091'},
+        {rpcHost: '31.220.96.199:9090'},
+        {rpcHost: '31.220.96.199:9091'},
+        {rpcHost: '31.220.96.198:9090'},
+        {rpcHost: '31.220.96.198:9091'},
+    ],
+};

--- a/packages/file-storage/README.md
+++ b/packages/file-storage/README.md
@@ -1,23 +1,25 @@
 # @cere-ddc-sdk/file-storage
 
+> After the major update `v2.0.0` the documentation below is outdated and no longer relevant. It will be updated before the final release.
+
 Package for working with large data by splitting it to small pieces fixed size.
 
 Support commands:
 
-- `read` - read file as `Uint8Array` stream
-- `upload` - upload `Uint8Array` stream to DDC
+-   `read` - read file as `Uint8Array` stream
+-   `upload` - upload `Uint8Array` stream to DDC
 
 ## Example
 
 ### Setup
 
 ```typescript
-import {Scheme} from "@cere-ddc-sdk/core";
-import {FileStorage} from "@cere-ddc-sdk/file-storage";
+import {Scheme} from '@cere-ddc-sdk/core';
+import {FileStorage} from '@cere-ddc-sdk/file-storage';
 
-const signatureAlgorithm = "sr25519";
-const secretPhrase = "0x93e0153dc...";
-const cdnUlrl = "https://node-0.v2.us.cdn.testnet.cere.network"; // CDN cluster id or CDN url
+const signatureAlgorithm = 'sr25519';
+const secretPhrase = '0x93e0153dc...';
+const cdnUlrl = 'https://node-0.v2.us.cdn.testnet.cere.network'; // CDN cluster id or CDN url
 
 const fileStorage = FileStorage.build({clusterAddress: cdnUlrl, scheme: signatureAlgorithm}, cdnUlrl, secretPhrase);
 ```
@@ -30,7 +32,7 @@ Read data from DDC browser example.
 
 ```typescript
 const bucketId = 1n;
-const cid = "QmbWqxBE...";
+const cid = 'QmbWqxBE...';
 
 const fileStream: ReadableStream<Uint8Array> = fileStorage.read(bucketId, cid);
 ```
@@ -40,10 +42,10 @@ const fileStream: ReadableStream<Uint8Array> = fileStorage.read(bucketId, cid);
 Read data from DDC NodeJS example.
 
 ```typescript
-import * as streamWeb from "stream/web";
+import * as streamWeb from 'stream/web';
 
 const bucketId = 1n;
-const cid = "QmbWqxBE...";
+const cid = 'QmbWqxBE...';
 
 const fileStream: streamWeb.ReadableStream<Uint8Array> = fileStorage.read(bucketId, cid);
 ```
@@ -54,7 +56,7 @@ Download and decrypt data from DDC.
 
 ```typescript
 const bucketId = 1n;
-const cid = "bmbWqxBE...";
+const cid = 'bmbWqxBE...';
 const dek = new Uint8Array([1, 2, 3, 4]);
 
 const fileStream = fileStorage.readDecrypted(bucketId, cid, dek);
@@ -66,7 +68,7 @@ Download data by links.
 
 ```typescript
 const bucketId = 1n;
-const links = [new Link("bmbWqxBE..."), new Link("basddbEqasdxBE...")];
+const links = [new Link('bmbWqxBE...'), new Link('basddbEqasdxBE...')];
 const dek = new Uint8Array([1, 2, 3, 4]);
 
 const fileStream = fileStorage.readLinks(bucketId, links);
@@ -78,7 +80,7 @@ Download data and decrypt by links.
 
 ```typescript
 const bucketId = 1n;
-const links = [new Link("bmbWqxBE..."), new Link("basddbEqasdxBE...")];
+const links = [new Link('bmbWqxBE...'), new Link('basddbEqasdxBE...')];
 const dek = new Uint8Array([1, 2, 3, 4]);
 
 const fileStream = fileStorage.readLinks(bucketId, links, dek);
@@ -88,16 +90,16 @@ const fileStream = fileStorage.readLinks(bucketId, links, dek);
 
 Upload command support many types of data:
 
-- Browser:
-    - `ReadableStream<Uint8Array>`
-    - `Blob`
-    - url as`string`
-    - `Uint8Array`
-- NodeJS:
-    - `ReadableStream<Uint8Array>` from `node:stream/web`
-    - `Readable` from `node:stream`
-    - `PathLike` from `fs`
-    - `Uint8Array`
+-   Browser:
+    -   `ReadableStream<Uint8Array>`
+    -   `Blob`
+    -   url as`string`
+    -   `Uint8Array`
+-   NodeJS:
+    -   `ReadableStream<Uint8Array>` from `node:stream/web`
+    -   `Readable` from `node:stream`
+    -   `PathLike` from `fs`
+    -   `Uint8Array`
 
 #### Browser
 
@@ -115,9 +117,9 @@ const headPieceUri: Promise<PieceUri> = fileStorage.upload(bucketId, data);
 Upload data to DDC NodeJS example.
 
 ```typescript
-import * as streamWeb from "node:stream/web";
-import {Readable} from "node:stream";
-import {PathLike} from "fs";
+import * as streamWeb from 'node:stream/web';
+import {Readable} from 'node:stream';
+import {PathLike} from 'fs';
 
 let data: streamWeb.ReadableStream<Uint8Array> | Readable | PathLike | Uint8Array;
 const bucketId = 1n;
@@ -131,7 +133,7 @@ Upload encrypted data to DDC.
 
 ```typescript
 const bucketId = 1n;
-const encryptionOptions = {dekPath: "/data/secret", dek: dekBytes}
+const encryptionOptions = {dekPath: '/data/secret', dek: dekBytes};
 
 const headPieceUri: Promise<PieceUri> = fileStorage.uploadEncrypted(bucketId, data, encryptionOptions);
 ```

--- a/tests/v2/DdcClient.spec.ts
+++ b/tests/v2/DdcClient.spec.ts
@@ -7,18 +7,15 @@ describe('DDC Client', () => {
     let client: DdcClient;
 
     beforeAll(async () => {
-        client = await DdcClient.create(
-            {
-                smartContract: getContractOptions(),
-                nodes: [
-                    {rpcHost: 'localhost:9091'},
-                    {rpcHost: 'localhost:9092'},
-                    {rpcHost: 'localhost:9093'},
-                    {rpcHost: 'localhost:9094'},
-                ],
-            },
-            ROOT_USER_SEED,
-        );
+        client = await DdcClient.create(ROOT_USER_SEED, {
+            smartContract: getContractOptions(),
+            nodes: [
+                {rpcHost: 'localhost:9091'},
+                {rpcHost: 'localhost:9092'},
+                {rpcHost: 'localhost:9093'},
+                {rpcHost: 'localhost:9094'},
+            ],
+        });
     });
 
     afterAll(async () => {


### PR DESCRIPTION
Add DDC Client configuration presets:
- DEVNET
- TESTNET
- MAINNET

So we could hide temporary storage nodes hardcoded list from the SDK users.
Also changed the order of parameters in `DdcClient.create` to make the configuration default to TESTNET (braking but should be easy to fix)