### PR TITLE
feat: Extend auth token API with methods to delegate access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3280,9 +3280,9 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.21.tgz",
+      "integrity": "sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g==",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -5227,9 +5227,9 @@
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.2.tgz",
-      "integrity": "sha512-RKzxFxBHq9ysZ83fn8Iduv3A283K7zPPYuhL/z9CQuyFrjwpErJx0h4aeb/bnJ+q29GRLgJpY66ceQ/Wcsn3wA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.5.tgz",
+      "integrity": "sha512-idWaG8xeSRCfRq9KpRysDHJ/rEHBEXcHuJ82XY0yYFIWnLMjZv9vF/7DOq8djQ2n3Lk6+3qfSH8AqlmHlmi1MA==",
       "cpu": [
         "arm"
       ],
@@ -5240,9 +5240,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.2.tgz",
-      "integrity": "sha512-yZ+MUbnwf3SHNWQKJyWh88ii2HbuHCFQnAYTeeO1Nb8SyEiWASEi5dQUygt3ClHWtA9My9RQAYkjvrsZ0WK8Xg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.5.tgz",
+      "integrity": "sha512-f14d7uhAMtsCGjAYwZGv6TwuS3IFaM4ZnGMUn3aCBgkcHAYErhV1Ad97WzBvS2o0aaDv4mVz+syiN0ElMyfBPg==",
       "cpu": [
         "arm64"
       ],
@@ -5253,9 +5253,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.2.tgz",
-      "integrity": "sha512-vqJ/pAUh95FLc/G/3+xPqlSBgilPnauVf2EXOQCZzhZJCXDXt/5A8mH/OzU6iWhb3CNk5hPJrh8pqJUPldN5zw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.5.tgz",
+      "integrity": "sha512-ndoXeLx455FffL68OIUrVr89Xu1WLzAG4n65R8roDlCoYiQcGGg6MALvs2Ap9zs7AHg8mpHtMpwC8jBBjZrT/w==",
       "cpu": [
         "arm64"
       ],
@@ -5266,9 +5266,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.2.tgz",
-      "integrity": "sha512-otPHsN5LlvedOprd3SdfrRNhOahhVBwJpepVKUN58L0RnC29vOAej1vMEaVU6DadnpjivVsNTM5eNt0CcwTahw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.5.tgz",
+      "integrity": "sha512-UmElV1OY2m/1KEEqTlIjieKfVwRg0Zwg4PLgNf0s3glAHXBN99KLpw5A5lrSYCa1Kp63czTpVll2MAqbZYIHoA==",
       "cpu": [
         "x64"
       ],
@@ -5279,9 +5279,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.2.tgz",
-      "integrity": "sha512-ewG5yJSp+zYKBYQLbd1CUA7b1lSfIdo9zJShNTyc2ZP1rcPrqyZcNlsHgs7v1zhgfdS+kW0p5frc0aVqhZCiYQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.5.tgz",
+      "integrity": "sha512-Q0LcU61v92tQB6ae+udZvOyZ0wfpGojtAKrrpAaIqmJ7+psq4cMIhT/9lfV6UQIpeItnq/2QDROhNLo00lOD1g==",
       "cpu": [
         "arm"
       ],
@@ -5292,9 +5292,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.2.tgz",
-      "integrity": "sha512-pL6QtV26W52aCWTG1IuFV3FMPL1m4wbsRG+qijIvgFO/VBsiXJjDPE/uiMdHBAO6YcpV4KvpKtd0v3WFbaxBtg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.5.tgz",
+      "integrity": "sha512-dkRscpM+RrR2Ee3eOQmRWFjmV/payHEOrjyq1VZegRUa5OrZJ2MAxBNs05bZuY0YCtpqETDy1Ix4i/hRqX98cA==",
       "cpu": [
         "arm64"
       ],
@@ -5305,9 +5305,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.2.tgz",
-      "integrity": "sha512-On+cc5EpOaTwPSNetHXBuqylDW+765G/oqB9xGmWU3npEhCh8xu0xqHGUA+4xwZLqBbIZNcBlKSIYfkBm6ko7g==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.5.tgz",
+      "integrity": "sha512-QaKFVOzzST2xzY4MAmiDmURagWLFh+zZtttuEnuNn19AiZ0T3fhPyjPPGwLNdiDT82ZE91hnfJsUiDwF9DClIQ==",
       "cpu": [
         "arm64"
       ],
@@ -5318,9 +5318,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.2.tgz",
-      "integrity": "sha512-Wnx/IVMSZ31D/cO9HSsU46FjrPWHqtdF8+0eyZ1zIB5a6hXaZXghUKpRrC4D5DcRTZOjml2oBhXoqfGYyXKipw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.5.tgz",
+      "integrity": "sha512-HeGqmRJuyVg6/X6MpE2ur7GbymBPS8Np0S/vQFHDmocfORT+Zt76qu+69NUoxXzGqVP1pzaY6QIi0FJWLC3OPA==",
       "cpu": [
         "riscv64"
       ],
