### PR TITLE
fix(ddc): Fix sending excessive messages to already closing upload stream

### DIFF
--- a/packages/ddc/src/FileApi/FileApi.ts
+++ b/packages/ddc/src/FileApi/FileApi.ts
@@ -122,7 +122,7 @@ export class FileApi {
       });
     }
 
-    const { requests, response } = this.api.putRawPiece({ meta });
+    const { requests, response, headers } = this.api.putRawPiece({ meta });
 
     await requests.send({
       body: {
@@ -131,21 +131,30 @@ export class FileApi {
       },
     });
 
+    let shouldStopSending = false;
+
+    headers
+      .then((headers) => this.logger.debug({ headers }, 'Server responded with headers'))
+      .catch(() => {})
+      .finally(() => {
+        shouldStopSending = true;
+      });
+
     for await (const data of createContentStream(content)) {
-      await Promise.race([
-        response,
-        requests.send({
-          body: {
-            oneofKind: 'content',
-            content: { data },
-          },
-        }),
-      ]);
+      if (shouldStopSending) {
+        break;
+      }
+
+      await requests.send({
+        body: { oneofKind: 'content', content: { data } },
+      });
     }
 
-    await requests.complete();
-    const { cid } = await response;
+    if (!shouldStopSending) {
+      await requests.complete();
+    }
 
+    const { cid } = await response;
     this.logger.debug({ cid }, 'Raw piece stored');
 
     return new Uint8Array(cid);

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -139,7 +139,6 @@ export const Playground = () => {
       setStep(step + 1);
     } catch (error) {
       setErrorStep(step);
-      console.error(error);
     } finally {
       setInProgress(false);
     }
@@ -165,8 +164,6 @@ export const Playground = () => {
       setStep(step + 1);
     } catch (error) {
       setErrorStep(step);
-
-      console.error(error);
     }
 
     setInProgress(false);
@@ -204,8 +201,6 @@ export const Playground = () => {
       setRealFileCid(uri.cid);
     } catch (error) {
       setErrorStep(step);
-
-      console.error(error);
     }
 
     setStep(step + 1);
@@ -230,8 +225,6 @@ export const Playground = () => {
       setBuckets(buckets);
     } catch (error) {
       setErrorStep(step);
-
-      console.error(error);
     }
 
     setInProgress(false);


### PR DESCRIPTION
In client stream gRPC requests the stream closes when the server (storage node) sends headers, so FileApi should also stop reading/streaming data in case it receives headers.