### PR TITLE
Use multiformats base32 to encode/decode CIDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14081,6 +14081,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/multimatch": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
@@ -20396,6 +20406,7 @@
       },
       "devDependencies": {
         "@protobuf-ts/plugin": "^2.9.1",
+        "multiformats": "^12.1.3",
         "stream-consumers": "^1.0.2",
         "web-streams-polyfill": "^3.2.1"
       }

--- a/packages/ddc/package.json
+++ b/packages/ddc/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@protobuf-ts/plugin": "^2.9.1",
+    "multiformats": "^12.1.3",
     "stream-consumers": "^1.0.2",
     "web-streams-polyfill": "^3.2.1"
   },

--- a/packages/ddc/src/Cid.ts
+++ b/packages/ddc/src/Cid.ts
@@ -1,4 +1,4 @@
-import { base32 } from 'rfc4648';
+import { base32 } from 'multiformats/bases/base32';
 
 export class Cid {
   private cid: Uint8Array | string;
@@ -12,11 +12,11 @@ export class Cid {
   }
 
   toString() {
-    return typeof this.cid === 'string' ? this.cid : base32.stringify(this.cid, { pad: false });
+    return typeof this.cid === 'string' ? this.cid : base32.encode(this.cid);
   }
 
   toBytes() {
-    return typeof this.cid === 'string' ? base32.parse(this.cid, { loose: true }) : this.cid;
+    return typeof this.cid === 'string' ? base32.decode(this.cid) : this.cid;
   }
 
   static isCid(cid: string | Uint8Array) {

--- a/tests/setup/environment/docker-compose.blockchain.ci.yml
+++ b/tests/setup/environment/docker-compose.blockchain.ci.yml
@@ -4,7 +4,9 @@ services:
   cere-chain:
     platform: linux/amd64
     container_name: cere-chain
-    image: "625402836641.dkr.ecr.us-west-2.amazonaws.com/pos-network-node:dev-latest"
+    # TODO: Switch back to dev-latest tag when the polkadot-js compatibility issue is resolved:
+    # https://cere-network.slack.com/archives/C01ALH83YVB/p1700715684686459?thread_ts=1700651433.622179&cid=C01ALH83YVB
+    image: "625402836641.dkr.ecr.us-west-2.amazonaws.com/pos-network-node@sha256:afb8ace97dc381fdf593668f4b3598bedace2eaa7a4cf0653da7768bc3b49117"
     command: bash -c "/usr/local/bin/cere --dev --alice --ws-external --rpc-external"
     ports:
       - "9944:9944"

--- a/tests/setup/environment/docker-compose.blockchain.yml
+++ b/tests/setup/environment/docker-compose.blockchain.yml
@@ -4,7 +4,9 @@ services:
   cere-chain:
     platform: linux/amd64
     container_name: cere-chain
-    image: "625402836641.dkr.ecr.us-west-2.amazonaws.com/pos-network-node:dev-latest"
+    # TODO: Switch back to dev-latest tag when the polkadot-js compatibility issue is resolved:
+    # https://cere-network.slack.com/archives/C01ALH83YVB/p1700715684686459?thread_ts=1700651433.622179&cid=C01ALH83YVB
+    image: "625402836641.dkr.ecr.us-west-2.amazonaws.com/pos-network-node@sha256:afb8ace97dc381fdf593668f4b3598bedace2eaa7a4cf0653da7768bc3b49117"
     command: bash -c "/usr/local/bin/cere --dev --alice --base-path ./data --ws-external --rpc-external"
     ports:
       - "9944:9944"

--- a/tests/specs/DdcApis.spec.ts
+++ b/tests/specs/DdcApis.spec.ts
@@ -121,7 +121,7 @@ describe.each(transports)('DDC APIs ($name)', ({ transport }) => {
   describe('Cns Api', () => {
     let signature: any;
 
-    const testCid = new Cid('AEBB4IEIDC5HNY76TBBV5CK5WQT7FXCGNJATYVLW5WRMJ7IMNOQECYYCDQ').toBytes();
+    const testCid = new Cid('baebb4ifbvlaklsqk4ex2n2xfaghhrkd3bbqg53d2du4sdgsz7uixt25ycu').toBytes();
     const alias = 'dir/file-name';
 
     test('Create alias', async () => {

--- a/tests/specs/StorageNode.spec.ts
+++ b/tests/specs/StorageNode.spec.ts
@@ -207,7 +207,7 @@ describe('Storage Node', () => {
   describe('CNS record', () => {
     let signature: any;
 
-    const testCid = 'AEBB4IEIDC5HNY76TBBV5CK5WQT7FXCGNJATYVLW5WRMJ7IMNOQECYYCDQ';
+    const testCid = 'baebb4ifbvlaklsqk4ex2n2xfaghhrkd3bbqg53d2du4sdgsz7uixt25ycu';
     const testName = 'piece/name';
 
     test('Store a record', async () => {


### PR DESCRIPTION
- Switch to [multiformats](https://www.npmjs.com/package/multiformats) to encode/decode CIDs
- Use only `base32` base to encode/decode CIDs, later we can add more decoding bases, just need to decide on the list

> Temporarily switched tests to use older version of blockchain nodes, since the last version introduces some braking changes which brakes tests. Since the latest BC version is not yet deployed to testnet we can temporarily fix tests to unblock S&T   