### PR TITLE
Allow multiple log outputs (console and file)

### DIFF
--- a/packages/ddc-client/README.md
+++ b/packages/ddc-client/README.md
@@ -21,19 +21,25 @@ yarn add @cere-ddc-sdk/ddc-client
 The `DdcClient` instance can be created using static `create` method
 
 ### Arguments
+
 - `account` - a string seed phrase or an instance of [Signer](/packages/blockchain/src/Signer/Signer.ts) interface
 - `options` - the client configuration object
 
-    ```ts
-    type Config = {
-        blockchain: string; // CERE blockchain rpc endpoint
-        nodes?: { // Optional, predefined list of nodes, by default retrieved from blockchain
-            grpcUrl: string; // gRPC endpoint for NodeJs communication
-            httpUrl: string // WebSocket endpoint for Web communication
-        }[];
-    };
-    ```
-    The package also exports several configuration presets which can be found [here](packages/ddc/src/presets.ts)
+  ```ts
+  type Config = {
+    blockchain: string; // CERE blockchain rpc endpoint
+    nodes?: {
+      // Optional, predefined list of nodes, by default retrieved from blockchain
+      grpcUrl: string; // gRPC endpoint for NodeJs communication
+      httpUrl: string; // WebSocket endpoint for Web communication
+    }[];
+  };
+  ```
+
+  The package also exports several configuration presets which can be found [here](packages/ddc/src/presets.ts)
+
+- `options.logLevel` - Specifies the level of logs to be recorded (`warn` by default)
+- `options.logOptions` - Specifies the configuration options for the logger. This can include output options such as writing logs to a file or console, and the log level for each output (`console` by default)
 
 ### Example
 
@@ -41,12 +47,25 @@ The `DdcClient` instance can be created using static `create` method
 import { DdcClient, TESTNET } from '@cere-ddc-sdk/ddc-client';
 
 const seed = 'hybrid label reunion only dawn maze asset draft cousin height flock nation';
-const ddcClient = await DdcClient.create(seed, TESTNET);
+const ddcClient = await DdcClient.create(seed, {
+  ...TESTNET,
+  logLevel: 'debug',
+  logOptions: {
+    output: [
+      { type: 'console' },
+      {
+        type: 'file',
+        path: './logs/ddc-client.log',
+      },
+    ],
+  },
+});
 ```
 
 # API
 
 `DdcClient` instance methods
+
 - [createBucket()](#createbucket)
 - [getBucket()](#getbucket)
 - [getBucketList()](#getbucketlist)
@@ -58,6 +77,7 @@ const ddcClient = await DdcClient.create(seed, TESTNET);
 Creates a new bucket and returns its ID
 
 ### Arguments
+
 - `clusterId` - the ID of a cluster to which the bucket will be connected
 
 ### Example
@@ -74,6 +94,7 @@ const bucketId: BucketId = await ddcClient.createBucket(clusterId);
 Returns information about a bucket by the bucket ID, or `undefined` if the bucket not found
 
 ### Arguments
+
 - `bucketId` - requested bucket ID
 
 ### Example
@@ -102,15 +123,16 @@ const buckets: Bucket[] = await ddcClient.getBucketList();
 Stores an object to DDC. The object can be either `File` or `DagNode`
 
 ### Arguments
+
 - `bucketId` - Bucket ID to store the object to
 - `object` - Object to store: `File` or `DagNode`
 - `options` - Operation options
-    - `name` - CNS name to assign to the created object
-    
+  - `name` - CNS name to assign to the created object
 
 ### Example
 
 Store a file to DDC bucket from NodeJS
+
 ```ts
 import { statSync, createReadStream } from 'fs';
 import { File, FileUri } from '@cere-ddc-sdk/ddc-client';
