### PR TITLE
feat(ddc): Use internal SDK signers to reduce signature requests to web3 wallets

### DIFF
--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -5,7 +5,7 @@ export { Blockchain, type Sendable, type SendResult, type Event } from './Blockc
 /**
  * Utilities
  */
-export { decodeAddress, encodeAddress, cryptoWaitReady } from './utils';
+export { decodeAddress, encodeAddress, cryptoWaitReady, createRandomSigner } from './utils';
 
 /**
  * Constants

--- a/packages/blockchain/src/utils/index.ts
+++ b/packages/blockchain/src/utils/index.ts
@@ -1,6 +1,7 @@
 import * as cryptoUtil from '@polkadot/util-crypto';
 
 import { CERE_SS58_PREFIX } from '../constants';
+import { UriSigner, UriSignerOptions } from '../Signer';
 
 export { cryptoWaitReady } from '@polkadot/util-crypto';
 
@@ -10,4 +11,10 @@ export const decodeAddress = (address: string, ignoreChecksum?: boolean) => {
 
 export const encodeAddress = (address: Uint8Array) => {
   return cryptoUtil.encodeAddress(address, CERE_SS58_PREFIX);
+};
+
+export const createRandomSigner = (options: UriSignerOptions = {}) => {
+  const uri = cryptoUtil.mnemonicGenerate();
+
+  return new UriSigner(uri, options);
 };

--- a/packages/ddc/src/CnsApi/CnsApi.ts
+++ b/packages/ddc/src/CnsApi/CnsApi.ts
@@ -95,11 +95,11 @@ export class CnsApi {
     if (this.options.enableAcks) {
       meta.request = await createActivityRequest(
         { bucketId, size: ProtoRecord.toBinary(record).byteLength, requestType: ActivityRequestType.STORE },
-        { logger: this.logger, signer: this.options.signer },
+        { logger: this.logger, signer },
       );
     }
 
-    const signature = await createSignature(signer, createSignatureMessage(record));
+    const signature = await createSignature(signer, createSignatureMessage(record), { token });
 
     await this.api.put({ bucketId, record: { ...record, signature } }, { meta });
 
@@ -141,7 +141,7 @@ export class CnsApi {
     if (this.options.enableAcks) {
       meta.request = await createActivityRequest(
         { bucketId, requestType: ActivityRequestType.GET },
-        { logger: this.logger, signer: this.options.signer },
+        { token, logger: this.logger, signer: this.options.signer },
       );
     }
 

--- a/packages/ddc/src/DagApi/DagApi.ts
+++ b/packages/ddc/src/DagApi/DagApi.ts
@@ -71,7 +71,7 @@ export class DagApi {
     if (this.options.enableAcks && node) {
       meta.request = await createActivityRequest(
         { id: cid, bucketId, size: Node.toBinary(node).byteLength, requestType: ActivityRequestType.STORE },
-        { logger: this.logger, signer: this.options.signer },
+        { token, logger: this.logger, signer: this.options.signer },
       );
     }
 
@@ -116,7 +116,7 @@ export class DagApi {
     if (this.options.enableAcks) {
       meta.request = await createActivityRequest(
         { id: request.cid, bucketId: request.bucketId, requestType: ActivityRequestType.GET },
-        { logger: this.logger, signer: this.options.signer },
+        { token, logger: this.logger, signer: this.options.signer },
       );
     }
 

--- a/packages/ddc/src/activity/createAck.ts
+++ b/packages/ddc/src/activity/createAck.ts
@@ -2,9 +2,9 @@ import type { Signer } from '@cere-ddc-sdk/blockchain';
 
 import type { Logger } from '../logger';
 import { ActivityAcknowledgment } from '../grpc/activity_report/activity_report';
-import { createSignature } from '../signature';
+import { createSignature, CreateSignatureOptions } from '../signature';
 
-export type CreateAckOptions = {
+export type CreateAckOptions = CreateSignatureOptions & {
   signer?: Signer;
   logger?: Logger;
 };
@@ -14,7 +14,7 @@ export type CreateAckOptions = {
  */
 export const createAck = async (
   ack: Omit<ActivityAcknowledgment, 'signature'>,
-  { signer, logger }: CreateAckOptions,
+  { signer, logger, ...options }: CreateAckOptions,
 ) => {
   if (!signer) {
     throw new Error('Cannot sign acknowledgment. Signer requred!');
@@ -22,7 +22,7 @@ export const createAck = async (
 
   const signedAck = ActivityAcknowledgment.create({
     ...ack,
-    signature: await createSignature(signer, ActivityAcknowledgment.toBinary(ack)),
+    signature: await createSignature(signer, ActivityAcknowledgment.toBinary(ack), options),
   });
 
   logger?.debug({ signedAck }, 'Activity acknowledgment');

--- a/packages/ddc/src/auth/index.ts
+++ b/packages/ddc/src/auth/index.ts
@@ -1,2 +1,3 @@
 export * from './createRpcMeta';
 export * from './AuthToken';
+export * from './sdkToken';

--- a/packages/ddc/src/auth/sdkToken.ts
+++ b/packages/ddc/src/auth/sdkToken.ts
@@ -1,0 +1,46 @@
+import { Signer, Web3Signer, createRandomSigner } from '@cere-ddc-sdk/blockchain';
+
+import { AuthToken } from './AuthToken';
+
+const signerRegestry = new WeakMap<Signer, Map<string, Signer>>();
+
+const isWeb3Signer = (signer: Signer): signer is Web3Signer => {
+  return signer instanceof Web3Signer;
+};
+
+const getRegestry = (signer: Signer) => {
+  if (!signerRegestry.has(signer)) {
+    signerRegestry.set(signer, new Map());
+  }
+
+  return signerRegestry.get(signer)!;
+};
+
+const createSdkSigner = async (signer: Signer) => {
+  const randomSigner = createRandomSigner({ type: signer.type });
+  await randomSigner.isReady();
+
+  getRegestry(signer).set(randomSigner.address, randomSigner);
+
+  return randomSigner;
+};
+
+export const getSdkSigner = (signer: Signer, address: string) => {
+  return getRegestry(signer).get(address);
+};
+
+export const createSdkToken = async (signer: Signer) => {
+  if (!isWeb3Signer(signer)) {
+    return AuthToken.fullAccess().sign(signer);
+  }
+
+  const sdkSigner = await createSdkSigner(signer);
+
+  return AuthToken.fullAccess({ subject: sdkSigner.address }).sign(signer);
+};
+
+export const maybeSdkSigner = (signer: Signer, token?: AuthToken | string) => {
+  const finalToken = AuthToken.maybeToken(token);
+
+  return (finalToken?.signature && getSdkSigner(signer, finalToken.signature.signer)) || signer;
+};

--- a/packages/ddc/src/auth/sdkToken.ts
+++ b/packages/ddc/src/auth/sdkToken.ts
@@ -2,18 +2,18 @@ import { Signer, Web3Signer, createRandomSigner } from '@cere-ddc-sdk/blockchain
 
 import { AuthToken } from './AuthToken';
 
-const signerRegestry = new WeakMap<Signer, Map<string, Signer>>();
+const signerRegistry = new WeakMap<Signer, Map<string, Signer>>();
 
 const isWeb3Signer = (signer: Signer): signer is Web3Signer => {
   return signer instanceof Web3Signer;
 };
 
 const getRegestry = (signer: Signer) => {
-  if (!signerRegestry.has(signer)) {
-    signerRegestry.set(signer, new Map());
+  if (!signerRegistry.has(signer)) {
+    signerRegistry.set(signer, new Map());
   }
 
-  return signerRegestry.get(signer)!;
+  return signerRegistry.get(signer)!;
 };
 
 const createSdkSigner = async (signer: Signer) => {

--- a/packages/ddc/src/signature/mapSignature.ts
+++ b/packages/ddc/src/signature/mapSignature.ts
@@ -1,13 +1,14 @@
-import type { SignerType } from '@cere-ddc-sdk/blockchain';
+import { type SignerType, encodeAddress } from '@cere-ddc-sdk/blockchain';
 
 import { Signature as ApiSignature, Signature_Algorithm as SigAlg } from '../grpc/common/signature';
 
-export type Signature = Omit<ApiSignature, 'algorithm'> & {
+export type Signature = Omit<ApiSignature, 'algorithm' | 'signer'> & {
+  signer: string;
   algorithm: SignerType;
 };
 
 export const mapSignature = (signature: ApiSignature): Signature => ({
   algorithm: signature.algorithm === SigAlg.SR_25519 ? 'sr25519' : 'ed25519',
-  signer: new Uint8Array(signature.signer),
+  signer: encodeAddress(signature.signer),
   value: new Uint8Array(signature.value),
 });

--- a/tests/specs/StorageNode.spec.ts
+++ b/tests/specs/StorageNode.spec.ts
@@ -220,7 +220,7 @@ describe('Storage Node', () => {
 
       expect(signature).toEqual({
         algorithm: signer.type,
-        signer: expect.any(Uint8Array),
+        signer: expect.any(String),
         value: expect.any(Uint8Array),
       });
     });


### PR DESCRIPTION
Use token delegation mechanism to delegate access to internal SDK signer. The real signer needs to sign only the delegation and the rest is signed by internal SDK signer.

Note: This optimization currently not applied to use cases with external auth tokens