@@ -5331,9 +5331,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.2.tgz",
-      "integrity": "sha512-ym5x1cj4mUAMBummxxRkI4pG5Vht1QMsJexwGP8547TZ0sox9fCLDHw9KCH9c1FO5d9GopvkaJsBIOkTKxksdw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.5.tgz",
+      "integrity": "sha512-Dq1bqBdLaZ1Gb/l2e5/+o3B18+8TI9ANlA1SkejZqDgdU/jK/ThYaMPMJpVMMXy2uRHvGKbkz9vheVGdq3cJfA==",
       "cpu": [
         "x64"
       ],
@@ -5344,9 +5344,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.2.tgz",
-      "integrity": "sha512-m0hYELHGXdYx64D6IDDg/1vOJEaiV8f1G/iO+tejvRCJNSwK4jJ15e38JQy5Q6dGkn1M/9KcyEOwqmlZ2kqaZg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.5.tgz",
+      "integrity": "sha512-ezyFUOwldYpj7AbkwyW9AJ203peub81CaAIVvckdkyH8EvhEIoKzaMFJj0G4qYJ5sw3BpqhFrsCc30t54HV8vg==",
       "cpu": [
         "x64"
       ],
@@ -5357,9 +5357,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.2.tgz",
-      "integrity": "sha512-x1CWburlbN5JjG+juenuNa4KdedBdXLjZMp56nHFSHTOsb/MI2DYiGzLtRGHNMyydPGffGId+VgjOMrcltOksA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.5.tgz",
+      "integrity": "sha512-aHSsMnUw+0UETB0Hlv7B/ZHOGY5bQdwMKJSzGfDfvyhnpmVxLMGnQPGNE9wgqkLUs3+gbG1Qx02S2LLfJ5GaRQ==",
       "cpu": [
         "arm64"
       ],
@@ -5370,9 +5370,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.2.tgz",
-      "integrity": "sha512-VVzCB5yXR1QlfsH1Xw1zdzQ4Pxuzv+CPr5qpElpKhVxlxD3CRdfubAG9mJROl6/dmj5gVYDDWk8sC+j9BI9/kQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.5.tgz",
+      "integrity": "sha512-AiqiLkb9KSf7Lj/o1U3SEP9Zn+5NuVKgFdRIZkvd4N0+bYrTOovVd0+LmYCPQGbocT4kvFyK+LXCDiXPBF3fyA==",
       "cpu": [
         "ia32"
       ],
@@ -5383,9 +5383,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.2.tgz",
-      "integrity": "sha512-SYRedJi+mweatroB+6TTnJYLts0L0bosg531xnQWtklOI6dezEagx4Q0qDyvRdK+qgdA3YZpjjGuPFtxBmddBA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.5.tgz",
+      "integrity": "sha512-1q+mykKE3Vot1kaFJIDoUFv5TuW+QQVaf2FmTT9krg86pQrGStOSJJ0Zil7CFagyxDuouTepzt5Y5TVzyajOdQ==",
       "cpu": [
         "x64"
       ],
@@ -5415,6 +5415,14 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@sigstore/core": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-0.2.0.tgz",
+      "integrity": "sha512-THobAPPZR9pDH2CAvDLpkrYedt7BlZnsyxDe+Isq4ZmGfPy5juOFZq487vCU2EgKD7aHSiTfE/i7sN7aEdzQnA==",
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/@sigstore/protobuf-specs": {
@@ -5636,6 +5644,30 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@sigstore/verify": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-0.1.0.tgz",
+      "integrity": "sha512-2UzMNYAa/uaz11NhvgRnIQf4gpLTJ59bhb8ESXaoSS5sxedfS+eLak8bsdMc+qpNQfITUTFoSKFx5h8umlRRiA==",
+      "dependencies": {
+        "@sigstore/bundle": "^2.1.1",
+        "@sigstore/core": "^0.2.0",
+        "@sigstore/protobuf-specs": "^0.2.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@sigstore/verify/node_modules/@sigstore/bundle": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.1.1.tgz",
+      "integrity": "sha512-v3/iS+1nufZdKQ5iAlQKcCsoh0jffQyABvYIxKsZQFWc4ubuGjwZklFHpDgV6O6T7vvV78SW5NHI91HFKEcxKg==",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.2.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -7438,9 +7470,9 @@
       }
     },
     "node_modules/cacache": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.1.tgz",
-      "integrity": "sha512-g4Uf2CFZPaxtJKre6qr4zqLDOOPU7bNVhWjlNhvzc51xaTOx2noMOLhfFkTAqwtrAZAKQUuDfyjitzilpA8WsQ==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.2.tgz",
+      "integrity": "sha512-r3NU8h/P+4lVUHfeRw1dtgQYar3DZMm4/cm2bZgOvrFC/su7budSOeqh52VJIC4U4iG1WWwV6vRW0znqBvxNuw==",
       "dependencies": {
         "@npmcli/fs": "^3.1.0",
         "fs-minipass": "^3.0.0",
@@ -15089,9 +15121,9 @@
       }
     },
     "node_modules/pacote/node_modules/@sigstore/bundle": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.1.0.tgz",
-      "integrity": "sha512-89uOo6yh/oxaU8AeOUnVrTdVMcGk9Q1hJa7Hkvalc6G3Z3CupWk4Xe9djSgJm9fMkH69s0P0cVHUoKSOemLdng==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.1.1.tgz",
+      "integrity": "sha512-v3/iS+1nufZdKQ5iAlQKcCsoh0jffQyABvYIxKsZQFWc4ubuGjwZklFHpDgV6O6T7vvV78SW5NHI91HFKEcxKg==",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.2.1"
       },
