### PR TITLE
feat(cli): Introduce DDC command line interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2047,6 +2047,10 @@
       "resolved": "packages/blockchain",
       "link": true
     },
+    "node_modules/@cere-ddc-sdk/cli": {
+      "resolved": "packages/cli",
+      "link": true
+    },
     "node_modules/@cere-ddc-sdk/conventional-changelog-changelog-preset": {
       "resolved": "packages/changelog-preset",
       "link": true
@@ -20519,6 +20523,22 @@
       "license": "Apache-2.0",
       "dependencies": {
         "conventional-changelog-conventionalcommits": "^7.0.2"
+      }
+    },
+    "packages/cli": {
+      "name": "@cere-ddc-sdk/cli",
+      "version": "2.3.0-rc.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cere-ddc-sdk/ddc-client": "2.3.0",
+        "@types/yargs": "^17.0.32",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "cere-ddc": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "packages/ddc": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,77 @@
+# @cere-ddc-sdk/cli
+
+DDC CLI provides a flexible set of commands for developers to help setting up a DDC account, upload/download files and more. 
+
+## System requirements
+
+- NodeJS >= 18.0.0
+
+# Installation
+
+Global installation:
+
+```bash
+npm install -g @cere-ddc-sdk/cli
+```
+
+As a project dependency
+
+```bash
+npm install --save-dev @cere-ddc-sdk/cli
+```
+
+Running with [NPX](https://www.npmjs.com/package/npx) will auto-install the package
+
+```bash
+npx @cere-ddc-sdk/cli [command] [options]
+```
+
+# Usage
+
+All interactions with DDC CLI are of the form
+
+```bash
+npx @cere-ddc-sdk/cli [command] [options]
+```
+or using named binary
+```bash
+cere-ddc [command] [options]
+```
+
+## Help
+To display basic commands and arguments -
+
+```bash
+npx @cere-ddc-sdk/cli --help
+```
+
+## Example
+
+Upload a file to DDC
+
+```bash
+npx @cere-ddc-sdk/cli upload ./image.jpg network=testnet --signer="seed phrase" --bucketId=123
+```
+
+## Configuration
+
+It is possible to provide configuration file instead of adding all options to a command line
+
+```bash
+npx @cere-ddc-sdk/cli upload ./image.jpg --config ./ddc.config.json
+```
+
+The configuration file example
+
+```json
+{
+    "network": "testnet",
+    "signer": "seed phrase",
+    "signerType": "sr25519",
+    "clusterId": "0x...",
+}
+```
+
+# License
+
+Licensed under the [Apache License](./LICENSE)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@cere-ddc-sdk/cli",
+  "description": "DDC command line interface",
+  "version": "2.3.0",
+  "repository": {
+    "type": "git",
+    "directory": "packages/cli",
+    "url": "git+https://github.com/Cerebellum-Network/cere-ddc-sdk-js.git"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "main": "dist/index.js",
+  "bin": {
+    "cere-ddc": "dist/cli.js"
+  },
+  "author": "Cere Network <contact@cere.io (https://www.cere.io/)",
+  "license": "Apache-2.0",
+  "scripts": {
+    "build": "microbundle -i src/index.ts -i src/cli.ts --tsconfig tsconfig.build.json --format cjs --target node",
+    "package": "clean-publish",
+    "clean": "rimraf dist package"
+  },
+  "dependencies": {
+    "@cere-ddc-sdk/ddc-client": "2.3.0",
+    "@types/yargs": "^17.0.32",
+    "yargs": "^17.7.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/cli/src/account.ts
+++ b/packages/cli/src/account.ts
@@ -1,0 +1,19 @@
+import { DdcClient, UriSigner } from '@cere-ddc-sdk/ddc-client';
+import { CreateClientOptions } from './createClient';
+import { CERE } from './constants';
+
+export type AccountOptions = Pick<CreateClientOptions, 'signer' | 'signerType'>;
+
+export const account = async (client: DdcClient, { signer, signerType }: AccountOptions) => {
+  const uriSigner = new UriSigner(signer, {
+    type: signerType === 'ed25519' ? 'ed25519' : 'sr25519',
+  });
+
+  const [balance, deposit] = await Promise.all([client.getBalance(), client.getDeposit()]);
+
+  return {
+    balance: Number(balance / BigInt(CERE)),
+    deposit: Number(deposit / BigInt(CERE)),
+    address: uriSigner.address,
+  };
+};

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { upload } from './upload';
+import { createBucket } from './createBucket';
+import { deposit } from './deposit';
+import { withClient } from './createClient';
+import { account } from './account';
+
+yargs(hideBin(process.argv))
+  .demandCommand()
+  .config('config', 'Configuration file path', (path) => JSON.parse(fs.readFileSync(path, 'utf-8')))
+  .option('network', {
+    alias: 'n',
+    choices: ['devnet', 'testnet', 'mainnet'],
+    default: 'devnet',
+    describe: 'DDC network',
+  })
+  .option('signer', {
+    alias: 's',
+    type: 'string',
+    demandOption: true,
+    describe: 'Mnemonic of the actor wallet',
+  })
+  .option('signerType', {
+    choices: ['sr25519', 'ed25519'],
+    default: 'sr25519',
+    describe: 'Type of the actor wallet signer',
+  })
+  .option('logLevel', {
+    alias: 'log',
+    choices: ['silent', 'warn', 'info', 'debug', 'error'],
+    default: 'silent',
+    describe: 'Log level for DDC client',
+  })
+  .command(
+    'upload <path>',
+    'Uploads file or directory to DDC',
+    (yargs) =>
+      yargs
+        .positional('path', {
+          type: 'string',
+          normalize: true,
+          demandOption: true,
+          describe: 'Path to directory or file to upload',
+        })
+        .option('bucketId', {
+          alias: 'b',
+          type: 'string',
+          demandOption: true,
+          describe: 'Bucket ID',
+        })
+        .option('cnsName', {
+          alias: 'name',
+          type: 'string',
+          describe: 'CNS name of the uploaded piece',
+        }),
+    async (argv) => {
+      const { isDirectory, cid } = await withClient(argv, (client) => upload(client, argv.path, argv));
+
+      console.group(isDirectory ? 'Directory upload completed' : 'File upload completed');
+      console.log('Network:', argv.network);
+      console.log('Bucket ID:', argv.bucketId);
+      console.log('Path:', argv.path);
+      console.log('CID:', cid);
+
+      if (argv.name) {
+        console.log('CNS name:', argv.name);
+      }
+
+      console.groupEnd();
+    },
+  )
+  .command(
+    'deposit <amount>',
+    'Deposit CERE tokens',
+    (yargs) =>
+      yargs
+        .positional('amount', {
+          type: 'number',
+          demandOption: true,
+          describe: 'Amount of CERE tokens to deposit',
+        })
+        .option('allowExtra', {
+          type: 'boolean',
+          default: true,
+          describe: 'Whether to allow extra amount to be deposited',
+        }),
+    async (argv) => {
+      const total = await withClient(argv, (client) => deposit(client, argv.amount, argv));
+
+      console.group('Deposit completed');
+      console.log('Network:', argv.network);
+      console.log('Amount:', argv.amount);
+      console.log('Total deposit:', total);
+      console.groupEnd();
+    },
+  )
+  .command(
+    'create-bucket',
+    'Creates a new bucket in DDC cluster',
+    (yargs) =>
+      yargs
+        .option('clusterId', {
+          alias: 'c',
+          type: 'string',
+          demandOption: true,
+          describe: 'Cluster ID where the bucket will be created',
+        })
+        .option('bucketAccess', {
+          alias: 'access',
+          choices: ['public', 'private'],
+          default: 'public',
+          describe: 'Whether the bucket is public',
+        }),
+    async ({ bucketAccess, ...argv }) => {
+      const bucketId = await withClient(argv, (client) =>
+        createBucket(client, { ...argv, isPublic: argv.bucketAccess === 'public' }),
+      );
+
+      console.group('Deposit completed');
+      console.log('Network:', argv.network);
+      console.log('Cluster ID:', argv.clusterId);
+      console.log('Bucket ID:', bucketId);
+      console.groupEnd();
+    },
+  )
+  .command(
+    'account',
+    'Prints DDC account information',
+    (yargs) => yargs,
+    async (argv) => {
+      const acc = await withClient(argv, (client) => account(client, argv));
+
+      console.group('Account information');
+      console.log('Network:', argv.network);
+      console.log('Address:', acc.address);
+      console.log('Balance:', acc.balance);
+      console.log('Deposit:', acc.deposit);
+      console.groupEnd();
+    },
+  )
+  .parse();

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,0 +1,1 @@
+export const CERE = 10_000_000_000;

--- a/packages/cli/src/createBucket.ts
+++ b/packages/cli/src/createBucket.ts
@@ -1,0 +1,14 @@
+import { DdcClient } from '@cere-ddc-sdk/ddc-client';
+
+export type CreateBucketOptions = {
+  isPublic: boolean;
+  clusterId: string;
+};
+
+export const createBucket = async (client: DdcClient, options: CreateBucketOptions) => {
+  const clusterId = options.clusterId as `0x${string}`;
+
+  return client.createBucket(clusterId, {
+    isPublic: options.isPublic,
+  });
+};

--- a/packages/cli/src/createClient.ts
+++ b/packages/cli/src/createClient.ts
@@ -1,0 +1,34 @@
+import { DdcClient, DEVNET, TESTNET, MAINNET, DdcClientConfig, UriSigner } from '@cere-ddc-sdk/ddc-client';
+
+export type CreateClientOptions = {
+  signer: string;
+  network: string;
+  logLevel: string;
+  signerType?: string;
+};
+
+const networkToPreset = {
+  devnet: DEVNET,
+  testnet: TESTNET,
+  mainnet: MAINNET,
+};
+
+export const createClient = (options: CreateClientOptions) => {
+  const network = options.network as keyof typeof networkToPreset;
+  const signer = new UriSigner(options.signer, {
+    type: options.signerType === 'ed25519' ? 'ed25519' : 'sr25519',
+  });
+
+  return DdcClient.create(signer, {
+    ...networkToPreset[network],
+    logLevel: options.logLevel as DdcClientConfig['logLevel'],
+  });
+};
+
+export const withClient = async <T>(options: CreateClientOptions, fn: (client: DdcClient) => Promise<T>) => {
+  const client = await createClient(options);
+  const result = await fn(client);
+  await client.disconnect();
+
+  return result;
+};

--- a/packages/cli/src/deposit.ts
+++ b/packages/cli/src/deposit.ts
@@ -1,0 +1,14 @@
+import { DdcClient } from '@cere-ddc-sdk/ddc-client';
+
+import { CERE } from './constants';
+
+export type DepositOptions = {
+  allowExtra: boolean;
+};
+
+export const deposit = async (client: DdcClient, amount: number, options: DepositOptions) => {
+  await client.depositBalance(BigInt(amount * CERE), options);
+  const totalBalance = await client.getDeposit();
+
+  return Number(totalBalance / BigInt(CERE));
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,4 @@
+export * from './createClient';
+export * from './createBucket';
+export * from './deposit';
+export * from './upload';

--- a/packages/cli/src/upload/index.ts
+++ b/packages/cli/src/upload/index.ts
@@ -1,0 +1,22 @@
+import fs from 'fs/promises';
+
+import { uploadDir } from './uploadDir';
+import { uploadFile } from './uploadFile';
+import { DdcClient } from '@cere-ddc-sdk/ddc-client';
+
+export type UploadOptions = {
+  bucketId: string;
+  name?: string;
+};
+
+export const upload = async (client: DdcClient, path: string, options: UploadOptions) => {
+  const stats = await fs.stat(path);
+  const isDirectory = stats.isDirectory();
+
+  const uploadPromise = isDirectory ? uploadDir(client, path, options) : uploadFile(client, path, stats, options);
+
+  return {
+    isDirectory,
+    cid: await uploadPromise,
+  };
+};

--- a/packages/cli/src/upload/uploadDir.ts
+++ b/packages/cli/src/upload/uploadDir.ts
@@ -1,0 +1,55 @@
+import { Stats } from 'fs';
+import fs from 'fs/promises';
+import path from 'path';
+import { DagNode, DdcClient, Link } from '@cere-ddc-sdk/ddc-client';
+
+import { uploadFile } from './uploadFile';
+
+export type UploadDirOptions = {
+  bucketId: string;
+  name?: string;
+};
+
+async function uploadFileLink(client: DdcClient, bucketId: bigint, rootDir: string, filePath: string, stats: Stats) {
+  const cid = await uploadFile(client, filePath, stats, {
+    bucketId: bucketId.toString(),
+  });
+
+  return new Link(cid, stats.size, path.relative(rootDir, filePath));
+}
+
+async function uploadDirLinks(client: DdcClient, bucketId: bigint, rootDir: string, currentDir?: string) {
+  const links: Promise<Link>[] = [];
+  const dir = currentDir || rootDir;
+  const files = await fs.readdir(dir);
+
+  for (const fileName of files) {
+    // Skip hidden files
+    if (fileName.startsWith('.')) {
+      continue;
+    }
+
+    const filePath = path.join(dir, fileName);
+    const stats = await fs.stat(filePath);
+    const subLinks = stats.isDirectory()
+      ? await uploadDirLinks(client, bucketId, rootDir, filePath)
+      : [uploadFileLink(client, bucketId, rootDir, filePath, stats)];
+
+    links.push(...subLinks);
+  }
+
+  return links;
+}
+
+export const uploadDir = async (client: DdcClient, path: string, options: UploadDirOptions) => {
+  const bucketId = BigInt(options.bucketId);
+  const linkPromises = await uploadDirLinks(client, bucketId, path);
+  const fileLinks = await Promise.all(linkPromises);
+
+  const rootDagNode = new DagNode(new Date().toISOString(), fileLinks);
+  const rootDagNodeUri = await client.store(bucketId, rootDagNode, {
+    name: options.name,
+  });
+
+  return rootDagNodeUri.cid;
+};

--- a/packages/cli/src/upload/uploadFile.ts
+++ b/packages/cli/src/upload/uploadFile.ts
@@ -1,0 +1,21 @@
+import { Stats, createReadStream } from 'fs';
+import { DdcClient, File } from '@cere-ddc-sdk/ddc-client';
+
+export type UploadFileOptions = {
+  bucketId: string;
+  name?: string;
+};
+
+export const uploadFile = async (
+  client: DdcClient,
+  path: string,
+  stats: Stats,
+  { name, bucketId }: UploadFileOptions,
+) => {
+  const fileStream = createReadStream(path);
+  const ddcFile = new File(fileStream, { size: stats.size });
+
+  const fileUri = await client.store(BigInt(bucketId), ddcFile, { name });
+
+  return fileUri.cid;
+};

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist",
+    "declarationDir": "dist/types",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
DDC CLI provides a flexible set of commands for developers to help setting up a DDC account, upload/download files and more. Check [README](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/blob/feature/cli/packages/cli/README.md) from more info.

The command set is quite limited for now, only the ones needed for Drones AI demo project. But it will be improved later.
