### PR TITLE
Add test enabled flag to storage nodes

### DIFF
--- a/tests/setup/environment/ddc.ts
+++ b/tests/setup/environment/ddc.ts
@@ -13,11 +13,12 @@ export const startDDC = async (bc: Blockchain) => {
         .withEnv('BLOCKCHAIN_DDC_BUCKET_CONTRACT', bc.contractAddress)
         .withEnv('CLUSTER_ID', bc.clusterId.toString())
         .withEnv('HOST_IP', getHostIP())
-        .withWaitStrategy('ddc-cdn-node-0', Wait.forHealthCheck())
-        .withWaitStrategy('ddc-cdn-node-1', Wait.forHealthCheck())
-        .withWaitStrategy('ddc-storage-node-0', Wait.forHealthCheck())
+        // .withWaitStrategy('ddc-cdn-node-0', Wait.forHealthCheck())
+        // .withWaitStrategy('ddc-cdn-node-1', Wait.forHealthCheck())
         .withWaitStrategy('ddc-storage-node-1', Wait.forHealthCheck())
         .withWaitStrategy('ddc-storage-node-2', Wait.forHealthCheck())
+        .withWaitStrategy('ddc-storage-node-3', Wait.forHealthCheck())
+        .withWaitStrategy('ddc-storage-node-4', Wait.forHealthCheck())
         .up();
 
     console.log('The environment has started!');

--- a/tests/setup/environment/docker-compose.ddc.yml
+++ b/tests/setup/environment/docker-compose.ddc.yml
@@ -1,53 +1,56 @@
 version: "3.4"
 
 services:
-  ddc-cdn-node-0:
-    platform: linux/amd64
-    container_name: ddc-cdn-node-1
-    image: "625402836641.dkr.ecr.us-west-2.amazonaws.com/ddc-cdn-node:dev-latest"
-    environment:
-      - 'HTTP_PORT=8081'
-      - 'HTTP_ADDRESS=http://${HOST_IP}:8081'
-      - 'LOG_LEVEL=debug'
-      - 'LOG_JSON_FORMAT=false'
-      - 'NODE_SECRET_PHRASE=//Bob'
-      - "BLOCKCHAIN_API_URL=${BLOCKCHAIN_API_URL}"
-      - "BLOCKCHAIN_DDC_BUCKET_CONTRACT=${BLOCKCHAIN_DDC_BUCKET_CONTRACT}"
-      - "CLUSTER_ID=${CLUSTER_ID}"
-    ports:
-      - '8081:8081'
-    healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://${HOST_IP}:8081/info || exit 1
-      interval: 3s
-      timeout: 1s
-      retries: 5
-    depends_on:
-      redis:
-        condition: service_healthy
+  # CDN Nodes are currently not used in the test environment, so we can disable them for now.
+  # TODO: Enable CDN Nodes when they are needed
 
-  ddc-cdn-node-2:
-    platform: linux/amd64
-    container_name: ddc-cdn-node-2
-    image: "625402836641.dkr.ecr.us-west-2.amazonaws.com/ddc-cdn-node:dev-latest"
-    environment:
-      - 'HTTP_PORT=8082'
-      - 'HTTP_ADDRESS=http://${HOST_IP}:8082'
-      - 'LOG_LEVEL=debug'
-      - 'LOG_JSON_FORMAT=false'
-      - 'NODE_SECRET_PHRASE=//Dave'
-      - "BLOCKCHAIN_API_URL=${BLOCKCHAIN_API_URL}"
-      - "BLOCKCHAIN_DDC_BUCKET_CONTRACT=${BLOCKCHAIN_DDC_BUCKET_CONTRACT}"
-      - "CLUSTER_ID=${CLUSTER_ID}"
-    ports:
-      - '8082:8082'
-    healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://${HOST_IP}:8082/info || exit 1
-      interval: 3s
-      timeout: 1s
-      retries: 5
-    depends_on:
-      redis:
-        condition: service_healthy
+  # ddc-cdn-node-1:
+  #   platform: linux/amd64
+  #   container_name: ddc-cdn-node-1
+  #   image: "625402836641.dkr.ecr.us-west-2.amazonaws.com/ddc-cdn-node:dev-latest"
+  #   environment:
+  #     - 'HTTP_PORT=8081'
+  #     - 'HTTP_ADDRESS=http://${HOST_IP}:8081'
+  #     - 'LOG_LEVEL=debug'
+  #     - 'LOG_JSON_FORMAT=false'
+  #     - 'NODE_SECRET_PHRASE=//Bob'
+  #     - "BLOCKCHAIN_API_URL=${BLOCKCHAIN_API_URL}"
+  #     - "BLOCKCHAIN_DDC_BUCKET_CONTRACT=${BLOCKCHAIN_DDC_BUCKET_CONTRACT}"
+  #     - "CLUSTER_ID=${CLUSTER_ID}"
+  #   ports:
+  #     - '8081:8081'
+  #   healthcheck:
+  #     test: wget --no-verbose --tries=1 --spider http://${HOST_IP}:8081/info || exit 1
+  #     interval: 3s
+  #     timeout: 1s
+  #     retries: 5
+  #   depends_on:
+  #     redis:
+  #       condition: service_healthy
+
+  # ddc-cdn-node-2:
+  #   platform: linux/amd64
+  #   container_name: ddc-cdn-node-2
+  #   image: "625402836641.dkr.ecr.us-west-2.amazonaws.com/ddc-cdn-node:dev-latest"
+  #   environment:
+  #     - 'HTTP_PORT=8082'
+  #     - 'HTTP_ADDRESS=http://${HOST_IP}:8082'
+  #     - 'LOG_LEVEL=debug'
+  #     - 'LOG_JSON_FORMAT=false'
+  #     - 'NODE_SECRET_PHRASE=//Dave'
+  #     - "BLOCKCHAIN_API_URL=${BLOCKCHAIN_API_URL}"
+  #     - "BLOCKCHAIN_DDC_BUCKET_CONTRACT=${BLOCKCHAIN_DDC_BUCKET_CONTRACT}"
+  #     - "CLUSTER_ID=${CLUSTER_ID}"
+  #   ports:
+  #     - '8082:8082'
+  #   healthcheck:
+  #     test: wget --no-verbose --tries=1 --spider http://${HOST_IP}:8082/info || exit 1
+  #     interval: 3s
+  #     timeout: 1s
+  #     retries: 5
+  #   depends_on:
+  #     redis:
+  #       condition: service_healthy
 
   ddc-storage-node-1:
     platform: linux/amd64
@@ -82,9 +85,6 @@ services:
       interval: 3s
       timeout: 1s
       retries: 5
-    depends_on:
-      redis:
-        condition: service_healthy
 
   ddc-storage-node-2:
     platform: linux/amd64
@@ -119,9 +119,6 @@ services:
       interval: 3s
       timeout: 1s
       retries: 5
-    depends_on:
-      redis:
-        condition: service_healthy
 
   ddc-storage-node-3:
     platform: linux/amd64
@@ -156,9 +153,6 @@ services:
       interval: 3s
       timeout: 1s
       retries: 5
-    depends_on:
-      redis:
-        condition: service_healthy
 
   ddc-storage-node-4:
     platform: linux/amd64
@@ -193,26 +187,26 @@ services:
       interval: 3s
       timeout: 1s
       retries: 5
-    depends_on:
-      redis:
-        condition: service_healthy
 
-  redis:
-    image: 625402836641.dkr.ecr.us-west-2.amazonaws.com/dac-redis:dev-latest
-    container_name: redis
-    healthcheck:
-      test: ["CMD-SHELL", "/healthchecker-runner.sh || exit 1"]
-      interval: 10s
-      timeout: 10s
-      start_period: 10s
-      retries: 5
-    ports:
-      - "6379:6379"
+  # Redis is used by CDN Nodes only right now, so we can disable it along with CDN Nodes
+  # TODO: Maybe enable later if needed
 
-  webdis:
-    image: nicolas/webdis:0.1.21
-    container_name: webdis
-    environment:
-      REDIS_HOST: redis
-    ports:
-      - "7379:7379"
+  # redis:
+  #   image: 625402836641.dkr.ecr.us-west-2.amazonaws.com/dac-redis:dev-latest
+  #   container_name: redis
+  #   healthcheck:
+  #     test: ["CMD-SHELL", "/healthchecker-runner.sh || exit 1"]
+  #     interval: 10s
+  #     timeout: 10s
+  #     start_period: 10s
+  #     retries: 5
+  #   ports:
+  #     - "6379:6379"
+
+  # webdis:
+  #   image: nicolas/webdis:0.1.21
+  #   container_name: webdis
+  #   environment:
+  #     REDIS_HOST: redis
+  #   ports:
+  #     - "7379:7379"

--- a/tests/setup/environment/docker-compose.ddc.yml
+++ b/tests/setup/environment/docker-compose.ddc.yml
@@ -72,6 +72,7 @@ services:
       - "REDUNDANCY_ERASURE_CODING_REPAIR_THRESHOLD=2"
       - "REDUNDANCY_REPLICATION=3"
       - "P2P_MAX_MESSAGE_SIZE=68157440"
+      - "TEST_ENABLED=true"
     ports:
       - '8091:8091'
       - '9071:9071'
@@ -108,6 +109,7 @@ services:
       - "REDUNDANCY_ERASURE_CODING_REPAIR_THRESHOLD=2"
       - "REDUNDANCY_REPLICATION=3"
       - "P2P_MAX_MESSAGE_SIZE=68157440"
+      - "TEST_ENABLED=true"
     ports:
       - '8092:8092'
       - '9072:9072'
@@ -144,6 +146,7 @@ services:
       - "REDUNDANCY_ERASURE_CODING_REPAIR_THRESHOLD=2"
       - "REDUNDANCY_REPLICATION=3"
       - "P2P_MAX_MESSAGE_SIZE=68157440"
+      - "TEST_ENABLED=true"
     ports:
       - '8093:8093'
       - '9073:9073'
@@ -180,6 +183,7 @@ services:
       - "REDUNDANCY_ERASURE_CODING_REPAIR_THRESHOLD=2"
       - "REDUNDANCY_REPLICATION=3"
       - "P2P_MAX_MESSAGE_SIZE=68157440"
+      - "TEST_ENABLED=true"
     ports:
       - '8094:8094'
       - '9074:9074'

--- a/tests/v2/DdcClient.spec.ts
+++ b/tests/v2/DdcClient.spec.ts
@@ -165,7 +165,7 @@ describe('DDC Client', () => {
      *
      * TODO: Revise these methods during migration to palettes
      */
-    describe.skip('Blockhain operations', () => {
+    describe('Blockhain operations', () => {
         let createdBucketId: bigint;
 
         test('Account deposit', async () => {


### PR DESCRIPTION
- Set `TEST_ENABLED=true` flag to storage nodes to get proper peers  configuration
- Disabled CDN nodes and related services in the test env since they are not used for now