@@ -121,13 +143,14 @@ const fileStream = createReadStream(filePath);
 const file = new File(fileStream, { size: fileStats.size });
 
 const fileUri = await ddcClient.store(bucketId, file, {
-    name: 'my-first-file', // CNS name of the file
+  name: 'my-first-file', // CNS name of the file
 });
 
 console.log(fileUri.cid);
 ```
 
 Store a DagNode to DDC bucket
+
 ```ts
 import { DagNode, Tag, Link, DagNodeUri } from '@cere-ddc-sdk/ddc-client';
 
@@ -137,7 +160,7 @@ const links: Link[] = []; // Links to another node or file
 const dagNode = new DagNode('Some data', links, tags);
 
 const nodeUri: DagNodeUri = await client.store(bucketId, dagNode, {
-    name: 'my-first-dag-node', // CNS name of the DAG node
+  name: 'my-first-dag-node', // CNS name of the DAG node
 });
 
 console.log(nodeUri.cid);
@@ -148,23 +171,26 @@ console.log(nodeUri.cid);
 Reads an object from DDC. The object can be either `File` or `DagNode`
 
 ### Arguments
+
 - `objectUri` - `DdcUri` instance or its subclass (`FileUri` or `DagNodeUri`)
 - `options` - Operation options
-    - `path` - Optional path argument to traverse the DAG Node links by their names (available only for DAG nodes)
-    - `range` - Optional range argument to read a part of the requested file (available only for files)
+  - `path` - Optional path argument to traverse the DAG Node links by their names (available only for DAG nodes)
+  - `range` - Optional range argument to read a part of the requested file (available only for files)
 
 ### Example
 
 Read a file from DDC
+
 ```ts
 import { FileUri } from '@cere-ddc-sdk/ddc-client';
 
 const bucketId = 1n;
 const nodeResponse = await ddcClient.read(nodeUri, {
-    range: { // Optional range argument to read a part of the requested file
-        start: 0,
-        end: 16383, // First 16 KB (the range should be aligned to 16 KB)
-    }, 
+  range: {
+    // Optional range argument to read a part of the requested file
+    start: 0,
+    end: 16383, // First 16 KB (the range should be aligned to 16 KB)
+  },
 });
 
 const text = await nodeResponse.text(); // It is also possible to read `arrayBuffer()` or `json()`
@@ -173,6 +199,7 @@ console.log(text);
 ```
 
 Read a DAG Node from DDC
