### PR TITLE
tests: Fix blockchain bootstrap configuration

### DIFF
--- a/packages/blockchain/src/types.ts
+++ b/packages/blockchain/src/types.ts
@@ -38,6 +38,7 @@ export type Bucket = /*PalletDdcCustomersBucket;*/ {
   readonly ownerId: AccountId;
   readonly clusterId: ClusterId;
   readonly isPublic: boolean;
+  readonly isRemoved: boolean;
 };
 
 export type AccountId = /*AccountId32;*/ string;

--- a/tests/setup/environment/blockchain.ts
+++ b/tests/setup/environment/blockchain.ts
@@ -49,7 +49,7 @@ export const startBlockchain = async (): Promise<BlockchainConfig> => {
     .withEnvironment({
       BC_CAHCHE_DIR: bcCachePath,
     })
-    .withWaitStrategy('cere-chain', Wait.forLogMessage(/Running JSON-RPC WS server/gi))
+    .withWaitStrategy('cere-chain', Wait.forLogMessage(/Running JSON-RPC server/gi))
     .up();
 
   const blockchainState: BlockchainState = !process.env.CI && chachedState ? chachedState : await setupBlockchain();

--- a/tests/setup/environment/docker-compose.blockchain.ci.yml
+++ b/tests/setup/environment/docker-compose.blockchain.ci.yml
@@ -5,7 +5,6 @@ services:
     platform: linux/amd64
     container_name: cere-chain
     image: '625402836641.dkr.ecr.us-west-2.amazonaws.com/pos-network-node:dev-latest'
-    command: bash -c "/usr/local/bin/cere --dev --alice --ws-external --rpc-external"
+    command: bash -c "/usr/local/bin/cere --dev --alice --rpc-external"
     ports:
       - '9944:9944'
-      - '9933:9933'

--- a/tests/setup/environment/docker-compose.blockchain.yml
+++ b/tests/setup/environment/docker-compose.blockchain.yml
@@ -5,9 +5,8 @@ services:
     platform: linux/amd64
     container_name: cere-chain
     image: '625402836641.dkr.ecr.us-west-2.amazonaws.com/pos-network-node:dev-latest'
-    command: bash -c "/usr/local/bin/cere --dev --alice --base-path ./data --ws-external --rpc-external"
+    command: bash -c "/usr/local/bin/cere --dev --alice --base-path ./data --rpc-external"
     ports:
       - '9944:9944'
-      - '9933:9933'
     volumes:
       - ${BC_CAHCHE_DIR}:/data


### PR DESCRIPTION
- Replaced `--ws-*` node options with `--rpc-*` to fix blockchain startup on CI (still does not work on Mac)
- Added `isRemoved` property to bucket info type