### PR TITLE
Align bucketId type

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -52,6 +52,9 @@ jobs:
             - name: Build packages
               run: npm run build
 
+            - name: Check types
+              run: npm run check-types:ci
+
             - name: Run integration tests
               if: ${{ !inputs.skipTests }}
               run: npm run test:ci

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,5 +45,8 @@ jobs:
             - name: Build packages
               run: npm run build
 
+            - name: Check types
+              run: npm run check-types:ci
+
             - name: Run integration tests
               run: npm run test:ci

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
         "release": "lerna version --exact --force-publish --preid rc",
         "release:no-push": "npm run release --no-push --no-git-tag-version",
         "release:publish": "lerna publish from-package",
+        "check-types": "tsc --noEmit",
+        "check-types:ci": "npm run check-types -- -p ./tsconfig.build.json",
         "playground": "npm start --workspace=@cere-ddc-sdk/playground"
     },
     "dependencies": {

--- a/packages/ddc-client/src/DdcClient.ts
+++ b/packages/ddc-client/src/DdcClient.ts
@@ -15,7 +15,9 @@ import {Blockchain, BucketId, ClusterId} from '@cere-ddc-sdk/blockchain';
 
 import {DagNodeUri, DdcEntity, DdcUri, FileUri} from './DdcUri';
 
-export type DdcClientConfig = ConfigPreset & {};
+export type DdcClientConfig = Omit<ConfigPreset, 'blockchain'> & {
+    blockchain: Blockchain | ConfigPreset['blockchain'];
+};
 
 export type {FileStoreOptions, DagNodeStoreOptions};
 
@@ -47,14 +49,14 @@ export class DdcClient {
         const result = await this.blockchain.send(this.blockchain.ddcCustomers.createBucket(clusterId));
         const [bucketId] = this.blockchain.ddcCustomers.extractCreatedBucketIds(result.events);
 
-        return {bucketId};
+        return bucketId;
     }
 
-    getBucket(bucketId: BucketId) {
+    async getBucket(bucketId: BucketId) {
         return this.blockchain.ddcCustomers.getBucket(bucketId);
     }
 
-    getBucketList() {
+    async getBucketList() {
         return this.blockchain.ddcCustomers.listBuckets();
     }
 
@@ -75,18 +77,17 @@ export class DdcClient {
     async store(bucketId: BucketId, entity: File, options?: FileStoreOptions): Promise<FileUri>;
     async store(bucketId: BucketId, entity: DagNode, options?: DagNodeStoreOptions): Promise<DagNodeUri>;
     async store(bucketId: BucketId, entity: File | DagNode, options?: FileStoreOptions | DagNodeStoreOptions) {
-        const numBucketId = Number(bucketId); // TODO: Convert bucketId to number everywhere
         const entityType: DdcEntity = entity instanceof File ? 'file' : 'dag-node';
 
         const cid =
             entity instanceof File
-                ? await this.fileStorage.store(numBucketId, entity, options)
-                : await this.storeDagNode(numBucketId, entity, options);
+                ? await this.fileStorage.store(bucketId, entity, options)
+                : await this.storeDagNode(bucketId, entity, options);
 
         return new DdcUri(bucketId, cid, entityType, options);
     }
 
-    private async storeDagNode(bucketId: number, node: DagNode, options?: DagNodeStoreOptions) {
+    private async storeDagNode(bucketId: BucketId, node: DagNode, options?: DagNodeStoreOptions) {
         const ddcNode = await this.router.getNode(RouterOperation.STORE_DAG_NODE, BigInt(bucketId));
 
         return ddcNode.storeDagNode(bucketId, node, options);
@@ -95,14 +96,12 @@ export class DdcClient {
     async read(uri: FileUri, options?: FileReadOptions): Promise<FileResponse>;
     async read(uri: DagNodeUri, options?: DagNodeGetOptions): Promise<DagNodeResponse>;
     async read(uri: DdcUri, options?: FileReadOptions | DagNodeGetOptions) {
-        const numBucketId = Number(uri.bucketId); // TODO: Convert bucketId to number everywhere
-
         if (uri.entity === 'file') {
-            return this.fileStorage.read(numBucketId, uri.cidOrName, options as FileReadOptions);
+            return this.fileStorage.read(uri.bucketId, uri.cidOrName, options as FileReadOptions);
         }
 
         const ddcNode = await this.router.getNode(RouterOperation.READ_DAG_NODE, uri.bucketId);
 
-        return ddcNode.getDagNode(numBucketId, uri.cidOrName, options as DagNodeGetOptions);
+        return ddcNode.getDagNode(uri.bucketId, uri.cidOrName, options as DagNodeGetOptions);
     }
 }

--- a/packages/ddc-client/src/index.ts
+++ b/packages/ddc-client/src/index.ts
@@ -23,3 +23,5 @@ export {
     type FileStoreOptions,
     type FileReadOptions,
 } from '@cere-ddc-sdk/file-storage';
+
+export type {BucketId, ClusterId, Bucket, AccountId} from '@cere-ddc-sdk/blockchain';

--- a/packages/ddc/package.json
+++ b/packages/ddc/package.json
@@ -23,6 +23,7 @@
         "build": "npm-run-all --parallel build:node build:web",
         "build:node": "microbundle --tsconfig tsconfig.node.json --format esm,cjs --target node",
         "build:web": "microbundle --tsconfig tsconfig.web.json --format modern --output dist/browser.js --alias stream/consumers=stream-consumers,stream/web=web-streams-polyfill/ponyfill/es2018",
+        "compile": "protoc --ts_opt long_type_number --ts_out ./src/grpc --proto_path protos ./protos/*.proto",
         "package": "clean-publish",
         "clean": "rimraf dist package"
     },

--- a/packages/ddc/protos/cns_api.proto
+++ b/packages/ddc/protos/cns_api.proto
@@ -22,14 +22,14 @@ service CnsApi {
 }
 
 message PutRequest {
-  uint64 bucketId = 1;
+  uint64 bucketId = 1 [jstype = JS_NORMAL];
   Record record = 2;
 }
 
 message PutResponse {}
 
 message GetRequest {
-  uint64 bucketId = 1;
+  uint64 bucketId = 1 [jstype = JS_NORMAL];
   string name = 2;
 }
 

--- a/packages/ddc/protos/dag_api.proto
+++ b/packages/ddc/protos/dag_api.proto
@@ -25,7 +25,7 @@ service DagApi {
 }
 
 message PutRequest {
-  uint64 BucketId = 1;
+  uint64 BucketId = 1 [jstype = JS_NORMAL];
   Node Node = 2;
 }
 
@@ -34,7 +34,7 @@ message PutResponse {
 }
 
 message GetRequest {
-  uint64 BucketId = 1;
+  uint64 BucketId = 1 [jstype = JS_NORMAL];
   bytes Cid = 2;
   optional string Path = 3;
 }

--- a/packages/ddc/protos/file_api.proto
+++ b/packages/ddc/protos/file_api.proto
@@ -12,7 +12,7 @@ service FileApi {
 
 message PutRawPieceRequest {
   message Metadata {
-    uint64 bucketId = 1;
+    uint64 bucketId = 1 [jstype = JS_NORMAL];
     optional bytes cid = 2;
     optional uint64 offset = 3; // starting offset of the piece inside a file. Should be set only if isMultipart = true
     bool isMultipart = 4; // whether the piece is part of a file or not
@@ -34,7 +34,7 @@ message PutRawPieceResponse {
 }
 
 message PutMultiPartPieceRequest {
-  uint64 bucketId = 1; // bucket where file is stored
+  uint64 bucketId = 1 [jstype = JS_NORMAL]; // bucket where file is stored
   optional bytes cid = 2; // root hash of the file hash tree
   uint64 totalSize = 3; // size of the multi-part piece (large file total size)
   uint64 partSize = 4; // size of the raw piece (large file part size)
@@ -49,7 +49,7 @@ message PutMultiPartPieceResponse {
 message GetFileRequest {
   message Request {
     bytes cid = 1; // CID of either raw or multi-part piece
-    uint64 bucketId = 2;
+    uint64 bucketId = 2 [jstype = JS_NORMAL];
     optional Range range = 3; // indicates part of the file to be returned (return whole file if range is missing)
 
     message Range {

--- a/packages/ddc/src/StorageNode.ts
+++ b/packages/ddc/src/StorageNode.ts
@@ -1,4 +1,4 @@
-import type {Signer} from '@cere-ddc-sdk/blockchain';
+import type {Signer, BucketId} from '@cere-ddc-sdk/blockchain';
 
 import {Cid} from './Cid';
 import {CnsApi} from './CnsApi';
@@ -39,7 +39,7 @@ export class StorageNode {
         this.cnsApi = new CnsApi(transport);
     }
 
-    async storePiece(bucketId: number, piece: Piece | MultipartPiece, options?: PieceStoreOptions) {
+    async storePiece(bucketId: BucketId, piece: Piece | MultipartPiece, options?: PieceStoreOptions) {
         let cidBytes: Uint8Array;
 
         if (piece instanceof MultipartPiece) {
@@ -69,7 +69,7 @@ export class StorageNode {
         return cid;
     }
 
-    async storeDagNode(bucketId: number, node: DagNode, options?: DagNodeStoreOptions) {
+    async storeDagNode(bucketId: BucketId, node: DagNode, options?: DagNodeStoreOptions) {
         const cidBytes = await this.dagApi.putNode({
             bucketId,
             node: mapDagNodeToAPI(node),
@@ -84,7 +84,7 @@ export class StorageNode {
         return cid;
     }
 
-    async readPiece(bucketId: number, cidOrName: string, options?: PieceReadOptions) {
+    async readPiece(bucketId: BucketId, cidOrName: string, options?: PieceReadOptions) {
         const cid = await this.resolveName(bucketId, cidOrName);
         const contentStream = await this.fileApi.getFile({
             bucketId,
@@ -97,7 +97,7 @@ export class StorageNode {
         });
     }
 
-    async getDagNode(bucketId: number, cidOrName: string, options?: DagNodeGetOptions) {
+    async getDagNode(bucketId: BucketId, cidOrName: string, options?: DagNodeGetOptions) {
         const cid = await this.resolveName(bucketId, cidOrName);
         const node = await this.dagApi.getNode({
             bucketId,
@@ -108,7 +108,7 @@ export class StorageNode {
         return node && new DagNodeResponse(cid, new Uint8Array(node.data), node.links, node.tags);
     }
 
-    async storeCnsRecord(bucketId: number, record: CnsRecord) {
+    async storeCnsRecord(bucketId: BucketId, record: CnsRecord) {
         if (!record.signature && this.signer) {
             await this.signer.isReady();
 
@@ -121,13 +121,13 @@ export class StorageNode {
         });
     }
 
-    async getCnsRecord(bucketId: number, name: string) {
+    async getCnsRecord(bucketId: BucketId, name: string) {
         const record = await this.cnsApi.getRecord({bucketId, name});
 
         return record && new CnsRecordResponse(record.cid, record.name, record.signature);
     }
 
-    async resolveName(bucketId: number, cidOrName: string) {
+    async resolveName(bucketId: BucketId, cidOrName: string) {
         if (Cid.isCid(cidOrName)) {
             return new Cid(cidOrName);
         }

--- a/packages/ddc/src/grpc/cns_api.ts
+++ b/packages/ddc/src/grpc/cns_api.ts
@@ -17,9 +17,9 @@ import { MessageType } from "@protobuf-ts/runtime";
  */
 export interface PutRequest {
     /**
-     * @generated from protobuf field: uint64 bucketId = 1;
+     * @generated from protobuf field: uint64 bucketId = 1 [jstype = JS_NORMAL];
      */
-    bucketId: number;
+    bucketId: bigint;
     /**
      * @generated from protobuf field: cns.Record record = 2;
      */
@@ -35,9 +35,9 @@ export interface PutResponse {
  */
 export interface GetRequest {
     /**
-     * @generated from protobuf field: uint64 bucketId = 1;
+     * @generated from protobuf field: uint64 bucketId = 1 [jstype = JS_NORMAL];
      */
-    bucketId: number;
+    bucketId: bigint;
     /**
      * @generated from protobuf field: string name = 2;
      */
@@ -103,12 +103,12 @@ export enum Record_Signature_Algorithm {
 class PutRequest$Type extends MessageType<PutRequest> {
     constructor() {
         super("cns.PutRequest", [
-            { no: 1, name: "bucketId", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
+            { no: 1, name: "bucketId", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
             { no: 2, name: "record", kind: "message", T: () => Record }
         ]);
     }
     create(value?: PartialMessage<PutRequest>): PutRequest {
-        const message = { bucketId: 0 };
+        const message = { bucketId: 0n };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<PutRequest>(this, message, value);
@@ -119,8 +119,8 @@ class PutRequest$Type extends MessageType<PutRequest> {
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* uint64 bucketId */ 1:
-                    message.bucketId = reader.uint64().toNumber();
+                case /* uint64 bucketId = 1 [jstype = JS_NORMAL];*/ 1:
+                    message.bucketId = reader.uint64().toBigInt();
                     break;
                 case /* cns.Record record */ 2:
                     message.record = Record.internalBinaryRead(reader, reader.uint32(), options, message.record);
@@ -137,8 +137,8 @@ class PutRequest$Type extends MessageType<PutRequest> {
         return message;
     }
     internalBinaryWrite(message: PutRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* uint64 bucketId = 1; */
-        if (message.bucketId !== 0)
+        /* uint64 bucketId = 1 [jstype = JS_NORMAL]; */
+        if (message.bucketId !== 0n)
             writer.tag(1, WireType.Varint).uint64(message.bucketId);
         /* cns.Record record = 2; */
         if (message.record)
@@ -183,12 +183,12 @@ export const PutResponse = new PutResponse$Type();
 class GetRequest$Type extends MessageType<GetRequest> {
     constructor() {
         super("cns.GetRequest", [
-            { no: 1, name: "bucketId", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
+            { no: 1, name: "bucketId", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
             { no: 2, name: "name", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<GetRequest>): GetRequest {
-        const message = { bucketId: 0, name: "" };
+        const message = { bucketId: 0n, name: "" };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<GetRequest>(this, message, value);
@@ -199,8 +199,8 @@ class GetRequest$Type extends MessageType<GetRequest> {
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* uint64 bucketId */ 1:
-                    message.bucketId = reader.uint64().toNumber();
+                case /* uint64 bucketId = 1 [jstype = JS_NORMAL];*/ 1:
+                    message.bucketId = reader.uint64().toBigInt();
                     break;
                 case /* string name */ 2:
                     message.name = reader.string();
@@ -217,8 +217,8 @@ class GetRequest$Type extends MessageType<GetRequest> {
         return message;
     }
     internalBinaryWrite(message: GetRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* uint64 bucketId = 1; */
-        if (message.bucketId !== 0)
+        /* uint64 bucketId = 1 [jstype = JS_NORMAL]; */
+        if (message.bucketId !== 0n)
             writer.tag(1, WireType.Varint).uint64(message.bucketId);
         /* string name = 2; */
         if (message.name !== "")

--- a/packages/ddc/src/grpc/dag_api.ts
+++ b/packages/ddc/src/grpc/dag_api.ts
@@ -17,9 +17,9 @@ import { MessageType } from "@protobuf-ts/runtime";
  */
 export interface PutRequest {
     /**
-     * @generated from protobuf field: uint64 BucketId = 1 [json_name = "BucketId"];
+     * @generated from protobuf field: uint64 BucketId = 1 [json_name = "BucketId", jstype = JS_NORMAL];
      */
-    bucketId: number;
+    bucketId: bigint;
     /**
      * @generated from protobuf field: dag.Node Node = 2 [json_name = "Node"];
      */
@@ -39,9 +39,9 @@ export interface PutResponse {
  */
 export interface GetRequest {
     /**
-     * @generated from protobuf field: uint64 BucketId = 1 [json_name = "BucketId"];
+     * @generated from protobuf field: uint64 BucketId = 1 [json_name = "BucketId", jstype = JS_NORMAL];
      */
-    bucketId: number;
+    bucketId: bigint;
     /**
      * @generated from protobuf field: bytes Cid = 2 [json_name = "Cid"];
      */
@@ -117,12 +117,12 @@ export interface Tag {
 class PutRequest$Type extends MessageType<PutRequest> {
     constructor() {
         super("dag.PutRequest", [
-            { no: 1, name: "BucketId", kind: "scalar", jsonName: "BucketId", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
+            { no: 1, name: "BucketId", kind: "scalar", jsonName: "BucketId", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
             { no: 2, name: "Node", kind: "message", jsonName: "Node", T: () => Node }
         ]);
     }
     create(value?: PartialMessage<PutRequest>): PutRequest {
-        const message = { bucketId: 0 };
+        const message = { bucketId: 0n };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<PutRequest>(this, message, value);
@@ -133,8 +133,8 @@ class PutRequest$Type extends MessageType<PutRequest> {
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* uint64 BucketId = 1 [json_name = "BucketId"];*/ 1:
-                    message.bucketId = reader.uint64().toNumber();
+                case /* uint64 BucketId = 1 [json_name = "BucketId", jstype = JS_NORMAL];*/ 1:
+                    message.bucketId = reader.uint64().toBigInt();
                     break;
                 case /* dag.Node Node = 2 [json_name = "Node"];*/ 2:
                     message.node = Node.internalBinaryRead(reader, reader.uint32(), options, message.node);
@@ -151,8 +151,8 @@ class PutRequest$Type extends MessageType<PutRequest> {
         return message;
     }
     internalBinaryWrite(message: PutRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* uint64 BucketId = 1 [json_name = "BucketId"]; */
-        if (message.bucketId !== 0)
+        /* uint64 BucketId = 1 [json_name = "BucketId", jstype = JS_NORMAL]; */
+        if (message.bucketId !== 0n)
             writer.tag(1, WireType.Varint).uint64(message.bucketId);
         /* dag.Node Node = 2 [json_name = "Node"]; */
         if (message.node)
@@ -218,13 +218,13 @@ export const PutResponse = new PutResponse$Type();
 class GetRequest$Type extends MessageType<GetRequest> {
     constructor() {
         super("dag.GetRequest", [
-            { no: 1, name: "BucketId", kind: "scalar", jsonName: "BucketId", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
+            { no: 1, name: "BucketId", kind: "scalar", jsonName: "BucketId", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
             { no: 2, name: "Cid", kind: "scalar", jsonName: "Cid", T: 12 /*ScalarType.BYTES*/ },
             { no: 3, name: "Path", kind: "scalar", jsonName: "Path", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<GetRequest>): GetRequest {
-        const message = { bucketId: 0, cid: new Uint8Array(0) };
+        const message = { bucketId: 0n, cid: new Uint8Array(0) };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<GetRequest>(this, message, value);
@@ -235,8 +235,8 @@ class GetRequest$Type extends MessageType<GetRequest> {
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* uint64 BucketId = 1 [json_name = "BucketId"];*/ 1:
-                    message.bucketId = reader.uint64().toNumber();
+                case /* uint64 BucketId = 1 [json_name = "BucketId", jstype = JS_NORMAL];*/ 1:
+                    message.bucketId = reader.uint64().toBigInt();
                     break;
                 case /* bytes Cid = 2 [json_name = "Cid"];*/ 2:
                     message.cid = reader.bytes();
@@ -256,8 +256,8 @@ class GetRequest$Type extends MessageType<GetRequest> {
         return message;
     }
     internalBinaryWrite(message: GetRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* uint64 BucketId = 1 [json_name = "BucketId"]; */
-        if (message.bucketId !== 0)
+        /* uint64 BucketId = 1 [json_name = "BucketId", jstype = JS_NORMAL]; */
+        if (message.bucketId !== 0n)
             writer.tag(1, WireType.Varint).uint64(message.bucketId);
         /* bytes Cid = 2 [json_name = "Cid"]; */
         if (message.cid.length)

--- a/packages/ddc/src/grpc/file_api.ts
+++ b/packages/ddc/src/grpc/file_api.ts
@@ -40,9 +40,9 @@ export interface PutRawPieceRequest {
  */
 export interface PutRawPieceRequest_Metadata {
     /**
-     * @generated from protobuf field: uint64 bucketId = 1;
+     * @generated from protobuf field: uint64 bucketId = 1 [jstype = JS_NORMAL];
      */
-    bucketId: number;
+    bucketId: bigint;
     /**
      * @generated from protobuf field: optional bytes cid = 2;
      */
@@ -79,9 +79,9 @@ export interface PutRawPieceResponse {
  */
 export interface PutMultiPartPieceRequest {
     /**
-     * @generated from protobuf field: uint64 bucketId = 1;
+     * @generated from protobuf field: uint64 bucketId = 1 [jstype = JS_NORMAL];
      */
-    bucketId: number; // bucket where file is stored
+    bucketId: bigint; // bucket where file is stored
     /**
      * @generated from protobuf field: optional bytes cid = 2;
      */
@@ -134,9 +134,9 @@ export interface GetFileRequest_Request {
      */
     cid: Uint8Array; // CID of either raw or multi-part piece
     /**
-     * @generated from protobuf field: uint64 bucketId = 2;
+     * @generated from protobuf field: uint64 bucketId = 2 [jstype = JS_NORMAL];
      */
-    bucketId: number;
+    bucketId: bigint;
     /**
      * @generated from protobuf field: optional file.GetFileRequest.Request.Range range = 3;
      */
@@ -251,14 +251,14 @@ export const PutRawPieceRequest = new PutRawPieceRequest$Type();
 class PutRawPieceRequest_Metadata$Type extends MessageType<PutRawPieceRequest_Metadata> {
     constructor() {
         super("file.PutRawPieceRequest.Metadata", [
-            { no: 1, name: "bucketId", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
+            { no: 1, name: "bucketId", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
             { no: 2, name: "cid", kind: "scalar", opt: true, T: 12 /*ScalarType.BYTES*/ },
             { no: 3, name: "offset", kind: "scalar", opt: true, T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
             { no: 4, name: "isMultipart", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
     create(value?: PartialMessage<PutRawPieceRequest_Metadata>): PutRawPieceRequest_Metadata {
-        const message = { bucketId: 0, isMultipart: false };
+        const message = { bucketId: 0n, isMultipart: false };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<PutRawPieceRequest_Metadata>(this, message, value);
@@ -269,8 +269,8 @@ class PutRawPieceRequest_Metadata$Type extends MessageType<PutRawPieceRequest_Me
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* uint64 bucketId */ 1:
-                    message.bucketId = reader.uint64().toNumber();
+                case /* uint64 bucketId = 1 [jstype = JS_NORMAL];*/ 1:
+                    message.bucketId = reader.uint64().toBigInt();
                     break;
                 case /* optional bytes cid */ 2:
                     message.cid = reader.bytes();
@@ -293,8 +293,8 @@ class PutRawPieceRequest_Metadata$Type extends MessageType<PutRawPieceRequest_Me
         return message;
     }
     internalBinaryWrite(message: PutRawPieceRequest_Metadata, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* uint64 bucketId = 1; */
-        if (message.bucketId !== 0)
+        /* uint64 bucketId = 1 [jstype = JS_NORMAL]; */
+        if (message.bucketId !== 0n)
             writer.tag(1, WireType.Varint).uint64(message.bucketId);
         /* optional bytes cid = 2; */
         if (message.cid !== undefined)
@@ -413,7 +413,7 @@ export const PutRawPieceResponse = new PutRawPieceResponse$Type();
 class PutMultiPartPieceRequest$Type extends MessageType<PutMultiPartPieceRequest> {
     constructor() {
         super("file.PutMultiPartPieceRequest", [
-            { no: 1, name: "bucketId", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
+            { no: 1, name: "bucketId", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
             { no: 2, name: "cid", kind: "scalar", opt: true, T: 12 /*ScalarType.BYTES*/ },
             { no: 3, name: "totalSize", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
             { no: 4, name: "partSize", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
@@ -421,7 +421,7 @@ class PutMultiPartPieceRequest$Type extends MessageType<PutMultiPartPieceRequest
         ]);
     }
     create(value?: PartialMessage<PutMultiPartPieceRequest>): PutMultiPartPieceRequest {
-        const message = { bucketId: 0, totalSize: 0, partSize: 0, partHashes: [] };
+        const message = { bucketId: 0n, totalSize: 0, partSize: 0, partHashes: [] };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<PutMultiPartPieceRequest>(this, message, value);
@@ -432,8 +432,8 @@ class PutMultiPartPieceRequest$Type extends MessageType<PutMultiPartPieceRequest
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* uint64 bucketId */ 1:
-                    message.bucketId = reader.uint64().toNumber();
+                case /* uint64 bucketId = 1 [jstype = JS_NORMAL];*/ 1:
+                    message.bucketId = reader.uint64().toBigInt();
                     break;
                 case /* optional bytes cid */ 2:
                     message.cid = reader.bytes();
@@ -459,8 +459,8 @@ class PutMultiPartPieceRequest$Type extends MessageType<PutMultiPartPieceRequest
         return message;
     }
     internalBinaryWrite(message: PutMultiPartPieceRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* uint64 bucketId = 1; */
-        if (message.bucketId !== 0)
+        /* uint64 bucketId = 1 [jstype = JS_NORMAL]; */
+        if (message.bucketId !== 0n)
             writer.tag(1, WireType.Varint).uint64(message.bucketId);
         /* optional bytes cid = 2; */
         if (message.cid !== undefined)
@@ -586,12 +586,12 @@ class GetFileRequest_Request$Type extends MessageType<GetFileRequest_Request> {
     constructor() {
         super("file.GetFileRequest.Request", [
             { no: 1, name: "cid", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
-            { no: 2, name: "bucketId", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 2 /*LongType.NUMBER*/ },
+            { no: 2, name: "bucketId", kind: "scalar", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
             { no: 3, name: "range", kind: "message", T: () => GetFileRequest_Request_Range }
         ]);
     }
     create(value?: PartialMessage<GetFileRequest_Request>): GetFileRequest_Request {
-        const message = { cid: new Uint8Array(0), bucketId: 0 };
+        const message = { cid: new Uint8Array(0), bucketId: 0n };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<GetFileRequest_Request>(this, message, value);
@@ -605,8 +605,8 @@ class GetFileRequest_Request$Type extends MessageType<GetFileRequest_Request> {
                 case /* bytes cid */ 1:
                     message.cid = reader.bytes();
                     break;
-                case /* uint64 bucketId */ 2:
-                    message.bucketId = reader.uint64().toNumber();
+                case /* uint64 bucketId = 2 [jstype = JS_NORMAL];*/ 2:
+                    message.bucketId = reader.uint64().toBigInt();
                     break;
                 case /* optional file.GetFileRequest.Request.Range range */ 3:
                     message.range = GetFileRequest_Request_Range.internalBinaryRead(reader, reader.uint32(), options, message.range);
@@ -626,8 +626,8 @@ class GetFileRequest_Request$Type extends MessageType<GetFileRequest_Request> {
         /* bytes cid = 1; */
         if (message.cid.length)
             writer.tag(1, WireType.LengthDelimited).bytes(message.cid);
-        /* uint64 bucketId = 2; */
-        if (message.bucketId !== 0)
+        /* uint64 bucketId = 2 [jstype = JS_NORMAL]; */
+        if (message.bucketId !== 0n)
             writer.tag(2, WireType.Varint).uint64(message.bucketId);
         /* optional file.GetFileRequest.Request.Range range = 3; */
         if (message.range)

--- a/packages/ddc/src/presets.ts
+++ b/packages/ddc/src/presets.ts
@@ -3,7 +3,7 @@ import {Blockchain} from '@cere-ddc-sdk/blockchain';
 import {RouterNode} from './Router';
 
 export type ConfigPreset = {
-    blockchain: Blockchain | string;
+    blockchain: string;
     nodes?: RouterNode[];
 };
 

--- a/packages/file-storage/src/FileStorage.ts
+++ b/packages/file-storage/src/FileStorage.ts
@@ -1,4 +1,4 @@
-import {Blockchain} from '@cere-ddc-sdk/blockchain';
+import {Blockchain, BucketId} from '@cere-ddc-sdk/blockchain';
 import {
     PieceReadOptions,
     MAX_PIECE_SIZE,
@@ -18,7 +18,10 @@ import {
 
 import {File, FileResponse} from './File';
 
-export type FileStorageConfig = ConfigPreset;
+export type FileStorageConfig = Omit<ConfigPreset, 'blockchain'> & {
+    blockchain: Blockchain | ConfigPreset['blockchain'];
+};
+
 export type FileReadOptions = PieceReadOptions;
 export type FileStoreOptions = PieceStoreOptions;
 
@@ -41,7 +44,7 @@ export class FileStorage {
         return new FileStorage(new Router({...config, blockchain, signer}));
     }
 
-    private async storeLarge(node: StorageNode, bucketId: number, file: File, options?: FileStoreOptions) {
+    private async storeLarge(node: StorageNode, bucketId: BucketId, file: File, options?: FileStoreOptions) {
         const parts = await splitStream(file.body, MAX_PIECE_SIZE, (content, multipartOffset) => {
             const piece = new Piece(content, {multipartOffset});
 
@@ -55,11 +58,11 @@ export class FileStorage {
         );
     }
 
-    private async storeSmall(node: StorageNode, bucketId: number, file: File, options?: FileStoreOptions) {
+    private async storeSmall(node: StorageNode, bucketId: BucketId, file: File, options?: FileStoreOptions) {
         return node.storePiece(bucketId, new Piece(file.body), options);
     }
 
-    async store(bucketId: number, file: File, options?: FileStoreOptions) {
+    async store(bucketId: BucketId, file: File, options?: FileStoreOptions) {
         const isLarge = file.size > MAX_PIECE_SIZE;
         const node = await this.router.getNode(RouterOperation.STORE_PIECE, BigInt(bucketId));
         const cid = isLarge
@@ -69,7 +72,7 @@ export class FileStorage {
         return cid;
     }
 
-    async read(bucketId: number, cidOrName: string, options?: FileReadOptions) {
+    async read(bucketId: BucketId, cidOrName: string, options?: FileReadOptions) {
         const node = await this.router.getNode(RouterOperation.READ_PIECE, BigInt(bucketId));
         const piece = await node.readPiece(bucketId, cidOrName, options);
 

--- a/tests/specs/DdcApis.spec.ts
+++ b/tests/specs/DdcApis.spec.ts
@@ -29,7 +29,7 @@ const transports = [
 describe.each(transports)('DDC APIs ($name)', ({transport}) => {
     let signer: Signer;
 
-    const bucketId = 1;
+    const bucketId = 1n;
     const dagApi = new DagApi(transport);
     const fileApi = new FileApi(transport);
     const cnsApi = new CnsApi(transport);

--- a/tests/specs/DdcClient.spec.ts
+++ b/tests/specs/DdcClient.spec.ts
@@ -189,9 +189,7 @@ describe('DDC Client', () => {
         const clusterId = '0x0000000000000000000000000000000000000000';
 
         test('Create bucket', async () => {
-            const bucket = await client.createBucket(clusterId);
-
-            createdBucketId = bucket.bucketId;
+            createdBucketId = await client.createBucket(clusterId);
 
             expect(createdBucketId).toEqual(expect.any(BigInt));
         });

--- a/tests/specs/FileStorage.spec.ts
+++ b/tests/specs/FileStorage.spec.ts
@@ -8,7 +8,7 @@ import {FileStorage, File, UriSigner} from '@cere-ddc-sdk/file-storage';
 import {createDataStream, getStorageNodes, MB, ROOT_USER_SEED} from '../helpers';
 
 describe('File storage', () => {
-    const bucketId = 1;
+    const bucketId = 1n;
     const fileStorage = new FileStorage({
         signer: new UriSigner(ROOT_USER_SEED),
         nodes: getStorageNodes(),

--- a/tests/specs/StorageNode.spec.ts
+++ b/tests/specs/StorageNode.spec.ts
@@ -12,7 +12,7 @@ import {
 import {createDataStream, MB, DDC_BLOCK_SIZE, ROOT_USER_SEED, getStorageNodes} from '../helpers';
 
 describe('Storage Node', () => {
-    const bucketId = 1;
+    const bucketId = 1n;
     const [storageNodeParams] = getStorageNodes();
     const storageNode = new StorageNode(new UriSigner(ROOT_USER_SEED), storageNodeParams);
 


### PR DESCRIPTION
- Export blockchain types (`BucketId`, `ClusterId`, ...) from. `ddc-client` package for easier access
- Align all bucket id usages to blockchain `BucketId` type (JS `bigint`)