@@ -15100,11 +15132,12 @@
       }
     },
     "node_modules/pacote/node_modules/@sigstore/sign": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.2.0.tgz",
-      "integrity": "sha512-AAbmnEHDQv6CSfrWA5wXslGtzLPtAtHZleKOgxdQYvx/s76Fk6T6ZVt7w2IGV9j1UrFeBocTTQxaXG2oRrDhYA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.2.1.tgz",
+      "integrity": "sha512-U5sKQEj+faE1MsnLou1f4DQQHeFZay+V9s9768lw48J4pKykPj34rWyI1lsMOGJ3Mae47Ye6q3HAJvgXO21rkQ==",
       "dependencies": {
-        "@sigstore/bundle": "^2.1.0",
+        "@sigstore/bundle": "^2.1.1",
+        "@sigstore/core": "^0.2.0",
         "@sigstore/protobuf-specs": "^0.2.1",
         "make-fetch-happen": "^13.0.0"
       },
@@ -15113,12 +15146,12 @@
       }
     },
     "node_modules/pacote/node_modules/@sigstore/tuf": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-2.2.0.tgz",
-      "integrity": "sha512-KKATZ5orWfqd9ZG6MN8PtCIx4eevWSuGRKQvofnWXRpyMyUEpmrzg5M5BrCpjM+NfZ0RbNGOh5tCz/P2uoRqOA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-2.3.0.tgz",
+      "integrity": "sha512-S98jo9cpJwO1mtQ+2zY7bOdcYyfVYCUaofCG6wWRzk3pxKHVAkSfshkfecto2+LKsx7Ovtqbgb2LS8zTRhxJ9Q==",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.2.1",
-        "tuf-js": "^2.1.0"
+        "tuf-js": "^2.2.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -15262,9 +15295,9 @@
       }
     },
     "node_modules/pacote/node_modules/npm-packlist": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-8.0.1.tgz",
-      "integrity": "sha512-MQpL27ZrsJQ2kiAuQPpZb5LtJwydNRnI15QWXsf3WHERu4rzjRj6Zju/My2fov7tLuu3Gle/uoIX/DDZ3u4O4Q==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-8.0.2.tgz",
+      "integrity": "sha512-shYrPFIS/JLP4oQmAwDyk5HcyysKW8/JLTEA32S0Z5TzvpaeeX2yMFfoK1fjEBnCBvVyIB/Jj/GBFdm0wsgzbA==",
       "dependencies": {
         "ignore-walk": "^6.0.4"
       },
@@ -15304,14 +15337,16 @@
       }
     },
     "node_modules/pacote/node_modules/sigstore": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-2.1.0.tgz",
-      "integrity": "sha512-kPIj+ZLkyI3QaM0qX8V/nSsweYND3W448pwkDgS6CQ74MfhEkIR8ToK5Iyx46KJYRjseVcD3Rp9zAmUAj6ZjPw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-2.2.0.tgz",
+      "integrity": "sha512-fcU9clHwEss2/M/11FFM8Jwc4PjBgbhXoNskoK5guoK0qGQBSeUbQZRJ+B2fDFIvhyf0gqCaPrel9mszbhAxug==",
       "dependencies": {
-        "@sigstore/bundle": "^2.1.0",
+        "@sigstore/bundle": "^2.1.1",
+        "@sigstore/core": "^0.2.0",
         "@sigstore/protobuf-specs": "^0.2.1",
-        "@sigstore/sign": "^2.1.0",
-        "@sigstore/tuf": "^2.1.0"
+        "@sigstore/sign": "^2.2.1",
+        "@sigstore/tuf": "^2.3.0",
+        "@sigstore/verify": "^0.1.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -15329,9 +15364,9 @@
       }
     },
     "node_modules/pacote/node_modules/tuf-js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-2.1.0.tgz",
-      "integrity": "sha512-eD7YPPjVlMzdggrOeE8zwoegUaG/rt6Bt3jwoQPunRiNVzgcCE009UDFJKJjG+Gk9wFu6W/Vi+P5d/5QpdD9jA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-2.2.0.tgz",
+      "integrity": "sha512-ZSDngmP1z6zw+FIkIBjvOp/II/mIub/O7Pp12j1WNsiCpg5R5wAc//i555bBQsE44O94btLt0xM/Zr2LQjwdCg==",
       "dependencies": {
         "@tufjs/models": "2.0.0",
         "debug": "^4.3.4",
@@ -19698,11 +19733,20 @@
         }
       }
     },
+    "node_modules/vite/node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "devOptional": true
+    },
     "node_modules/vite/node_modules/rollup": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.2.tgz",