+
 ```ts
 import { DagNodeUri } from '@cere-ddc-sdk/ddc-client';
 
@@ -180,7 +207,7 @@ const bucketId = 1n;
 const nodeUri = new DagNodeUri(bucketId, 'my-first-dag-node'); // the DAG Node CID can be used instead of CNS name
 
 const nodeResponse = await ddcClient.read(nodeUri, {
-    path: '', // Optional path argument to traverse the DAG Node links by their names. EG. `root/link1/link2`
+  path: '', // Optional path argument to traverse the DAG Node links by their names. EG. `root/link1/link2`
 });
 
 console.log(nodeResponse.data.toString()); // Some data

--- a/packages/ddc-client/src/DdcClient.ts
+++ b/packages/ddc-client/src/DdcClient.ts
@@ -43,10 +43,10 @@ export class DdcClient {
         : config.blockchain;
 
     const router = config.nodes
-      ? new Router({ signer, nodes: config.nodes, logLevel: config.logLevel })
-      : new Router({ signer, blockchain, logLevel: config.logLevel });
+      ? new Router({ signer, nodes: config.nodes, logger })
+      : new Router({ signer, blockchain, logger });
 
-    const fileStorage = new FileStorage(router, config);
+    const fileStorage = new FileStorage(router, { ...config, logger });
 
     logger.debug(config, 'DdcClient created');
 

--- a/packages/ddc-client/src/DdcClient.ts
+++ b/packages/ddc-client/src/DdcClient.ts
@@ -35,7 +35,7 @@ export class DdcClient {
   }
 
   static async create(uriOrSigner: Signer | string, config: DdcClientConfig = DEFAULT_PRESET) {
-    const logger = createLogger({ ...config, prefix: 'DdcClient' });
+    const logger = createLogger('DdcClient', config);
     const signer = typeof uriOrSigner === 'string' ? new UriSigner(uriOrSigner) : uriOrSigner;
     const blockchain =
       typeof config.blockchain === 'string'

--- a/packages/ddc/src/FileApi/FileApi.ts
+++ b/packages/ddc/src/FileApi/FileApi.ts
@@ -36,7 +36,7 @@ export class FileApi {
 
   constructor(transport: RpcTransport, options: FileApiOptions = {}) {
     this.api = new FileApiClient(transport);
-    this.logger = createLogger({ ...options, prefix: 'FileApi' });
+    this.logger = createLogger('FileApi', options);
 
     this.options = {
       ...options,

--- a/packages/ddc/src/Logger/createLogger.ts
+++ b/packages/ddc/src/Logger/createLogger.ts
@@ -1,10 +1,20 @@
 import pino from 'pino';
-import { Logger, LoggerOptions } from './types';
+import { Logger, LoggerOptions, isLogger } from './types';
 
-export const createLogger = (prefix: string, options: LoggerOptions = {}): Logger =>
-  pino({
+export const createLogger = (prefix: string, options: LoggerOptions = {}): Logger => {
+  const { logger } = options;
+  const msgPrefix = `[${prefix}] `;
+
+  /**
+   * If the provided logger is already a pino logger, we just add a child logger to it.
+   */
+  if (isLogger(logger)) {
+    return logger.child({}, { msgPrefix });
+  }
+
+  return pino({
     level: options.logLevel || 'warn',
-    msgPrefix: `[${prefix}] `,
+    msgPrefix,
     transport: {
       target: 'pino-pretty',
       options: {
@@ -15,3 +25,4 @@ export const createLogger = (prefix: string, options: LoggerOptions = {}): Logge
       },
     },
   });
+};

--- a/packages/ddc/src/Logger/createLogger.ts
+++ b/packages/ddc/src/Logger/createLogger.ts
@@ -1,10 +1,10 @@
 import pino from 'pino';
 import { Logger, LoggerOptions } from './types';
 
-export const createLogger = (options: LoggerOptions = {}): Logger =>
+export const createLogger = (prefix: string, options: LoggerOptions = {}): Logger =>
   pino({
     level: options.logLevel || 'warn',
-    msgPrefix: options.prefix ? `[${options.prefix}] ` : undefined,
+    msgPrefix: `[${prefix}] `,
     transport: {
       target: 'pino-pretty',
       options: {

--- a/packages/ddc/src/Logger/createLogger.ts
+++ b/packages/ddc/src/Logger/createLogger.ts
@@ -1,28 +1,47 @@
-import pino from 'pino';
-import { Logger, LoggerOptions, isLogger } from './types';
+import pino, { TransportTargetOptions } from 'pino';
+import { LoggerConfig, Logger, LoggerOptions } from './types';
 
 export const createLogger = (prefix: string, options: LoggerOptions = {}): Logger => {
-  const { logger } = options;
+  const { logger, logOptions = {}, logLevel = 'warn' } = options;
   const msgPrefix = `[${prefix}] `;
 
   /**
    * If the provided logger is already a pino logger, we just add a child logger to it.
    */
-  if (isLogger(logger)) {
-    return logger.child({}, { msgPrefix });
+  if (logger) {
+    const pinologger = logger as pino.Logger;
+
+    return pinologger.child({}, { msgPrefix });
   }
 
+  const output: LoggerConfig['output'] = logOptions.output || { type: 'console' };
+  const outputs = Array.isArray(output) ? output : [output];
+  const targets: TransportTargetOptions[] = outputs.map((output) =>
+    output.type === 'console'
+      ? {
+          target: 'pino-pretty',
+          level: output.level || logLevel,
+          options: {
+            levelFirst: true,
+            colorize: true,
+            colorizeObjects: true,
+            ignore: 'hostname,pid',
+          },
+        }
+      : {
+          target: 'pino/file',
+          level: output.level || logLevel,
+          options: {
+            destination: output.path,
+            append: output.append ?? false,
+            mkdir: true,
+          },
+        },
+  );
+
   return pino({
-    level: options.logLevel || 'warn',
+    level: logLevel,
     msgPrefix,
-    transport: {
-      target: 'pino-pretty',
-      options: {
-        levelFirst: true,
-        colorize: true,
-        colorizeObjects: true,
-        ignore: 'hostname,pid',
-      },
-    },
+    transport: { targets },
   });
 };

--- a/packages/ddc/src/Logger/types.ts
+++ b/packages/ddc/src/Logger/types.ts
@@ -1,17 +1,26 @@
-import { BaseLogger as Logger, LevelWithSilent, Logger as FullLogger } from 'pino';
+import { BaseLogger as Logger, LevelWithSilent } from 'pino';
 
 export type LogLevel = LevelWithSilent;
+
+type LogOutputFile = {
+  type: 'file';
+  path: string;
+  append?: boolean;
+};
+
+type LogOutputConsole = {
+  type: 'console';
+};
+
+export type LogOutput = { level?: LogLevel } & (LogOutputFile | LogOutputConsole);
 export type LoggerConfig = {
-  format: 'pretty' | 'json';
+  output?: LogOutput | LogOutput[];
 };
 
 export type LoggerOptions = {
   logLevel?: LogLevel;
-  logger?: LoggerConfig | Logger;
-};
-
-export const isLogger = (logger: unknown): logger is FullLogger => {
-  return !!logger && typeof logger === 'object' && 'child' in logger && typeof logger.child === 'function';
+  logOptions?: LoggerConfig;
+  logger?: Logger;
 };
 
 export type { Logger };

--- a/packages/ddc/src/Logger/types.ts
+++ b/packages/ddc/src/Logger/types.ts
@@ -1,9 +1,13 @@
 import { BaseLogger as Logger, LevelWithSilent } from 'pino';
 
 export type LogLevel = LevelWithSilent;
+export type LoggerConfig = {
+  format: 'pretty' | 'json';
+};
+
 export type LoggerOptions = {
   logLevel?: LogLevel;
-  prefix?: string;
+  logger?: LoggerConfig;
 };
 
 export type { Logger };

--- a/packages/ddc/src/Logger/types.ts
+++ b/packages/ddc/src/Logger/types.ts
@@ -1,4 +1,4 @@
-import { BaseLogger as Logger, LevelWithSilent } from 'pino';
+import { BaseLogger as Logger, LevelWithSilent, Logger as FullLogger } from 'pino';
 
 export type LogLevel = LevelWithSilent;
 export type LoggerConfig = {
@@ -7,7 +7,11 @@ export type LoggerConfig = {
 
 export type LoggerOptions = {
   logLevel?: LogLevel;
-  logger?: LoggerConfig;
+  logger?: LoggerConfig | Logger;
+};
+
+export const isLogger = (logger: unknown): logger is FullLogger => {
+  return !!logger && typeof logger === 'object' && 'child' in logger && typeof logger.child === 'function';
 };
 
 export type { Logger };

--- a/packages/ddc/src/Router/Router.ts
+++ b/packages/ddc/src/Router/Router.ts
@@ -3,7 +3,7 @@ import { BucketId, Signer } from '@cere-ddc-sdk/blockchain';
 import { RouterOperation, RoutingStrategy } from './RoutingStrategy';
 import { BlockchainStrategy, BlockchainStrategyConfig } from './BlockchainStrategy';
 import { StaticStrategy, StaticStrategyConfig } from './StaticStrategy';
-import { LogLevel, Logger, LoggerOptions, createLogger } from '../Logger';
+import { Logger, LoggerOptions, createLogger } from '../Logger';
 import { StorageNode } from '../StorageNode';
 
 export type RouterConfig = (StaticStrategyConfig | BlockchainStrategyConfig) &
@@ -41,7 +41,7 @@ export class Router {
 
     return new StorageNode(this.signer, {
       ...node,
-      logLevel: this.logger.level as LogLevel,
+      logger: this.logger,
     });
   }
 }

--- a/packages/ddc/src/Router/Router.ts
+++ b/packages/ddc/src/Router/Router.ts
@@ -17,7 +17,7 @@ export class Router {
   private logger: Logger;
 
   constructor({ signer, ...config }: RouterConfig) {
-    this.logger = createLogger({ ...config, prefix: 'Router' });
+    this.logger = createLogger('Router', config);
     this.signer = signer;
 
     if ('nodes' in config) {

--- a/packages/ddc/src/StorageNode.ts
+++ b/packages/ddc/src/StorageNode.ts
@@ -39,7 +39,7 @@ export class StorageNode {
   constructor(signer: Signer, config: StorageNodeConfig) {
     const transport = new DefaultTransport(config);
 
-    this.logger = createLogger({ ...config, prefix: 'StorageNode' });
+    this.logger = createLogger('StorageNode', config);
     this.dagApi = new DagApi(transport);
     this.cnsApi = new CnsApi(transport, { signer });
     this.fileApi = new FileApi(transport, {

--- a/packages/ddc/src/StorageNode.ts
+++ b/packages/ddc/src/StorageNode.ts
@@ -44,7 +44,7 @@ export class StorageNode {
     this.cnsApi = new CnsApi(transport, { signer });
     this.fileApi = new FileApi(transport, {
       signer,
-      logLevel: config.logLevel,
+      logger: this.logger,
       enableAcks: config.enableAcks,
     });
 

--- a/packages/file-storage/src/FileStorage.ts
+++ b/packages/file-storage/src/FileStorage.ts
@@ -45,8 +45,8 @@ export class FileStorage {
 
       this.logger.debug(config, 'FileStorage created');
     } else {
-      this.router = new Router(configOrRouter);
       this.logger = createLogger('FileStorage', configOrRouter);
+      this.router = new Router({ ...configOrRouter, logger: this.logger });
 
       this.logger.debug(configOrRouter, 'FileStorage created');
     }

--- a/packages/file-storage/src/FileStorage.ts
+++ b/packages/file-storage/src/FileStorage.ts
@@ -41,12 +41,12 @@ export class FileStorage {
   constructor(configOrRouter: RouterConfig | Router, config?: Config) {
     if (configOrRouter instanceof Router) {
       this.router = configOrRouter;
-      this.logger = createLogger({ ...config, prefix: 'FileStorage' });
+      this.logger = createLogger('FileStorage', config);
 
       this.logger.debug(config, 'FileStorage created');
     } else {
       this.router = new Router(configOrRouter);
-      this.logger = createLogger({ ...configOrRouter, prefix: 'FileStorage' });
+      this.logger = createLogger('FileStorage', configOrRouter);
 
       this.logger.debug(configOrRouter, 'FileStorage created');
     }

--- a/tests/specs/DdcClient.spec.ts
+++ b/tests/specs/DdcClient.spec.ts
@@ -11,6 +11,7 @@ describe('DDC Client', () => {
 
     client = await DdcClient.create(ROOT_USER_SEED, {
       blockchain: rpcUrl,
+      logLevel: 'debug',
     });
   });
 

--- a/tests/specs/DdcClient.spec.ts
+++ b/tests/specs/DdcClient.spec.ts
@@ -11,7 +11,6 @@ describe('DDC Client', () => {
 
     client = await DdcClient.create(ROOT_USER_SEED, {
       blockchain: rpcUrl,
-      logLevel: 'debug',
     });
   });
 


### PR DESCRIPTION
- Refactor logger usages to re-use one logger instance
- Allow multiple log outputs (file and console)
- Add file output support