### PR TITLE
test: Remove Auth contract deployment from blockchain bootstrap script

### DIFF
--- a/tests/helpers/blockchain.ts
+++ b/tests/helpers/blockchain.ts
@@ -110,11 +110,10 @@ export const getBlockchainState = () => {
   };
 };
 
-export const signAndSend = (tx: SubmittableExtrinsic<'promise'>, account: AddressOrPair, apiPromise?: ApiPromise) =>
+export const signAndSend = (tx: SubmittableExtrinsic<'promise'>, account: AddressOrPair) =>
   new Promise<SignAndSendResult>((resolve, reject) =>
     tx.signAndSend(account, (result) => {
       const { events = [], status, contractEvents = [], dispatchError } = result as TxResult;
-
       if (status.isFinalized) {
         return resolve({
           events,
@@ -125,13 +124,12 @@ export const signAndSend = (tx: SubmittableExtrinsic<'promise'>, account: Addres
 
       if (dispatchError) {
         let errorMessage: string | undefined;
-        if (apiPromise) {
-          if (dispatchError.isModule) {
-            const decoded = apiPromise.registry.findMetaError(dispatchError.asModule);
-            errorMessage = `${decoded.section}.${decoded.name}: ${decoded.docs.join(' ')}`;
-          } else {
-            errorMessage = dispatchError.toString();
-          }
+
+        if (dispatchError.isModule) {
+          const decoded = tx.registry.findMetaError(dispatchError.asModule);
+          errorMessage = `${decoded.section}.${decoded.name}: ${decoded.docs.join(' ')}`;
+        } else {
+          errorMessage = dispatchError.toString();
         }
 
         return reject(new Error(errorMessage || dispatchError.toString()));

--- a/tests/helpers/contract.ts
+++ b/tests/helpers/contract.ts
@@ -32,6 +32,11 @@ const deployContract = async (api: ApiPromise, account: KeyringPair, abi: Abi, w
   return address;
 };
 
+/**
+ * This Auth contract is optional and no longer used in the tests.
+ *
+ * TODO: Remove this function and the contract from the fixtures if it will not be needed in future.
+ */
 export const deployAuthContract = async (api: ApiPromise, signer: KeyringPair) => {
   const contractDir = path.resolve(__dirname, '../fixtures/contract');
   const contractPath = path.resolve(contractDir, 'cluster_node_candidate_authorization.contract');

--- a/tests/setup/environment/blockchain.ts
+++ b/tests/setup/environment/blockchain.ts
@@ -8,7 +8,6 @@ import {
   getAccount,
   readBlockchainStateFromDisk,
   BlockchainState,
-  deployAuthContract,
   CERE,
   writeBlockchainStateToDisk,
   sendMultipleTransfers,
@@ -101,10 +100,6 @@ export const setupBlockchain = async () => {
   ]);
   console.timeEnd('Top-up accounts');
 
-  console.time('Deploy cluster node auth contract');
-  const clusterNodeAuthorizationContractAddress = await deployAuthContract(apiPromise, clusterManagerAccount);
-  console.timeEnd('Deploy cluster node auth contract');
-
   const blockchain = await Blockchain.connect({ apiPromise });
 
   console.time('Create cluster');
@@ -115,7 +110,7 @@ export const setupBlockchain = async () => {
         clusterManagerAccount.address,
         clusterManagerAccount.address,
         {
-          nodeProviderAuthContract: clusterNodeAuthorizationContractAddress,
+          nodeProviderAuthContract: null,
         },
         {
           treasuryShare: 100000000,

--- a/tests/specs/Blockchain.spec.ts
+++ b/tests/specs/Blockchain.spec.ts
@@ -3,7 +3,7 @@ import { cryptoWaitReady, randomAsHex } from '@polkadot/util-crypto';
 import { ApiPromise } from '@polkadot/api';
 import { KeyringPair } from '@polkadot/keyring/types';
 
-import { createAccount, createBlockhainApi, deployAuthContract, getAccount, sendMultipleTransfers } from '../helpers';
+import { createAccount, createBlockhainApi, getAccount, sendMultipleTransfers } from '../helpers';
 
 describe('Blockchain', () => {
   let apiPromise: ApiPromise;
@@ -18,7 +18,6 @@ describe('Blockchain', () => {
   let nonExistentKey1: string;
   const clusterId = randomAsHex(20);
   const bondSize = 10_000_000_000n;
-  let nodeProviderAuthContract: string;
 
   beforeAll(async () => {
     await cryptoWaitReady();
@@ -32,7 +31,6 @@ describe('Blockchain', () => {
     nonExistentKey1 = createAccount().address;
 
     apiPromise = await createBlockhainApi();
-    nodeProviderAuthContract = await deployAuthContract(apiPromise, rootAccount);
 
     await sendMultipleTransfers(apiPromise, [
       { to: storageNode1Account.address, tokens: 10 },
@@ -98,8 +96,6 @@ describe('Blockchain', () => {
   });
 
   test('Should create a cluster and find it by public key', async () => {
-    expect(nodeProviderAuthContract).toBeDefined();
-
     const clusterGovernmentParams = {
       treasuryShare: 0,
       validatorsShare: 0,
@@ -115,8 +111,9 @@ describe('Blockchain', () => {
       unitPerPutRequest: 0n,
       unitPerGetRequest: 0n,
     };
+
     const clusterProps = {
-      nodeProviderAuthContract,
+      nodeProviderAuthContract: null,
     };
 
     await blockchain.send(
@@ -149,8 +146,9 @@ describe('Blockchain', () => {
 
   test('Should set cluster props', async () => {
     const clusterProps = {
-      nodeProviderAuthContract,
+      nodeProviderAuthContract: null,
     };
+
     await blockchain.send(blockchain.ddcClusters.setClusterParams(clusterId, clusterProps), { account: rootAccount });
 
     const cluster = await blockchain.ddcClusters.findClusterById(clusterId);


### PR DESCRIPTION
Auth contract is optional and not needed in SDK tests. So removed it to fix the contract deployment errors and increase blockchain bootstrap time.