-      "integrity": "sha512-66RB8OtFKUTozmVEh3qyNfH+b+z2RXBVloqO2KCC/pjFaGaHtxP9fVfOQKPSGXg2mElmjmxjW/fZ7iKrEpMH5Q==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.5.tgz",
+      "integrity": "sha512-E4vQW0H/mbNMw2yLSqJyjtkHY9dslf/p0zuT1xehNRqUTBOFMqEjguDvqhXr7N7r/4ttb2jr4T41d3dncmIgbQ==",
       "devOptional": true,
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -19711,19 +19755,19 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.9.2",
-        "@rollup/rollup-android-arm64": "4.9.2",
-        "@rollup/rollup-darwin-arm64": "4.9.2",
-        "@rollup/rollup-darwin-x64": "4.9.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.9.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.9.2",
-        "@rollup/rollup-linux-arm64-musl": "4.9.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.9.2",
-        "@rollup/rollup-linux-x64-gnu": "4.9.2",
-        "@rollup/rollup-linux-x64-musl": "4.9.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.9.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.9.2",
-        "@rollup/rollup-win32-x64-msvc": "4.9.2",
+        "@rollup/rollup-android-arm-eabi": "4.9.5",
+        "@rollup/rollup-android-arm64": "4.9.5",
+        "@rollup/rollup-darwin-arm64": "4.9.5",
+        "@rollup/rollup-darwin-x64": "4.9.5",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.9.5",
+        "@rollup/rollup-linux-arm64-gnu": "4.9.5",
+        "@rollup/rollup-linux-arm64-musl": "4.9.5",
+        "@rollup/rollup-linux-riscv64-gnu": "4.9.5",
+        "@rollup/rollup-linux-x64-gnu": "4.9.5",
+        "@rollup/rollup-linux-x64-musl": "4.9.5",
+        "@rollup/rollup-win32-arm64-msvc": "4.9.5",
+        "@rollup/rollup-win32-ia32-msvc": "4.9.5",
+        "@rollup/rollup-win32-x64-msvc": "4.9.5",
         "fsevents": "~2.3.2"
       }
     },

--- a/packages/blockchain/src/Signer/UriSigner.ts
+++ b/packages/blockchain/src/Signer/UriSigner.ts
@@ -3,6 +3,7 @@ import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { Keyring } from '@polkadot/keyring';
 
 import { Signer } from './Signer';
+import { CERE_SS58_PREFIX } from '../constants';
 
 export type UriSignerOptions = Pick<KeyringOptions, 'type'>;
 
@@ -27,7 +28,7 @@ export class UriSigner implements Signer {
       return false;
     }
 
-    this.pair = new Keyring({ ss58Format: 54, type: this.type }).addFromUri(this.uri);
+    this.pair = new Keyring({ ss58Format: CERE_SS58_PREFIX, type: this.type }).addFromUri(this.uri);
 
     return true;
   }

--- a/packages/blockchain/src/constants.ts
+++ b/packages/blockchain/src/constants.ts
@@ -1,0 +1,1 @@
+export const CERE_SS58_PREFIX = 54;

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -2,3 +2,13 @@ export * from './types';
 export * from './Signer';
 
 export { Blockchain } from './Blockchain';
+
+/**
+ * Utilities
+ */
+export { decodeAddress, encodeAddress, cryptoWaitReady } from './utils';
+
+/**
+ * Utilities
+ */
+export { CERE_SS58_PREFIX } from './constants';

--- a/packages/blockchain/src/utils/index.ts
+++ b/packages/blockchain/src/utils/index.ts
@@ -1,0 +1,13 @@
+import * as cryptoUtil from '@polkadot/util-crypto';
+
+import { CERE_SS58_PREFIX } from '../constants';
+
+export { cryptoWaitReady } from '@polkadot/util-crypto';
+
+export const decodeAddress = (address: string, ignoreChecksum?: boolean) => {
+  return cryptoUtil.decodeAddress(address, ignoreChecksum, CERE_SS58_PREFIX);
+};
+
+export const encodeAddress = (address: Uint8Array) => {
+  return cryptoUtil.encodeAddress(address, CERE_SS58_PREFIX);
+};

--- a/packages/ddc-client/src/DdcClient.ts
+++ b/packages/ddc-client/src/DdcClient.ts
@@ -18,7 +18,7 @@ import {
   AuthToken,
 } from '@cere-ddc-sdk/ddc';
 import { FileStorage, File, FileStoreOptions, FileResponse, FileReadOptions } from '@cere-ddc-sdk/file-storage';
-import { Blockchain, BucketId, BucketParams, ClusterId } from '@cere-ddc-sdk/blockchain';
+import { AccountId, Blockchain, BucketId, BucketParams, ClusterId } from '@cere-ddc-sdk/blockchain';
 
 import { DagNodeUri, DdcUri, FileUri } from './DdcUri';
 
@@ -114,11 +114,11 @@ export class DdcClient {
     return this.getBucketList();
   }
 
