### PR TITLE
feat(ddc): Add network latency based routing to select closest nodes to the client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8249,6 +8249,33 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
+    "node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -20230,6 +20257,7 @@
         "async-retry": "^1.3.3",
         "bs58": "^5.0.0",
         "buffer": "^6.0.3",
+        "cross-fetch": "^4.0.0",
         "format-util": "^1.0.5",
         "hash-wasm": "^4.11.0",
         "pino": "^8.17.2",

--- a/packages/ddc/package.json
+++ b/packages/ddc/package.json
@@ -36,6 +36,7 @@
     "async-retry": "^1.3.3",
     "bs58": "^5.0.0",
     "buffer": "^6.0.3",
+    "cross-fetch": "^4.0.0",
     "format-util": "^1.0.5",
     "hash-wasm": "^4.11.0",
     "pino": "^8.17.2",

--- a/packages/ddc/src/constants.ts
+++ b/packages/ddc/src/constants.ts
@@ -15,3 +15,4 @@ export const PING_THRESHOLD = 10; // Minimum number of nodes to ping before any 
 export const PING_THRESHOLD_INC = 2; // Number of nodes to ping more in background after each operation
 export const PING_LATENCY_GROUP = 100; // The coeficient in ms to group nodes by latency
 export const PING_BACKGROUND_DELAY = 100; // Delay in ms before starting background pings after an operation
+export const PING_ABORT_TIMEOUT = 1000; // Timeout in ms for aborting a ping request

--- a/packages/ddc/src/constants.ts
+++ b/packages/ddc/src/constants.ts
@@ -13,5 +13,5 @@ export const RETRY_MAX_ATTEPTS = 5;
 
 export const PING_THRESHOLD = 10; // Minimum number of nodes to ping before any DDC operation
 export const PING_THRESHOLD_INC = 2; // Number of nodes to ping more in background after each operation
-export const PING_LATENCY_GROUP = 10; // The coeficient in ms to group nodes by latency
+export const PING_LATENCY_GROUP = 100; // The coeficient in ms to group nodes by latency
 export const PING_BACKGROUND_DELAY = 100; // Delay in ms before starting background pings after an operation

--- a/packages/ddc/src/constants.ts
+++ b/packages/ddc/src/constants.ts
@@ -10,3 +10,8 @@ export const AUTH_TOKEN_EXPIRATION_TIME = 30 * 24 * 60 * 60 * 1000; // One month
 
 export const RETRYABLE_GRPC_ERROR_CODES = [GrpcStatus.UNAVAILABLE];
 export const RETRY_MAX_ATTEPTS = 5;
+
+export const PING_THRESHOLD = 10; // Minimum number of nodes to ping before any DDC operation
+export const PING_THRESHOLD_INC = 2; // Number of nodes to ping more in background after each operation
+export const PING_LATENCY_GROUP = 10; // The coeficient in ms to group nodes by latency
+export const PING_BACKGROUND_DELAY = 100; // Delay in ms before starting background pings after an operation

