### PR TITLE
Add runtime type guards to major input entities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4432,24 +4432,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@polkadot/api-augment/node_modules/@polkadot/types": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.4.1.tgz",
-      "integrity": "sha512-vUPHqlBS5neNmI+8IgJxywCL3izdCgd3SrMKWM/xlxzhGh8zfBXaGiRu1sreEk4yuNCAMMWYYDp+eqecZ6wXGA==",
-      "dependencies": {
-        "@babel/runtime": "^7.19.0",
-        "@polkadot/keyring": "^10.1.8",
-        "@polkadot/types-augment": "9.4.1",
-        "@polkadot/types-codec": "9.4.1",
-        "@polkadot/types-create": "9.4.1",
-        "@polkadot/util": "^10.1.8",
-        "@polkadot/util-crypto": "^10.1.8",
-        "rxjs": "^7.5.6"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@polkadot/api-base": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-9.4.1.tgz",
@@ -4459,24 +4441,6 @@
         "@polkadot/rpc-core": "9.4.1",
         "@polkadot/types": "9.4.1",
         "@polkadot/util": "^10.1.8",
-        "rxjs": "^7.5.6"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@polkadot/api-base/node_modules/@polkadot/types": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.4.1.tgz",
-      "integrity": "sha512-vUPHqlBS5neNmI+8IgJxywCL3izdCgd3SrMKWM/xlxzhGh8zfBXaGiRu1sreEk4yuNCAMMWYYDp+eqecZ6wXGA==",
-      "dependencies": {
-        "@babel/runtime": "^7.19.0",
-        "@polkadot/keyring": "^10.1.8",
-        "@polkadot/types-augment": "9.4.1",
-        "@polkadot/types-codec": "9.4.1",
-        "@polkadot/types-create": "9.4.1",
-        "@polkadot/util": "^10.1.8",
-        "@polkadot/util-crypto": "^10.1.8",
         "rxjs": "^7.5.6"
       },
       "engines": {
@@ -4501,24 +4465,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@polkadot/api-contract/node_modules/@polkadot/types": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.4.1.tgz",
-      "integrity": "sha512-vUPHqlBS5neNmI+8IgJxywCL3izdCgd3SrMKWM/xlxzhGh8zfBXaGiRu1sreEk4yuNCAMMWYYDp+eqecZ6wXGA==",
-      "dependencies": {
-        "@babel/runtime": "^7.19.0",
-        "@polkadot/keyring": "^10.1.8",
-        "@polkadot/types-augment": "9.4.1",
-        "@polkadot/types-codec": "9.4.1",
-        "@polkadot/types-create": "9.4.1",
-        "@polkadot/util": "^10.1.8",
-        "@polkadot/util-crypto": "^10.1.8",
-        "rxjs": "^7.5.6"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@polkadot/api-derive": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-9.4.1.tgz",
@@ -4531,42 +4477,6 @@
         "@polkadot/rpc-core": "9.4.1",
         "@polkadot/types": "9.4.1",
         "@polkadot/types-codec": "9.4.1",
-        "@polkadot/util": "^10.1.8",
-        "@polkadot/util-crypto": "^10.1.8",
-        "rxjs": "^7.5.6"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@polkadot/api-derive/node_modules/@polkadot/types": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.4.1.tgz",
-      "integrity": "sha512-vUPHqlBS5neNmI+8IgJxywCL3izdCgd3SrMKWM/xlxzhGh8zfBXaGiRu1sreEk4yuNCAMMWYYDp+eqecZ6wXGA==",
-      "dependencies": {
-        "@babel/runtime": "^7.19.0",
-        "@polkadot/keyring": "^10.1.8",
-        "@polkadot/types-augment": "9.4.1",
-        "@polkadot/types-codec": "9.4.1",
-        "@polkadot/types-create": "9.4.1",
-        "@polkadot/util": "^10.1.8",
-        "@polkadot/util-crypto": "^10.1.8",
-        "rxjs": "^7.5.6"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@polkadot/api/node_modules/@polkadot/types": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.4.1.tgz",
-      "integrity": "sha512-vUPHqlBS5neNmI+8IgJxywCL3izdCgd3SrMKWM/xlxzhGh8zfBXaGiRu1sreEk4yuNCAMMWYYDp+eqecZ6wXGA==",
-      "dependencies": {
-        "@babel/runtime": "^7.19.0",
-        "@polkadot/keyring": "^10.1.8",
-        "@polkadot/types-augment": "9.4.1",
-        "@polkadot/types-codec": "9.4.1",
-        "@polkadot/types-create": "9.4.1",
         "@polkadot/util": "^10.1.8",
         "@polkadot/util-crypto": "^10.1.8",
         "rxjs": "^7.5.6"
@@ -4620,24 +4530,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@polkadot/rpc-augment/node_modules/@polkadot/types": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.4.1.tgz",
-      "integrity": "sha512-vUPHqlBS5neNmI+8IgJxywCL3izdCgd3SrMKWM/xlxzhGh8zfBXaGiRu1sreEk4yuNCAMMWYYDp+eqecZ6wXGA==",
-      "dependencies": {
-        "@babel/runtime": "^7.19.0",
-        "@polkadot/keyring": "^10.1.8",
-        "@polkadot/types-augment": "9.4.1",
-        "@polkadot/types-codec": "9.4.1",
-        "@polkadot/types-create": "9.4.1",
-        "@polkadot/util": "^10.1.8",
-        "@polkadot/util-crypto": "^10.1.8",
-        "rxjs": "^7.5.6"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@polkadot/rpc-core": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-9.4.1.tgz",
@@ -4648,24 +4540,6 @@
         "@polkadot/rpc-provider": "9.4.1",
         "@polkadot/types": "9.4.1",
         "@polkadot/util": "^10.1.8",
-        "rxjs": "^7.5.6"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@polkadot/rpc-core/node_modules/@polkadot/types": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.4.1.tgz",
-      "integrity": "sha512-vUPHqlBS5neNmI+8IgJxywCL3izdCgd3SrMKWM/xlxzhGh8zfBXaGiRu1sreEk4yuNCAMMWYYDp+eqecZ6wXGA==",
-      "dependencies": {
-        "@babel/runtime": "^7.19.0",
-        "@polkadot/keyring": "^10.1.8",
-        "@polkadot/types-augment": "9.4.1",
-        "@polkadot/types-codec": "9.4.1",
-        "@polkadot/types-create": "9.4.1",
-        "@polkadot/util": "^10.1.8",
-        "@polkadot/util-crypto": "^10.1.8",
         "rxjs": "^7.5.6"
       },
       "engines": {
@@ -4695,7 +4569,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/types": {
+    "node_modules/@polkadot/types": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.4.1.tgz",
       "integrity": "sha512-vUPHqlBS5neNmI+8IgJxywCL3izdCgd3SrMKWM/xlxzhGh8zfBXaGiRu1sreEk4yuNCAMMWYYDp+eqecZ6wXGA==",
@@ -4708,24 +4582,6 @@
         "@polkadot/util": "^10.1.8",
         "@polkadot/util-crypto": "^10.1.8",
         "rxjs": "^7.5.6"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@polkadot/types": {
-      "version": "9.14.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.14.2.tgz",
-      "integrity": "sha512-hGLddTiJbvowhhUZJ3k+olmmBc1KAjWIQxujIUIYASih8FQ3/YJDKxaofGOzh0VygOKW3jxQBN2VZPofyDP9KQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@polkadot/keyring": "^10.4.2",
-        "@polkadot/types-augment": "9.14.2",
-        "@polkadot/types-codec": "9.14.2",
-        "@polkadot/types-create": "9.14.2",
-        "@polkadot/util": "^10.4.2",
-        "@polkadot/util-crypto": "^10.4.2",
-        "rxjs": "^7.8.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -4740,24 +4596,6 @@
         "@polkadot/types": "9.4.1",
         "@polkadot/types-codec": "9.4.1",
         "@polkadot/util": "^10.1.8"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@polkadot/types-augment/node_modules/@polkadot/types": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.4.1.tgz",
-      "integrity": "sha512-vUPHqlBS5neNmI+8IgJxywCL3izdCgd3SrMKWM/xlxzhGh8zfBXaGiRu1sreEk4yuNCAMMWYYDp+eqecZ6wXGA==",
-      "dependencies": {
-        "@babel/runtime": "^7.19.0",
-        "@polkadot/keyring": "^10.1.8",
-        "@polkadot/types-augment": "9.4.1",
-        "@polkadot/types-codec": "9.4.1",
-        "@polkadot/types-create": "9.4.1",
-        "@polkadot/util": "^10.1.8",
-        "@polkadot/util-crypto": "^10.1.8",
-        "rxjs": "^7.5.6"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -4805,24 +4643,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@polkadot/types-known/node_modules/@polkadot/types": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.4.1.tgz",
-      "integrity": "sha512-vUPHqlBS5neNmI+8IgJxywCL3izdCgd3SrMKWM/xlxzhGh8zfBXaGiRu1sreEk4yuNCAMMWYYDp+eqecZ6wXGA==",
-      "dependencies": {
-        "@babel/runtime": "^7.19.0",
-        "@polkadot/keyring": "^10.1.8",
-        "@polkadot/types-augment": "9.4.1",
-        "@polkadot/types-codec": "9.4.1",
-        "@polkadot/types-create": "9.4.1",
-        "@polkadot/util": "^10.1.8",
-        "@polkadot/util-crypto": "^10.1.8",
-        "rxjs": "^7.5.6"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@polkadot/types-support": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.4.1.tgz",
@@ -4830,46 +4650,6 @@
       "dependencies": {
         "@babel/runtime": "^7.19.0",
         "@polkadot/util": "^10.1.8"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@polkadot/types/node_modules/@polkadot/types-augment": {
-      "version": "9.14.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.14.2.tgz",
-      "integrity": "sha512-WO9d7RJufUeY3iFgt2Wz762kOu1tjEiGBR5TT4AHtpEchVHUeosVTrN9eycC+BhleqYu52CocKz6u3qCT/jKLg==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@polkadot/types": "9.14.2",
-        "@polkadot/types-codec": "9.14.2",
-        "@polkadot/util": "^10.4.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@polkadot/types/node_modules/@polkadot/types-codec": {
-      "version": "9.14.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.14.2.tgz",
-      "integrity": "sha512-AJ4XF7W1no4PENLBRU955V6gDxJw0h++EN3YoDgThozZ0sj3OxyFupKgNBZcZb2V23H8JxQozzIad8k+nJbO1w==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@polkadot/util": "^10.4.2",
-        "@polkadot/x-bigint": "^10.4.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@polkadot/types/node_modules/@polkadot/types-create": {
-      "version": "9.14.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.14.2.tgz",
-      "integrity": "sha512-nSnKpBierlmGBQT8r6/SHf6uamBIzk4WmdMsAsR4uJKJF1PtbIqx2W5PY91xWSiMSNMzjkbCppHkwaDAMwLGaw==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@polkadot/types-codec": "9.14.2",
-        "@polkadot/util": "^10.4.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -5436,9 +5216,9 @@
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.5.1.tgz",
-      "integrity": "sha512-YaN43wTyEBaMqLDYeze+gQ4ZrW5RbTEGtT5o1GVDkhpdNcsLTnLRcLccvwy3E9wiDKWg9RIhuoy3JQKDRBfaZA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.6.0.tgz",
+      "integrity": "sha512-keHkkWAe7OtdALGoutLY3utvthkGF+Y17ws9LYT8pxMBYXaCoH/8dXS2uzo6e8+sEhY7y/zi5RFo22Dy2lFpDw==",
       "cpu": [
         "arm"
       ],
@@ -5449,9 +5229,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.5.1.tgz",
-      "integrity": "sha512-n1bX+LCGlQVuPlCofO0zOKe1b2XkFozAVRoczT+yxWZPGnkEAKTTYVOGZz8N4sKuBnKMxDbfhUsB1uwYdup/sw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.6.0.tgz",
+      "integrity": "sha512-y3Kt+34smKQNWilicPbBz/MXEY7QwDzMFNgwEWeYiOhUt9MTWKjHqe3EVkXwT2fR7izOvHpDWZ0o2IyD9SWX7A==",
       "cpu": [
         "arm64"
       ],
@@ -5462,9 +5242,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.5.1.tgz",
-      "integrity": "sha512-QqJBumdvfBqBBmyGHlKxje+iowZwrHna7pokj/Go3dV1PJekSKfmjKrjKQ/e6ESTGhkfPNLq3VXdYLAc+UtAQw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.6.0.tgz",
+      "integrity": "sha512-oLzzxcUIHltHxOCmaXl+pkIlU+uhSxef5HfntW7RsLh1eHm+vJzjD9Oo4oUKso4YuP4PpbFJNlZjJuOrxo8dPg==",
       "cpu": [
         "arm64"
       ],
@@ -5475,9 +5255,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.5.1.tgz",
-      "integrity": "sha512-RrkDNkR/P5AEQSPkxQPmd2ri8WTjSl0RYmuFOiEABkEY/FSg0a4riihWQGKDJ4LnV9gigWZlTMx2DtFGzUrYQw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.6.0.tgz",
+      "integrity": "sha512-+ANnmjkcOBaV25n0+M0Bere3roeVAnwlKW65qagtuAfIxXF9YxUneRyAn/RDcIdRa7QrjRNJL3jR7T43ObGe8Q==",
       "cpu": [
         "x64"
       ],
@@ -5488,9 +5268,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.5.1.tgz",
-      "integrity": "sha512-ZFPxvUZmE+fkB/8D9y/SWl/XaDzNSaxd1TJUSE27XAKlRpQ2VNce/86bGd9mEUgL3qrvjJ9XTGwoX0BrJkYK/A==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.6.0.tgz",
+      "integrity": "sha512-tBTSIkjSVUyrekddpkAqKOosnj1Fc0ZY0rJL2bIEWPKqlEQk0paORL9pUIlt7lcGJi3LzMIlUGXvtNi1Z6MOCQ==",
       "cpu": [
         "arm"
       ],
@@ -5501,9 +5281,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.5.1.tgz",
-      "integrity": "sha512-FEuAjzVIld5WVhu+M2OewLmjmbXWd3q7Zcx+Rwy4QObQCqfblriDMMS7p7+pwgjZoo9BLkP3wa9uglQXzsB9ww==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.6.0.tgz",
+      "integrity": "sha512-Ed8uJI3kM11de9S0j67wAV07JUNhbAqIrDYhQBrQW42jGopgheyk/cdcshgGO4fW5Wjq97COCY/BHogdGvKVNQ==",
       "cpu": [
         "arm64"
       ],
@@ -5514,9 +5294,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.5.1.tgz",
-      "integrity": "sha512-f5Gs8WQixqGRtI0Iq/cMqvFYmgFzMinuJO24KRfnv7Ohi/HQclwrBCYkzQu1XfLEEt3DZyvveq9HWo4bLJf1Lw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.6.0.tgz",
+      "integrity": "sha512-mZoNQ/qK4D7SSY8v6kEsAAyDgznzLLuSFCA3aBHZTmf3HP/dW4tNLTtWh9+LfyO0Z1aUn+ecpT7IQ3WtIg3ViQ==",
       "cpu": [
         "arm64"
       ],
@@ -5527,9 +5307,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.5.1.tgz",
-      "integrity": "sha512-CWPkPGrFfN2vj3mw+S7A/4ZaU3rTV7AkXUr08W9lNP+UzOvKLVf34tWCqrKrfwQ0NTk5GFqUr2XGpeR2p6R4gw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.6.0.tgz",
+      "integrity": "sha512-rouezFHpwCqdEXsqAfNsTgSWO0FoZ5hKv5p+TGO5KFhyN/dvYXNMqMolOb8BkyKcPqjYRBeT+Z6V3aM26rPaYg==",
       "cpu": [
         "x64"
       ],
@@ -5540,9 +5320,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.5.1.tgz",
-      "integrity": "sha512-ZRETMFA0uVukUC9u31Ed1nx++29073goCxZtmZARwk5aF/ltuENaeTtRVsSQzFlzdd4J6L3qUm+EW8cbGt0CKQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.6.0.tgz",
+      "integrity": "sha512-Bbm+fyn3S6u51urfj3YnqBXg5vI2jQPncRRELaucmhBVyZkbWClQ1fEsRmdnCPpQOQfkpg9gZArvtMVkOMsh1w==",
       "cpu": [
         "x64"
       ],
@@ -5553,9 +5333,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.5.1.tgz",
-      "integrity": "sha512-ihqfNJNb2XtoZMSCPeoo0cYMgU04ksyFIoOw5S0JUVbOhafLot+KD82vpKXOurE2+9o/awrqIxku9MRR9hozHQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.6.0.tgz",
+      "integrity": "sha512-+MRMcyx9L2kTrTUzYmR61+XVsliMG4odFb5UmqtiT8xOfEicfYAGEuF/D1Pww1+uZkYhBqAHpvju7VN+GnC3ng==",
       "cpu": [
         "arm64"
       ],
@@ -5566,9 +5346,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.5.1.tgz",
-      "integrity": "sha512-zK9MRpC8946lQ9ypFn4gLpdwr5a01aQ/odiIJeL9EbgZDMgbZjjT/XzTqJvDfTmnE1kHdbG20sAeNlpc91/wbg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.6.0.tgz",
+      "integrity": "sha512-rxfeE6K6s/Xl2HGeK6cO8SiQq3k/3BYpw7cfhW5Bk2euXNEpuzi2cc7llxx1si1QgwfjNtdRNTGqdBzGlFZGFw==",
       "cpu": [
         "ia32"
       ],
@@ -5579,9 +5359,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.5.1.tgz",
-      "integrity": "sha512-5I3Nz4Sb9TYOtkRwlH0ow+BhMH2vnh38tZ4J4mggE48M/YyJyp/0sPSxhw1UeS1+oBgQ8q7maFtSeKpeRJu41Q==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.6.0.tgz",
+      "integrity": "sha512-QqmCsydHS172Y0Kc13bkMXvipbJSvzeglBncJG3LsYJSiPlxYACz7MmJBs4A8l1oU+jfhYEIC/+AUSlvjmiX/g==",
       "cpu": [
         "x64"
       ],
@@ -6254,11 +6034,12 @@
       "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A=="
     },
     "node_modules/@types/ssh2": {
-      "version": "1.11.17",
-      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.11.17.tgz",
-      "integrity": "sha512-owd0cyrAzaUICWvgpvwg7mMZcPvY4pH2Zs3fg0dgT+I/O9+kFJ4i+AUrX82INWJtEHbX70ubnSVqWJvt2VxmqQ==",
+      "version": "0.5.52",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.52.tgz",
+      "integrity": "sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==",
       "dependencies": {
-        "@types/node": "^18.11.18"
+        "@types/node": "*",
+        "@types/ssh2-streams": "*"
       }
     },
     "node_modules/@types/ssh2-streams": {
@@ -6781,14 +6562,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/archiver-utils/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
     },
     "node_modules/are-we-there-yet": {
       "version": "3.0.1",
@@ -12845,14 +12618,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
-    "node_modules/lazystream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/lerna": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/lerna/-/lerna-8.0.0.tgz",
@@ -15793,9 +15558,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.3.tgz",
-      "integrity": "sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -18351,15 +18116,6 @@
         "ssh2": "^1.4.0"
       }
     },
-    "node_modules/ssh-remote-port-forward/node_modules/@types/ssh2": {
-      "version": "0.5.52",
-      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.52.tgz",
-      "integrity": "sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/ssh2-streams": "*"
-      }
-    },
     "node_modules/ssh2": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.14.0.tgz",
@@ -18458,12 +18214,17 @@
       }
     },
     "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/string-hash": {
       "version": "1.1.3",
@@ -18912,14 +18673,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/through2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
     },
     "node_modules/timers-browserify": {
       "version": "2.0.12",
@@ -19821,9 +19574,9 @@
       }
     },
     "node_modules/vite/node_modules/rollup": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.5.1.tgz",
-      "integrity": "sha512-0EQribZoPKpb5z1NW/QYm3XSR//Xr8BeEXU49Lc/mQmpmVVG5jPUVrpc2iptup/0WMrY9mzas0fxH+TjYvG2CA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.6.0.tgz",
+      "integrity": "sha512-R8i5Her4oO1LiMQ3jKf7MUglYV/mhQ5g5OKeld5CnkmPdIGo79FDDQYqPhq/PCVuTQVuxsWgIbDy9F+zdHn80w==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -19833,18 +19586,18 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.5.1",
-        "@rollup/rollup-android-arm64": "4.5.1",
-        "@rollup/rollup-darwin-arm64": "4.5.1",
-        "@rollup/rollup-darwin-x64": "4.5.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.5.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.5.1",
-        "@rollup/rollup-linux-arm64-musl": "4.5.1",
-        "@rollup/rollup-linux-x64-gnu": "4.5.1",
-        "@rollup/rollup-linux-x64-musl": "4.5.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.5.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.5.1",
-        "@rollup/rollup-win32-x64-msvc": "4.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.6.0",
+        "@rollup/rollup-android-arm64": "4.6.0",
+        "@rollup/rollup-darwin-arm64": "4.6.0",
+        "@rollup/rollup-darwin-x64": "4.6.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.6.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.6.0",
+        "@rollup/rollup-linux-arm64-musl": "4.6.0",
+        "@rollup/rollup-linux-x64-gnu": "4.6.0",
+        "@rollup/rollup-linux-x64-musl": "4.6.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.6.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.6.0",
+        "@rollup/rollup-win32-x64-msvc": "4.6.0",
         "fsevents": "~2.3.2"
       }
     },

--- a/packages/ddc-client/src/DdcClient.ts
+++ b/packages/ddc-client/src/DdcClient.ts
@@ -29,9 +29,9 @@ export class DdcClient {
   static async create(uriOrSigner: Signer | string, config: DdcClientConfig = DEFAULT_PRESET) {
     const signer = typeof uriOrSigner === 'string' ? new UriSigner(uriOrSigner) : uriOrSigner;
     const blockchain =
-      config.blockchain instanceof Blockchain
-        ? config.blockchain
-        : await Blockchain.connect({ account: signer, wsEndpoint: config.blockchain });
+      typeof config.blockchain === 'string'
+        ? await Blockchain.connect({ account: signer, wsEndpoint: config.blockchain })
+        : config.blockchain;
 
     const router = config.nodes ? new Router({ signer, nodes: config.nodes }) : new Router({ signer, blockchain });
     const fileStorage = new FileStorage(router);
@@ -75,13 +75,13 @@ export class DdcClient {
   async store(bucketId: BucketId, entity: File, options?: FileStoreOptions): Promise<FileUri>;
   async store(bucketId: BucketId, entity: DagNode, options?: DagNodeStoreOptions): Promise<DagNodeUri>;
   async store(bucketId: BucketId, entity: File | DagNode, options?: FileStoreOptions | DagNodeStoreOptions) {
-    if (entity instanceof File) {
+    if (File.isFile(entity)) {
       const cid = await this.fileStorage.store(bucketId, entity, options);
 
       return new FileUri(bucketId, cid, options);
     }
 
-    if (entity instanceof DagNode) {
+    if (DagNode.isDagNode(entity)) {
       const cid = await this.storeDagNode(bucketId, entity, options);
 
       return new DagNodeUri(bucketId, cid, options);

--- a/packages/ddc/src/CnsRecord.ts
+++ b/packages/ddc/src/CnsRecord.ts
@@ -7,6 +7,18 @@ export class CnsRecord implements Omit<cns.Record, 'cid' | 'signature'> {
     readonly cid: string,
     readonly name: string,
   ) {}
+
+  static isCnsRecord(object: unknown): object is CnsRecord {
+    const maybeRecord = object as CnsRecord | null;
+
+    if (object instanceof CnsRecord) {
+      return true;
+    }
+
+    return (
+      typeof maybeRecord === 'object' && typeof maybeRecord?.cid === 'string' && typeof maybeRecord.name === 'string'
+    );
+  }
 }
 
 export class CnsRecordResponse extends CnsRecord {

--- a/packages/ddc/src/DagNode.ts
+++ b/packages/ddc/src/DagNode.ts
@@ -32,6 +32,21 @@ export class DagNode {
   get size() {
     return dag.Node.toBinary(mapDagNodeToAPI(this)).byteLength;
   }
+
+  static isDagNode(object: unknown): object is DagNode {
+    const maybeNode = object as DagNode | null;
+
+    if (object instanceof DagNode) {
+      return true;
+    }
+
+    return (
+      typeof maybeNode === 'object' &&
+      maybeNode?.data instanceof Uint8Array &&
+      Array.isArray(maybeNode.links) &&
+      Array.isArray(maybeNode.tags)
+    );
+  }
 }
 
 export class DagNodeResponse extends DagNode {

--- a/packages/ddc/src/Piece.ts
+++ b/packages/ddc/src/Piece.ts
@@ -51,6 +51,21 @@ export class Piece {
 
     return this.contentLength;
   }
+
+  static isPiece(object: unknown): object is Piece {
+    const maybePiece = object as Piece | null;
+
+    if (object instanceof Piece) {
+      return true;
+    }
+
+    return (
+      typeof maybePiece === 'object' &&
+      typeof maybePiece?.meta === 'object' &&
+      typeof maybePiece.isPart === 'boolean' &&
+      !!maybePiece.body
+    );
+  }
 }
 
 export class MultipartPiece {
@@ -61,6 +76,23 @@ export class MultipartPiece {
     readonly meta: MultipartPieceMeta,
   ) {
     this.partHashes = parts.map((part) => new Cid(part).contentHash);
+  }
+
+  static isMultipartPiece(object: unknown): object is MultipartPiece {
+    const maybeMultipartPiece = object as MultipartPiece | null;
+
+    if (object instanceof MultipartPiece) {
+      return true;
+    }
+
+    return (
+      typeof maybeMultipartPiece === 'object' &&
+      typeof maybeMultipartPiece?.meta === 'object' &&
+      typeof maybeMultipartPiece.meta.partSize === 'number' &&
+      typeof maybeMultipartPiece.meta.totalSize === 'number' &&
+      Array.isArray(maybeMultipartPiece.parts) &&
+      Array.isArray(maybeMultipartPiece.partHashes)
+    );
   }
 }
 

--- a/packages/ddc/src/StorageNode.ts
+++ b/packages/ddc/src/StorageNode.ts
@@ -44,7 +44,7 @@ export class StorageNode {
   async storePiece(bucketId: BucketId, piece: Piece | MultipartPiece, options?: PieceStoreOptions) {
     let cidBytes: Uint8Array | undefined = undefined;
 
-    if (piece instanceof MultipartPiece) {
+    if (MultipartPiece.isMultipartPiece(piece)) {
       cidBytes = await this.fileApi.putMultipartPiece({
         bucketId,
         partHashes: piece.partHashes,
@@ -53,7 +53,7 @@ export class StorageNode {
       });
     }
 
-    if (piece instanceof Piece) {
+    if (Piece.isPiece(piece)) {
       cidBytes = await this.fileApi.putRawPiece(
         {
           bucketId,

--- a/packages/file-storage/src/File.ts
+++ b/packages/file-storage/src/File.ts
@@ -23,6 +23,16 @@ export class File {
     this.body = createContentStream(content);
     this.size = content instanceof Uint8Array ? content.byteLength : meta.size!;
   }
+
+  static isFile(object: unknown): object is File {
+    const maybeFile = object as File | null;
+
+    if (object instanceof File) {
+      return true;
+    }
+
+    return typeof maybeFile === 'object' && typeof maybeFile?.size === 'number' && !!maybeFile.body;
+  }
 }
 
 export class FileResponse extends PieceResponse {}

--- a/packages/file-storage/src/FileStorage.ts
+++ b/packages/file-storage/src/FileStorage.ts
@@ -37,9 +37,9 @@ export class FileStorage {
   static async create(uriOrSigner: Signer | string, config: FileStorageConfig = DEFAULT_PRESET) {
     const signer = typeof uriOrSigner === 'string' ? new UriSigner(uriOrSigner) : uriOrSigner;
     const blockchain =
-      config.blockchain instanceof Blockchain
-        ? config.blockchain
-        : await Blockchain.connect({ account: signer, wsEndpoint: config.blockchain });
+      typeof config.blockchain === 'string'
+        ? await Blockchain.connect({ account: signer, wsEndpoint: config.blockchain })
+        : config.blockchain;
 
     return new FileStorage(new Router({ ...config, blockchain, signer }));
   }


### PR DESCRIPTION
Change runtime checks from `instanceof` to type guards to prevent issues with mixed CJS and ESM approaches