-  async grantAccess(accountId: string, params: AuthTokenParams) {
-    this.logger.info('Granting access to account %s', accountId);
+  async grantAccess(subject: AccountId, params: AuthTokenParams) {
+    this.logger.info('Granting access to account %s', subject);
     this.logger.debug({ params }, 'Grant access params');
 
-    return new AuthToken({ ...params, subject: accountId }).sign(this.signer);
+    return new AuthToken({ ...params, subject }).sign(this.signer);
   }
 
   async store(bucketId: BucketId, entity: File, options?: FileStoreOptions): Promise<FileUri>;

--- a/packages/ddc-client/src/DdcClient.ts
+++ b/packages/ddc-client/src/DdcClient.ts
@@ -114,13 +114,11 @@ export class DdcClient {
     return this.getBucketList();
   }
 
-  async grantAccess(accountId: string, params: Partial<AuthTokenParams> = {}) {
+  async grantAccess(accountId: string, params: AuthTokenParams) {
     this.logger.info('Granting access to account %s', accountId);
     this.logger.debug({ params }, 'Grant access params');
 
-    const rootToken = await AuthToken.fullAccess(params).sign(this.signer);
-
-    return rootToken.delegate(accountId, params).sign(this.signer);
+    return new AuthToken({ ...params, subject: accountId }).sign(this.signer);
   }
 
   async store(bucketId: BucketId, entity: File, options?: FileStoreOptions): Promise<FileUri>;

--- a/packages/ddc-client/src/DdcClient.ts
+++ b/packages/ddc-client/src/DdcClient.ts
@@ -14,6 +14,8 @@ import {
   bindErrorLogger,
   NodeInterface,
   BalancedNode,
+  AuthTokenParams,
+  AuthToken,
 } from '@cere-ddc-sdk/ddc';
 import { FileStorage, File, FileStoreOptions, FileResponse, FileReadOptions } from '@cere-ddc-sdk/file-storage';
 import { Blockchain, BucketId, BucketParams, ClusterId } from '@cere-ddc-sdk/blockchain';
@@ -110,6 +112,15 @@ export class DdcClient {
    */
   bucketList() {
     return this.getBucketList();
+  }
+
+  async grantAccess(accountId: string, params: Partial<AuthTokenParams> = {}) {
+    this.logger.info('Granting access to account %s', accountId);
+    this.logger.debug({ params }, 'Grant access params');
+
+    const rootToken = await AuthToken.fullAccess(params).sign(this.signer);
+
+    return rootToken.delegate(accountId, params).sign(this.signer);
   }
 
   async store(bucketId: BucketId, entity: File, options?: FileStoreOptions): Promise<FileUri>;

--- a/packages/ddc-client/src/index.ts
+++ b/packages/ddc-client/src/index.ts
@@ -12,6 +12,8 @@ export {
   TESTNET,
   DEVNET,
   MAINNET,
+  AuthToken,
+  AuthTokenOperation,
   type DagNodeStoreOptions,
   type Signer,
 } from '@cere-ddc-sdk/ddc';

--- a/packages/ddc/src/auth/AuthToken.ts
+++ b/packages/ddc/src/auth/AuthToken.ts
@@ -1,34 +1,62 @@
 import base58 from 'bs58';
-import { BucketId, Signer } from '@cere-ddc-sdk/blockchain';
+import { AccountId, Signer, decodeAddress, encodeAddress } from '@cere-ddc-sdk/blockchain';
 
 import { AUTH_TOKEN_EXPIRATION_TIME } from '../constants';
 import { createSignature } from '../signature';
 import { AuthToken as Token, Payload, Operation } from '../grpc/auth_token';
+import { Cid } from '../Cid';
 
 export { Operation as AuthTokenOperation };
 
-type AuthTokenParams = {
-  operations: Operation[];
-  bucketId?: BucketId;
-  expiresAt?: number;
+type AuthTokenParams = Omit<Payload, 'subject' | 'prev' | 'pieceCid'> & {
+  pieceCid?: string | Uint8Array;
+  expiresIn?: number;
 };
+
+type DelegateTokenParams = Partial<AuthTokenParams>;
 
 export class AuthToken {
   private token: Token;
 
-  constructor({ bucketId, operations, expiresAt }: AuthTokenParams) {
+  constructor(params: AuthTokenParams) {
+    const expiresIn = params.expiresIn ?? AUTH_TOKEN_EXPIRATION_TIME;
     const payload: Payload = {
-      bucketId,
-      operations,
-      expiresAt: expiresAt ?? Date.now() + AUTH_TOKEN_EXPIRATION_TIME,
-      canDelegate: false,
+      bucketId: params.bucketId,
+      operations: params.operations,
+      canDelegate: params.canDelegate ?? true,
+      pieceCid: params.pieceCid ? new Cid(params.pieceCid).toBytes() : undefined,
+      expiresAt: params.expiresAt ?? Date.now() + expiresIn,
     };
 
     this.token = Token.create({ payload });
   }
 
+  get signer() {
+    return this.token.signature && encodeAddress(this.token.signature.signer);
+  }
+
+  get bucketId() {
+    return this.token.payload!.bucketId;
+  }
+
+  get operations() {
+    return this.token.payload!.operations;
+  }
+
+  get pieceCid() {
+    return this.token.payload!.pieceCid && new Cid(this.token.payload!.pieceCid).toString();
+  }
+
+  get expiresAt() {
+    return this.token.payload!.expiresAt;
+  }
+
   private toBinary() {
     return Token.toBinary(this.token);
+  }
+
+  toString() {
+    return base58.encode(this.toBinary());
   }
 
   async sign(signer: Signer) {
@@ -37,7 +65,44 @@ export class AuthToken {
     return this;
   }
 
-  toString() {
-    return base58.encode(this.toBinary());
+  delegate(to: AccountId, params: DelegateTokenParams = {}) {
+    const prevPayload = this.token.payload!;
+
+    if (!prevPayload.canDelegate) {
+      throw new Error('The token delegation is not allowed');
+    }
+
+    if (!this.token.signature) {
+      throw new Error('Cannopt delegate unsigned token');
+    }
+
+    const delegatedToken = new AuthToken({
+      ...prevPayload,
+      ...params,
+      canDelegate: params.canDelegate ?? false,
+    });
+
+    const nextPayload = delegatedToken.token.payload!;
+
+    nextPayload.prev = this.token;
+    nextPayload.subject = decodeAddress(to);
+
+    return delegatedToken;
+  }
+
+  static from(parentToken: string | AuthToken) {
+    const protoParentToken =
+      typeof parentToken === 'string' ? Token.fromBinary(base58.decode(parentToken)) : parentToken.token;
+
+    if (!protoParentToken.payload) {
+      throw new Error('Invalid token');
+    }
+
+    const nextToken = new AuthToken({ ...protoParentToken.payload });
+
+    nextToken.token.payload!.prev = protoParentToken;
+    nextToken.token.payload!.subject = undefined;
+
+    return nextToken;
   }
 }

--- a/packages/ddc/src/index.ts
+++ b/packages/ddc/src/index.ts
@@ -15,7 +15,7 @@ export * from './routing';
 export * from './Piece';
 export { DagNode, DagNodeResponse, Link, Tag } from './DagNode';
 export { CnsRecord, CnsRecordResponse } from './CnsRecord';
-export { AuthToken, AuthTokenOperation } from './auth';
+export { AuthToken, AuthTokenOperation, type AuthTokenParams } from './auth';
 export {
   UriSigner,
   StorageNodeMode,

--- a/packages/ddc/src/nodes/NodeInterface.ts
+++ b/packages/ddc/src/nodes/NodeInterface.ts
@@ -6,21 +6,31 @@ import { Piece, MultipartPiece, PieceResponse } from '../Piece';
 import { DagNode, DagNodeResponse } from '../DagNode';
 import { CnsRecord, CnsRecordResponse } from '../CnsRecord';
 import { Cid } from '../Cid';
+import { AuthToken } from '../auth';
 
 type NamingOptions = {
   name?: string;
 };
 
-export type PieceReadOptions = {
+export type OperationAuthOptions = {
+  accessToken?: AuthToken | string;
+};
+
+export type PieceReadOptions = OperationAuthOptions & {
   range?: ReadFileRange;
 };
 
-export type DagNodeGetOptions = {
+export type DagNodeGetOptions = OperationAuthOptions & {
   path?: string;
 };
 
-export type PieceStoreOptions = NamingOptions;
-export type DagNodeStoreOptions = NamingOptions;
+export type CnsRecordGetOptions = OperationAuthOptions & {
+  path?: string;
+};
+
+export type PieceStoreOptions = NamingOptions & OperationAuthOptions;
+export type DagNodeStoreOptions = NamingOptions & OperationAuthOptions;
+export type CnsRecordStoreOptions = OperationAuthOptions;
 
 export interface NodeInterface {
   readonly nodeId: string;
@@ -29,7 +39,7 @@ export interface NodeInterface {
   storeDagNode(bucketId: BucketId, node: DagNode, options?: DagNodeStoreOptions): Promise<string>;
   readPiece(bucketId: BucketId, cidOrName: string, options?: PieceReadOptions): Promise<PieceResponse>;
   getDagNode(bucketId: BucketId, cidOrName: string, options?: DagNodeGetOptions): Promise<DagNodeResponse | undefined>;
-  storeCnsRecord(bucketId: BucketId, record: CnsRecord): Promise<CnsApiRecord>;
-  getCnsRecord(bucketId: BucketId, name: string): Promise<CnsRecordResponse | undefined>;
-  resolveName(bucketId: BucketId, cidOrName: string): Promise<Cid>;
+  storeCnsRecord(bucketId: BucketId, record: CnsRecord, options?: CnsRecordStoreOptions): Promise<CnsApiRecord>;
+  getCnsRecord(bucketId: BucketId, name: string, options?: CnsRecordGetOptions): Promise<CnsRecordResponse | undefined>;
+  resolveName(bucketId: BucketId, cidOrName: string, options?: CnsRecordGetOptions): Promise<Cid>;
 }

--- a/packages/ddc/src/nodes/StorageNode.ts
+++ b/packages/ddc/src/nodes/StorageNode.ts
@@ -17,6 +17,9 @@ import {
   PieceReadOptions,
   PieceStoreOptions,
   NodeInterface,
+  OperationAuthOptions,
+  CnsRecordStoreOptions,
+  CnsRecordGetOptions,
 } from './NodeInterface';
 
 export type StorageNodeConfig = RpcTransportOptions &
@@ -70,13 +73,15 @@ export class StorageNode implements NodeInterface {
     ]);
   }
 
-  private async createAuthToken(bucketId: BucketId) {
-    return AuthToken.fullAccess({ bucketId }).sign(this.signer);
+  private async createAuthToken(bucketId: BucketId, { accessToken }: OperationAuthOptions = {}) {
+    const token = accessToken ? AuthToken.from(accessToken) : AuthToken.fullAccess({ bucketId });
+
+    return token.sign(this.signer);
   }
 
   async storePiece(bucketId: BucketId, piece: Piece | MultipartPiece, options?: PieceStoreOptions) {
     let cidBytes: Uint8Array | undefined = undefined;
-    const token = await this.createAuthToken(bucketId);
+    const token = await this.createAuthToken(bucketId, options);
 
     this.logger.info(options, 'Storing piece into bucket %s', bucketId);
     this.logger.debug({ piece }, 'Piece');
@@ -112,7 +117,7 @@ export class StorageNode implements NodeInterface {
     const cid = new Cid(cidBytes).toString();
 
     if (options?.name) {
-      await this.storeCnsRecord(bucketId, new CnsRecord(cid, options.name));
+      await this.storeCnsRecord(bucketId, new CnsRecord(cid, options.name), options);
     }
 
     this.logger.info({ cid }, 'Stored piece into bucket %s', bucketId);
@@ -121,7 +126,7 @@ export class StorageNode implements NodeInterface {
   }
 
   async storeDagNode(bucketId: BucketId, node: DagNode, options?: DagNodeStoreOptions) {
-    const token = await this.createAuthToken(bucketId);
+    const token = await this.createAuthToken(bucketId, options);
 
     this.logger.info(options, 'Storing DAG node into bucket %s', bucketId);
     this.logger.debug({ node }, 'DAG node');
@@ -136,7 +141,7 @@ export class StorageNode implements NodeInterface {
     const cid = new Cid(cidBytes).toString();
 
     if (options?.name) {
-      await this.storeCnsRecord(bucketId, new CnsRecord(cid, options.name));
+      await this.storeCnsRecord(bucketId, new CnsRecord(cid, options.name), options);
     }
 
     this.logger.info({ cid }, 'Stored DAG Node into bucket %s', bucketId);
@@ -145,7 +150,7 @@ export class StorageNode implements NodeInterface {
   }
 
   async readPiece(bucketId: BucketId, cidOrName: string, options?: PieceReadOptions) {
-    const token = await this.createAuthToken(bucketId);
+    const token = await this.createAuthToken(bucketId, options);
 
     this.logger.info(options, 'Reading piece by CID or name "%s" from bucket %s', cidOrName, bucketId);
     this.logger.debug({ token }, 'Auth token');
@@ -169,7 +174,7 @@ export class StorageNode implements NodeInterface {
   }
 
   async getDagNode(bucketId: BucketId, cidOrName: string, options?: DagNodeGetOptions) {
-    const token = await this.createAuthToken(bucketId);
+    const token = await this.createAuthToken(bucketId, options);
 
     this.logger.info('Getting DAG Node by CID or name "%s" from bucket %s', cidOrName, bucketId);
     this.logger.debug({ token }, 'Auth token');
@@ -190,8 +195,8 @@ export class StorageNode implements NodeInterface {
     return response;
   }
 
-  async storeCnsRecord(bucketId: BucketId, record: CnsRecord) {
-    const token = await this.createAuthToken(bucketId);
+  async storeCnsRecord(bucketId: BucketId, record: CnsRecord, options?: CnsRecordStoreOptions) {
+    const token = await this.createAuthToken(bucketId, options);
 
     this.logger.info('Storing CNS record into bucket %s', bucketId);
     this.logger.debug({ record }, 'CNS record');
@@ -208,8 +213,8 @@ export class StorageNode implements NodeInterface {
     return storredRecord;
   }
 
-  async getCnsRecord(bucketId: BucketId, name: string) {
-    const token = await this.createAuthToken(bucketId);
+  async getCnsRecord(bucketId: BucketId, name: string, options?: CnsRecordGetOptions) {
+    const token = await this.createAuthToken(bucketId, options);
 
     this.logger.info(`Getting CNS record by name "${name}" from bucket ${bucketId}`);
     this.logger.debug({ token }, 'Auth token');
@@ -222,13 +227,13 @@ export class StorageNode implements NodeInterface {
     return record && new CnsRecordResponse(record.cid, record.name, record.signature);
   }
 
-  async resolveName(bucketId: BucketId, cidOrName: string) {
+  async resolveName(bucketId: BucketId, cidOrName: string, options?: CnsRecordGetOptions) {
     if (Cid.isCid(cidOrName)) {
       return new Cid(cidOrName);
     }
 
     this.logger.info('Resolving CNS name "%s" from bucket %s', cidOrName, bucketId);
-    const record = await this.getCnsRecord(bucketId, cidOrName);
+    const record = await this.getCnsRecord(bucketId, cidOrName, options);
 
     if (!record) {
       throw new Error(`Cannot resolve CNS name: "${cidOrName}"`);

--- a/packages/ddc/src/nodes/StorageNode.ts
+++ b/packages/ddc/src/nodes/StorageNode.ts
@@ -10,7 +10,7 @@ import { DagNode, DagNodeResponse, mapDagNodeToAPI } from '../DagNode';
 import { CnsRecord, CnsRecordResponse, mapCnsRecordToAPI } from '../CnsRecord';
 import { DefaultTransport, RpcTransportOptions } from '../transports';
 import { bindErrorLogger, createLogger, Logger, LoggerOptions } from '../logger';
-import { AuthTokenOperation, AuthToken } from '../auth';
+import { AuthToken } from '../auth';
 import {
   DagNodeGetOptions,
   DagNodeStoreOptions,
@@ -70,19 +70,8 @@ export class StorageNode implements NodeInterface {
     ]);
   }
 
-  /**
-   * Creates a full access auth token for the given bucket
-   *
-   * TODO: Allow to accept the token as an operation method argument
-   */
   private async createAuthToken(bucketId: BucketId) {
-    const operations: AuthTokenOperation[] = [
-      AuthTokenOperation.PUT,
-      AuthTokenOperation.GET,
-      AuthTokenOperation.DELETE,
-    ];
-
-    return new AuthToken({ bucketId, operations }).sign(this.signer);
+    return AuthToken.fullAccess({ bucketId }).sign(this.signer);
   }
 
   async storePiece(bucketId: BucketId, piece: Piece | MultipartPiece, options?: PieceStoreOptions) {

--- a/packages/file-storage/src/FileStorage.ts
+++ b/packages/file-storage/src/FileStorage.ts
@@ -77,7 +77,11 @@ export class FileStorage {
         size: Math.min(file.size - offset, MAX_PIECE_SIZE),
       });
 
-      parts.push(await this.ddcNode.storePiece(bucketId, piece));
+      parts.push(
+        await this.ddcNode.storePiece(bucketId, piece, {
+          accessToken: options?.accessToken,
+        }),
+      );
     }
 
     return this.ddcNode.storePiece(

--- a/tests/setup/environment/docker-compose.ddc.yml
+++ b/tests/setup/environment/docker-compose.ddc.yml
@@ -4,7 +4,7 @@ services:
   ddc-storage-node-1:
     platform: linux/amd64
     container_name: ddc-storage-node-1
-    image: 'cerebellumnetwork/ddc-storage-node:dev'
+    image: 'cerebellumnetwork/ddc-storage-node:devnet'
     environment:
       - 'NODE_ID=1'
       - 'MODE=storage'
@@ -32,7 +32,7 @@ services:
   ddc-storage-node-2:
     platform: linux/amd64
     container_name: ddc-storage-node-2
-    image: 'cerebellumnetwork/ddc-storage-node:dev'
+    image: 'cerebellumnetwork/ddc-storage-node:devnet'
     environment:
       - 'NODE_ID=2'
       - 'MODE=storage'
@@ -60,7 +60,7 @@ services:
   ddc-storage-node-3:
     platform: linux/amd64
     container_name: ddc-storage-node-3
-    image: 'cerebellumnetwork/ddc-storage-node:dev'
+    image: 'cerebellumnetwork/ddc-storage-node:devnet'
     environment:
       - 'NODE_ID=3'
       - 'MODE=full'
@@ -88,7 +88,7 @@ services:
   ddc-storage-node-4:
     platform: linux/amd64
     container_name: ddc-storage-node-4
-    image: 'cerebellumnetwork/ddc-storage-node:dev'
+    image: 'cerebellumnetwork/ddc-storage-node:devnet'
     environment:
       - 'NODE_ID=4'
       - 'MODE=full'
@@ -116,7 +116,7 @@ services:
   ddc-storage-node-5:
     platform: linux/amd64
     container_name: ddc-storage-node-5
-    image: 'cerebellumnetwork/ddc-storage-node:dev'
+    image: 'cerebellumnetwork/ddc-storage-node:devnet'
     environment:
       - 'NODE_ID=5'
       - 'MODE=cache'

--- a/tests/specs/Auth.spec.ts
+++ b/tests/specs/Auth.spec.ts
@@ -39,23 +39,25 @@ describe('Auth', () => {
       operations: [AuthTokenOperation.PUT, AuthTokenOperation.GET],
     });
 
-    let delegatedToken: AuthToken;
+    let delegatedToken: string;
 
     beforeAll(async () => {
       await rootToken.sign(ownerSigner);
     });
 
     test('Delegate token', async () => {
-      delegatedToken = rootToken.delegate(readerSigner.address, {
+      const token = new AuthToken({
+        subject: readerSigner.address,
         operations: [AuthTokenOperation.GET],
       });
 
-      await delegatedToken.sign(ownerSigner);
+      await token.sign(ownerSigner);
 
-      expect(delegatedToken.parent).toEqual(rootToken);
-      expect(delegatedToken.signer).toEqual(ownerSigner.address);
-      expect(delegatedToken.subject).toEqual(readerSigner.address);
-      expect(delegatedToken.operations).toEqual([AuthTokenOperation.GET]);
+      delegatedToken = token.toString();
+
+      expect(delegatedToken).toEqual(expect.any(String));
+      expect(token.canDelegate).toEqual(false);
+      expect(token.operations).toEqual([AuthTokenOperation.GET]);
     });
 
     test('Accept token delegation', async () => {
@@ -64,9 +66,7 @@ describe('Auth', () => {
       const token = AuthToken.from(delegatedToken);
       await token.sign(readerSigner);
 
-      expect(token.parent).toEqual(delegatedToken);
-      expect(token.signer).toEqual(readerSigner.address);
-      expect(token.subject).toBeUndefined();
+      expect(token.canDelegate).toEqual(false);
       expect(token.operations).toEqual([AuthTokenOperation.GET]);
     });
   });


### PR DESCRIPTION
- Extend AuthToken API with methods related to delegation
- Allow passing the token to all operation methods
- Cover token delegation with tests
- Add high level method to DDCClient to grant access