--- a/packages/ddc/src/routing/BaseStrategy.ts
+++ b/packages/ddc/src/routing/BaseStrategy.ts
@@ -2,7 +2,7 @@ import { StorageNodeConfig } from '../nodes';
 import { RouterOperation, RoutingStrategy } from './RoutingStrategy';
 
 export abstract class BaseStrategy extends RoutingStrategy {
-  async filterNodes(operation: RouterOperation, nodes: StorageNodeConfig[]) {
+  async marshalNodes(operation: RouterOperation, nodes: StorageNodeConfig[]) {
     return nodes;
   }
 }

--- a/packages/ddc/src/routing/BaseStrategy.web.ts
+++ b/packages/ddc/src/routing/BaseStrategy.web.ts
@@ -3,7 +3,7 @@ import { RouterNode, RouterOperation, RoutingStrategy } from './RoutingStrategy'
 const isSSLRequired = () => globalThis.location?.protocol === 'https:';
 
 export abstract class BaseStrategy extends RoutingStrategy {
-  async filterNodes(operation: RouterOperation, allNodes: RouterNode[]) {
+  async marshalNodes(operation: RouterOperation, allNodes: RouterNode[]) {
     if (!isSSLRequired()) {
       return allNodes;
     }

--- a/packages/ddc/src/routing/BaseStrategy.web.ts
+++ b/packages/ddc/src/routing/BaseStrategy.web.ts
@@ -8,9 +8,6 @@ export abstract class BaseStrategy extends RoutingStrategy {
       return allNodes;
     }
 
-    const nodes = allNodes.filter((node) => node.ssl);
-    this.logger.debug({ nodes }, 'Filter nodes suitable for secure web (domain + SSL)');
-
-    return nodes;
+    return allNodes.filter((node) => node.ssl);
   }
 }

--- a/packages/ddc/src/routing/BlockchainStrategy.ts
+++ b/packages/ddc/src/routing/BlockchainStrategy.ts
@@ -1,14 +1,14 @@
 import { Blockchain, Bucket, BucketId, ClusterId, StorageNode as BCStorageNode } from '@cere-ddc-sdk/blockchain';
 
 import { RouterNode } from './RoutingStrategy';
-import { PriorityStrategy } from './PriorityStrategy';
 import { Logger } from '../logger';
+import { PingStrategy } from './PingStrategy';
 
 export type BlockchainStrategyConfig = {
   blockchain: Blockchain;
 };
 
-export class BlockchainStrategy extends PriorityStrategy {
+export class BlockchainStrategy extends PingStrategy {
   private blockchain: Blockchain;
   private bucketCache: Map<BucketId, Bucket> = new Map();
   private clusterNodes: Map<ClusterId, RouterNode[]> = new Map();
@@ -26,8 +26,6 @@ export class BlockchainStrategy extends PriorityStrategy {
   }
 
   async getNodes(bucketId: BucketId) {
-    await this.isReady();
-
     const { clusterId } = await this.getBucket(bucketId);
     const nodes = await this.getClusterNodes(clusterId);
 

--- a/packages/ddc/src/routing/NodeTypeStrategy.ts
+++ b/packages/ddc/src/routing/NodeTypeStrategy.ts
@@ -1,6 +1,5 @@
 import { StorageNodeMode as Mode } from '@cere-ddc-sdk/blockchain';
 
-import { shuffle } from './RandomStrategy';
 import { RouterOperation as Operation, RouterNode } from './RoutingStrategy';
 import { BaseStrategy } from './BaseStrategy.web';
 
@@ -45,21 +44,22 @@ const priorityMap: OperationPriorityMap = {
   },
 };
 
-export abstract class PriorityStrategy extends BaseStrategy {
-  selectNode(operation: Operation, nodes: RouterNode[]) {
+export abstract class NodeTypeStrategy extends BaseStrategy {
+  async marshalNodes(operation: Operation, allNodes: RouterNode[]): Promise<RouterNode[]> {
+    const nodes = await super.marshalNodes(operation, allNodes);
+
     const opertaionPriorityMap = priorityMap[operation];
     const operationNodes = nodes.filter(({ mode }) => opertaionPriorityMap[mode] !== undefined);
 
-    /**
-     * Sort nodes by priority where the lower the number the higher the priority. 0 - highest priority.
-     */
-    const [node] = shuffle(operationNodes).sort((a, b) => {
+    return operationNodes.sort((a, b) => {
       const aPriority = a.priority || opertaionPriorityMap[a.mode] || 0;
       const bPriority = a.priority || opertaionPriorityMap[b.mode] || 0;
 
       return aPriority - bPriority;
     });
+  }
 
-    return node;
+  selectNode(operation: Operation, nodes: RouterNode[]): RouterNode | undefined {
+    return nodes[0]; // select first node from the rundomly shuffled list
   }
 }

--- a/packages/ddc/src/routing/PingStrategy.ts
+++ b/packages/ddc/src/routing/PingStrategy.ts
@@ -85,15 +85,16 @@ export abstract class PingStrategy extends NodeTypeStrategy {
     /**
      * Shuffle nodes and sort by latency levels
      */
-    const latencySortedNodes = shuffle(this.getPingedNodes(DeferredState.RESOLVED)).sort((a, b) => {
-      const pingA = this.nodesMap.get(a.httpUrl)!;
-      const pingB = this.nodesMap.get(b.httpUrl)!;
+    const latencySortedNodes = shuffle(allOperationNodes).sort((a, b) => {
+      const pingA = this.nodesMap.get(a.httpUrl);
+      const pingB = this.nodesMap.get(b.httpUrl);
 
       /**
-       * Group latency by PING_LATENCY_GROUP ms levels to avaoid sorting by small differences
+       * Group latency by PING_LATENCY_GROUP ms levels to avaoid sorting by small differences.
+       * Keep nodes without ping at the end for fallback scenarios when all pings fail.
        */
-      const levelA = Math.ceil(pingA.latency! / PING_LATENCY_GROUP);
-      const levelB = Math.ceil(pingB.latency! / PING_LATENCY_GROUP);
+      const levelA = pingA ? Math.ceil(pingA.latency! / PING_LATENCY_GROUP) : Infinity;
+      const levelB = pingB ? Math.ceil(pingB.latency! / PING_LATENCY_GROUP) : Infinity;
 
       return levelA - levelB;
     });

--- a/packages/ddc/src/routing/PingStrategy.ts
+++ b/packages/ddc/src/routing/PingStrategy.ts
@@ -1,4 +1,4 @@
-import { fetch } from 'cross-fetch';
+import fetch from 'cross-fetch';
 import { Deferred, DeferredState } from '@protobuf-ts/runtime-rpc';
 
 import { PING_BACKGROUND_DELAY, PING_LATENCY_GROUP, PING_THRESHOLD, PING_THRESHOLD_INC } from '../constants';
@@ -29,13 +29,13 @@ export abstract class PingStrategy extends NodeTypeStrategy {
     const pingUrl = new URL('/info', record.node.httpUrl);
 
     try {
-      const response = await fetch(pingUrl);
+      const response = await fetch(pingUrl, { cache: 'no-cache' });
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status} ${response.statusText}`);
       }
     } catch (err: any) {
-      this.logger.warn('Node ping %s failed with error %s', record.node.httpUrl, err);
+      this.logger.warn({ err }, 'Node ping %s failed with error %s', record.node.httpUrl, err);
 
       throw err;
     }

--- a/packages/ddc/src/routing/PingStrategy.ts
+++ b/packages/ddc/src/routing/PingStrategy.ts
@@ -1,0 +1,103 @@
+import { fetch } from 'cross-fetch';
+import { Deferred, DeferredState } from '@protobuf-ts/runtime-rpc';
+
+import { PING_BACKGROUND_DELAY, PING_LATENCY_GROUP, PING_THRESHOLD, PING_THRESHOLD_INC } from '../constants';
+import { RouterOperation, RouterNode } from '.';
+import { NodeTypeStrategy } from './NodeTypeStrategy';
+import { shuffle } from './RandomStrategy';
+
+type PingRecord = {
+  node: RouterNode;
+  isDone: Deferred<boolean>;
+  latency?: number;
+};
+
+export abstract class PingStrategy extends NodeTypeStrategy {
+  private nodesMap = new Map<RouterNode['httpUrl'], PingRecord>();
+
+  private getPingedNodes(state?: DeferredState) {
+    const pings = Array.from(this.nodesMap.values());
+    const foundPings = pings.filter(({ isDone }) =>
+      state ? isDone.state === state : isDone.state !== DeferredState.REJECTED,
+    );
+
+    return foundPings.map(({ node }) => node);
+  }
+
+  private async ping(record: PingRecord): Promise<PingRecord> {
+    const start = Date.now();
+    const pingUrl = new URL('/info', record.node.httpUrl);
+
+    try {
+      const response = await fetch(pingUrl);
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} ${response.statusText}`);
+      }
+    } catch (err: any) {
+      this.logger.warn('Node ping %s failed with error %s', record.node.httpUrl, err);
+
+      throw err;
+    }
+
+    record.latency = Date.now() - start;
+    this.logger.info('Node ping completed %s with latency %d ms', record.node.httpUrl, record.latency);
+
+    return record;
+  }
+
+  private enqueuePing(node: RouterNode) {
+    const existingPing = this.nodesMap.get(node.httpUrl);
+
+    if (existingPing) {
+      return existingPing;
+    }
+
+    const isDone = new Deferred<boolean>();
+    const pingRecord: PingRecord = { node, isDone };
+
+    this.nodesMap.set(node.httpUrl, pingRecord);
+    this.ping(pingRecord)
+      .then(() => isDone.resolve(true))
+      .catch((err) => isDone.reject(err));
+
+    return isDone.promise;
+  }
+
+  async marshalNodes(operation: RouterOperation, allNodes: RouterNode[]): Promise<RouterNode[]> {
+    const pingedNodes = await super.marshalNodes(operation, this.getPingedNodes());
+    const allOperationNodes = await super.marshalNodes(operation, allNodes);
+    const notPingedNodes = allOperationNodes.filter((node) => !this.nodesMap.has(node.httpUrl));
+    const toPingSync = notPingedNodes.splice(0, Math.max(0, PING_THRESHOLD - pingedNodes.length));
+    const toPingAsync = notPingedNodes.splice(0, PING_THRESHOLD_INC);
+    const syncPings = [...this.getPingedNodes(), ...toPingSync].map((node) => this.enqueuePing(node));
+
+    /**
+     * Wait for all sync pings to complete
+     */
+    await Promise.allSettled(syncPings);
+
+    /**
+     * After a short delay, start async pings in background
+     */
+    setTimeout(() => toPingAsync.forEach((node) => this.enqueuePing(node)), PING_BACKGROUND_DELAY);
+
+    /**
+     * Shuffle nodes and sort by latency levels
+     */
+    const latencySortedNodes = shuffle(this.getPingedNodes(DeferredState.RESOLVED)).sort((a, b) => {
+      const pingA = this.nodesMap.get(a.httpUrl)!;
+      const pingB = this.nodesMap.get(b.httpUrl)!;
+
+      /**
+       * Group latency by PING_LATENCY_GROUP ms levels to avaoid sorting by small differences
+       */
+      const levelA = Math.ceil(pingA.latency! / PING_LATENCY_GROUP);
+      const levelB = Math.ceil(pingB.latency! / PING_LATENCY_GROUP);
+
+      return levelA - levelB;
+    });
+
+    return super.marshalNodes(operation, latencySortedNodes);
+  }
+}

--- a/packages/ddc/src/routing/RandomStrategy.ts
+++ b/packages/ddc/src/routing/RandomStrategy.ts
@@ -1,3 +1,4 @@
+import { StorageNodeConfig } from '..';
 import { BaseStrategy } from './BaseStrategy';
 import { RouterOperation, RouterNode } from './RoutingStrategy';
 
@@ -12,9 +13,11 @@ export const shuffle = (array: RouterNode[]) => {
 };
 
 export abstract class RandomStrategy extends BaseStrategy {
-  selectNode(operation: RouterOperation, nodes: RouterNode[]): RouterNode {
-    const [node] = shuffle(nodes);
+  async marshalNodes(operation: RouterOperation, nodes: StorageNodeConfig[]): Promise<StorageNodeConfig[]> {
+    return shuffle(nodes);
+  }
 
-    return node;
+  selectNode(operation: RouterOperation, nodes: RouterNode[]): RouterNode {
+    return nodes[0];
   }
 }

--- a/packages/ddc/src/routing/Router.ts
+++ b/packages/ddc/src/routing/Router.ts
@@ -34,10 +34,12 @@ export class Router {
   async getNode(operation: RouterOperation, bucketId: BucketId, exclude: string[] = []) {
     this.logger.info('Getting node for operation "%s" in bucket %s', operation, bucketId);
 
+    await this.strategy.isReady();
+
     const allNodes = await this.strategy.getNodes(bucketId);
     const nodes = allNodes.filter((node) => !exclude.includes(getNodeId(node)));
-    const filterNodes = await this.strategy.filterNodes(operation, nodes);
-    const node = this.strategy.selectNode(operation, filterNodes);
+    const finalNodes = await this.strategy.marshalNodes(operation, nodes);
+    const node = this.strategy.selectNode(operation, finalNodes);
 
     if (!node) {
       throw new Error('No nodes available to handle the operation');

--- a/packages/ddc/src/routing/RoutingStrategy.ts
+++ b/packages/ddc/src/routing/RoutingStrategy.ts
@@ -22,5 +22,5 @@ export abstract class RoutingStrategy {
   abstract selectNode(operation: RouterOperation, nodes: RouterNode[]): RouterNode | undefined;
   abstract getNodes(bucketId: BucketId): Promise<RouterNode[]>;
   abstract isReady(): Promise<boolean>;
-  abstract filterNodes(operation: RouterOperation, nodes: RouterNode[]): Promise<RouterNode[]>;
+  abstract marshalNodes(operation: RouterOperation, nodes: RouterNode[]): Promise<RouterNode[]>;
 }

--- a/packages/ddc/src/routing/StaticStrategy.ts
+++ b/packages/ddc/src/routing/StaticStrategy.ts
@@ -1,14 +1,14 @@
 import { BucketId } from '@cere-ddc-sdk/blockchain';
 
 import { RouterNode } from './RoutingStrategy';
-import { PriorityStrategy } from './PriorityStrategy';
 import { Logger } from '../logger';
+import { PingStrategy } from './PingStrategy';
 
 export type StaticStrategyConfig = {
   nodes: RouterNode[];
 };
 
-export class StaticStrategy extends PriorityStrategy {
+export class StaticStrategy extends PingStrategy {
   private nodes: RouterNode[];
 
   constructor(logger: Logger, { nodes }: StaticStrategyConfig) {
@@ -17,11 +17,11 @@ export class StaticStrategy extends PriorityStrategy {
     this.nodes = nodes;
   }
 
-  async isReady() {
-    return true;
-  }
-
   async getNodes(bucketId: BucketId) {
     return this.nodes;
+  }
+
+  async isReady() {
+    return true;
   }
 }


### PR DESCRIPTION
Implement, ping based, routing strategy on top of existing, node type based, strategy. This is the first iteration of client side routing described in [this spec](https://www.notion.so/cere/Client-side-routing-f8b5b847be084bb5a4bb454ea726844a?pvs=4#c693c3bc37924d5db8735b52aa6c54e5).