### PR TITLE
feat: Re-try piece store operation from buffered content

### DIFF
--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -18,7 +18,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'true'
 
@@ -27,7 +27,7 @@ jobs:
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Publish packages to NPM
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'true'
 
@@ -30,13 +30,13 @@ jobs:
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
 
       - name: Configure AWS credentials
         if: ${{ !inputs.skipTests }}
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::${{ vars.DEV_NETWORK_AWS_ACCOUNT_ID }}:role/github
           role-session-name: ${{ github.event.repository.name }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'true'
 
@@ -32,12 +32,12 @@ jobs:
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
 
       - name: Configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::${{ vars.DEV_NETWORK_AWS_ACCOUNT_ID }}:role/github
           role-session-name: ${{ github.event.repository.name }}

--- a/packages/ddc/src/Piece.ts
+++ b/packages/ddc/src/Piece.ts
@@ -125,6 +125,10 @@ export class Piece {
    * @returns A new `Piece` with the same content and metadata as the existing one.
    */
   static from(piece: Piece) {
+    if (isContentStream(piece.content) && piece.content.locked) {
+      throw new Error('The content stream is locked and can not be reused');
+    }
+
     return new Piece(piece.content, piece.meta as StreamPieceMeta);
   }
 }

--- a/packages/ddc/src/constants.ts
+++ b/packages/ddc/src/constants.ts
@@ -45,6 +45,9 @@ export const GRPC_REQUEST_INACTIVITY_TIMEOUT = 30 * 1000;
 export const RETRYABLE_GRPC_ERROR_CODES = [
   GrpcStatus.UNAVAILABLE,
   GrpcStatus.DEADLINE_EXCEEDED,
+  GrpcStatus.RESOURCE_EXHAUSTED,
+  GrpcStatus.ABORTED,
+  GrpcStatus.INTERNAL,
 
   /**
    * GRPC library uses this error code when a request is cancelled using abort signals, and it does not respect `AbortSignal.reason`.

--- a/packages/ddc/src/constants.ts
+++ b/packages/ddc/src/constants.ts
@@ -4,7 +4,7 @@ export const KB = 1024;
 export const MB = 1024 * KB;
 
 /**
- * Maximum size of a piece of content, in bytes.
+ * Minimum size of a piece of content, in bytes.
  *
  * @hidden
  */

--- a/packages/ddc/src/constants.ts
+++ b/packages/ddc/src/constants.ts
@@ -20,7 +20,7 @@ export const MAX_PIECE_SIZE = 128 * MB;
 /**
  * Size of a chunk of a content stream, in bytes.
  */
-export const CONTENT_CHUNK_SIZE = 64 * KB;
+export const CONTENT_CHUNK_SIZE = 1 * MB;
 
 /**
  * Default port for HTTPS connections.

--- a/packages/ddc/src/constants.ts
+++ b/packages/ddc/src/constants.ts
@@ -48,6 +48,7 @@ export const RETRYABLE_GRPC_ERROR_CODES = [
   GrpcStatus.RESOURCE_EXHAUSTED,
   GrpcStatus.ABORTED,
   GrpcStatus.INTERNAL,
+  GrpcStatus.UNKNOWN,
 
   /**
    * GRPC library uses this error code when a request is cancelled using abort signals, and it does not respect `AbortSignal.reason`.

--- a/packages/ddc/src/constants.ts
+++ b/packages/ddc/src/constants.ts
@@ -8,6 +8,13 @@ export const MB = 1024 * KB;
  *
  * @hidden
  */
+export const MIN_PIECE_SIZE = 4 * MB;
+
+/**
+ * Maximum size of a piece of content, in bytes.
+ *
+ * @hidden
+ */
 export const MAX_PIECE_SIZE = 128 * MB;
 
 /**

--- a/packages/ddc/src/index.ts
+++ b/packages/ddc/src/index.ts
@@ -28,12 +28,19 @@ export {
  * Utilities
  */
 export * from './logger';
-export { createContentStream, withChunkSize, isContentStream, type Content, type ContentStream } from './streams';
+export {
+  createContentStream,
+  withChunkSize,
+  isContentStream,
+  consumers as streamConsumers,
+  type Content,
+  type ContentStream,
+} from './streams';
 
 /**
  * Constants
  */
-export { KB, MB, MAX_PIECE_SIZE } from './constants';
+export { KB, MB, MAX_PIECE_SIZE, MIN_PIECE_SIZE } from './constants';
 
 /**
  * Configuration

--- a/packages/ddc/src/index.ts
+++ b/packages/ddc/src/index.ts
@@ -28,7 +28,7 @@ export {
  * Utilities
  */
 export * from './logger';
-export { createContentStream, isContentStream, type Content, type ContentStream } from './streams';
+export { createContentStream, withChunkSize, isContentStream, type Content, type ContentStream } from './streams';
 
 /**
  * Constants

--- a/packages/ddc/src/nodes/BalancedNode.ts
+++ b/packages/ddc/src/nodes/BalancedNode.ts
@@ -93,7 +93,13 @@ export class BalancedNode implements NodeInterface {
   }
 
   async storePiece(bucketId: BucketId, piece: Piece | MultipartPiece, options?: PieceStoreOptions) {
-    return this.withRetry(bucketId, RouterOperation.STORE_PIECE, (node) => node.storePiece(bucketId, piece, options));
+    return this.withRetry(bucketId, RouterOperation.STORE_PIECE, (node, bail, attempt) =>
+      /**
+       * Clone the piece if it is a piece and this is not the first attempt.
+       * This is done to avoid reusing the same stream multiple times.
+       */
+      node.storePiece(bucketId, Piece.isPiece(piece) && attempt > 0 ? Piece.from(piece) : piece, options),
+    );
   }
 
   async readPiece(bucketId: BucketId, cidOrName: string, options?: PieceReadOptions) {

--- a/packages/ddc/src/streams/createStream.ts
+++ b/packages/ddc/src/streams/createStream.ts
@@ -28,7 +28,7 @@ export type ContentStream = ReadableStream<Uint8Array> & {
   [ContentStreamSymbol]?: true;
 };
 
-const withChunkSize = (chunkSize: number) => {
+export const withChunkSize = (chunkSize: number) => {
   let buffer = Buffer.from([]);
 
   return new TransformStream<Uint8Array>({

--- a/packages/ddc/src/streams/createStream.ts
+++ b/packages/ddc/src/streams/createStream.ts
@@ -25,7 +25,7 @@ export type Content = Uint8Array | Iterable<Uint8Array> | AsyncIterable<Uint8Arr
  * @hidden
  */
 export type ContentStream = ReadableStream<Uint8Array> & {
-  [ContentStreamSymbol]?: true;
+  readonly [ContentStreamSymbol]?: boolean;
 };
 
 export const withChunkSize = (chunkSize: number) => {
@@ -103,8 +103,7 @@ export const createContentStream = (input: Content | ContentStream, chunkSize = 
     },
   });
 
-  const contentStream: ContentStream = stream.pipeThrough(withChunkSize(chunkSize));
-  contentStream[ContentStreamSymbol] = true;
-
-  return contentStream;
+  return Object.assign(stream.pipeThrough<Uint8Array>(withChunkSize(chunkSize)), {
+    [ContentStreamSymbol]: true,
+  });
 };

--- a/packages/file-storage/package.json
+++ b/packages/file-storage/package.json
@@ -21,8 +21,8 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "npm-run-all --parallel build:node build:web",
-    "build:node": "microbundle --tsconfig tsconfig.build.json --format esm,cjs --target node",
-    "build:web": "microbundle --tsconfig tsconfig.build.json --format modern --output dist/browser.js",
+    "build:node": "microbundle --tsconfig tsconfig.node.json --format esm,cjs --target node",
+    "build:web": "microbundle --tsconfig tsconfig.web.json --format modern --output dist/browser.js",
     "package": "clean-publish",
     "docs": "typedoc",
     "clean": "rimraf dist package"

--- a/packages/file-storage/src/FileStorage.ts
+++ b/packages/file-storage/src/FileStorage.ts
@@ -41,6 +41,7 @@ export type FileStoreOptions = PieceStoreOptions;
 export class FileStorage {
   private ddcNode: NodeInterface;
   private logger: Logger;
+  private blockchain?: Blockchain;
 
   constructor(config: RouterConfig);
   constructor(router: Router, config: Config);
@@ -52,6 +53,7 @@ export class FileStorage {
       this.logger.debug(config, 'FileStorage created');
     } else {
       this.logger = createLogger('FileStorage', configOrRouter);
+      this.blockchain = 'blockchain' in configOrRouter ? configOrRouter.blockchain : undefined;
       this.ddcNode = new BalancedNode({
         logger: this.logger,
         router: new Router({ ...configOrRouter, logger: this.logger }),
@@ -86,7 +88,11 @@ export class FileStorage {
         ? await Blockchain.connect({ wsEndpoint: config.blockchain })
         : config.blockchain;
 
-    return new FileStorage(new Router({ ...config, blockchain, signer }), config);
+    return new FileStorage({ ...config, blockchain, signer });
+  }
+
+  async disconnect() {
+    await this.blockchain?.disconnect();
   }
 
   private async storeLarge(bucketId: BucketId, file: File, options?: FileStoreOptions) {

--- a/packages/file-storage/src/FileStorage.ts
+++ b/packages/file-storage/src/FileStorage.ts
@@ -113,6 +113,7 @@ export class FileStorage {
       });
 
       parts.push(cid);
+      this.logger.info({ cid }, 'File part of size %s stored', part.byteLength);
     }
 
     return this.ddcNode.storePiece(bucketId, new MultipartPiece(parts, { totalSize: file.size, partSize }), options);

--- a/packages/file-storage/src/FileStorage.ts
+++ b/packages/file-storage/src/FileStorage.ts
@@ -113,7 +113,6 @@ export class FileStorage {
       });
 
       parts.push(cid);
-      this.logger.info({ cid }, 'File part of size %s stored', part.byteLength);
     }
 
     return this.ddcNode.storePiece(bucketId, new MultipartPiece(parts, { totalSize: file.size, partSize }), options);

--- a/packages/file-storage/src/constants.ts
+++ b/packages/file-storage/src/constants.ts
@@ -1,0 +1,5 @@
+import { MAX_PIECE_SIZE, MIN_PIECE_SIZE } from '@cere-ddc-sdk/ddc';
+
+export { MAX_PIECE_SIZE as MAX_BUFFER_SIZE, MIN_PIECE_SIZE as MIN_BUFFER_SIZE };
+
+export const DEFAULT_BUFFER_SIZE = MAX_PIECE_SIZE;

--- a/packages/file-storage/src/constants.web.ts
+++ b/packages/file-storage/src/constants.web.ts
@@ -1,0 +1,5 @@
+import { MB, MAX_PIECE_SIZE, MIN_PIECE_SIZE } from '@cere-ddc-sdk/ddc';
+
+export { MAX_PIECE_SIZE as MAX_BUFFER_SIZE, MIN_PIECE_SIZE as MIN_BUFFER_SIZE };
+
+export const DEFAULT_BUFFER_SIZE = 16 * MB;

--- a/packages/file-storage/src/index.ts
+++ b/packages/file-storage/src/index.ts
@@ -1,4 +1,5 @@
 export * from './File';
 export * from './FileStorage';
+export * from './constants';
 
 export { TESTNET, DEVNET, MAINNET, UriSigner, type Signer } from '@cere-ddc-sdk/ddc';

--- a/packages/file-storage/tsconfig.node.json
+++ b/packages/file-storage/tsconfig.node.json
@@ -4,7 +4,8 @@
     "baseUrl": ".",
     "outDir": "dist",
     "declarationDir": "dist/types",
-    "rootDir": "src"
+    "rootDir": "src",
+    "moduleSuffixes": [".node", ""]
   },
   "include": ["src", "src/**/*.json"]
 }

--- a/packages/file-storage/tsconfig.web.json
+++ b/packages/file-storage/tsconfig.web.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".web", ""]
+  }
+}

--- a/tests/helpers/streams.ts
+++ b/tests/helpers/streams.ts
@@ -4,7 +4,7 @@ import { ReadableStream } from 'stream/web';
 
 import { KB } from './constants';
 
-type DataStreamOptions = {
+export type DataStreamOptions = {
   chunkSize?: number;
   chunkDelay?: number;
 };

--- a/tests/jest.config.ts
+++ b/tests/jest.config.ts
@@ -7,7 +7,7 @@ const config: Config = {
   testEnvironment: 'node',
   roots: ['<rootDir>'],
   verbose: true,
-  testTimeout: 100000,
+  testTimeout: 10 * 60_000, // 10 mins (for tests with large file uploads and downloads)
 
   testMatch: ['<rootDir>/specs/**/*.spec.ts'],
   globalTeardown: './setup/globalTeardown.ts',

--- a/tests/jest.config.ts
+++ b/tests/jest.config.ts
@@ -7,7 +7,8 @@ const config: Config = {
   testEnvironment: 'node',
   roots: ['<rootDir>'],
   verbose: true,
-  testTimeout: 10 * 60_000, // 10 mins (for tests with large file uploads and downloads)
+  testTimeout: 2 * 60_000, // 2 mins (for tests with large file uploads and downloads)
+  slowTestThreshold: 1 * 60_000,
 
   testMatch: ['<rootDir>/specs/**/*.spec.ts'],
   globalTeardown: './setup/globalTeardown.ts',

--- a/tests/specs/Auth.spec.ts
+++ b/tests/specs/Auth.spec.ts
@@ -10,9 +10,16 @@ import {
   UriSigner,
 } from '@cere-ddc-sdk/ddc-client';
 
-import { KB, ROOT_USER_SEED, createDataStream, getBlockchainState, getClientConfig } from '../helpers';
+import {
+  KB,
+  ROOT_USER_SEED,
+  createDataStream,
+  DataStreamOptions,
+  getBlockchainState,
+  getClientConfig,
+} from '../helpers';
 
-const createFile = (size: number) => new File(createDataStream(size), { size });
+const createFile = (size: number, options?: DataStreamOptions) => new File(createDataStream(size, options), { size });
 
 describe('Auth', () => {
   const {
@@ -41,7 +48,9 @@ describe('Auth', () => {
 
   beforeEach(async () => {
     normalFile = createFile(KB);
-    largeFile = createFile(150 * MB);
+    largeFile = createFile(150 * MB, {
+      chunkSize: 1 * MB, // Use 1 MB chunk size to make the test faster
+    });
   });
 
   describe('Auth token', () => {

--- a/tests/specs/DdcClient.spec.ts
+++ b/tests/specs/DdcClient.spec.ts
@@ -192,7 +192,6 @@ describe('DDC Client', () => {
 
     test('Get balance', async () => {
       const balance = await client.getBalance();
-      console.log('Balance:', balance);
 
       expect(balance).toEqual(expect.any(BigInt));
     });

--- a/tests/specs/FileStorage.spec.ts
+++ b/tests/specs/FileStorage.spec.ts
@@ -7,6 +7,21 @@ import { FileStorage, File } from '@cere-ddc-sdk/file-storage';
 
 import { createDataStream, getBlockchainState, getClientConfig, MB, ROOT_USER_SEED } from '../helpers';
 
+function printMemoryUsage() {
+  const formatMemoryUsage = (data: number) => `${Math.round((data / 1024 / 1024) * 100) / 100} MB`;
+
+  const memoryData = process.memoryUsage();
+
+  const memoryUsage = {
+    rss: `${formatMemoryUsage(memoryData.rss)} -> Resident Set Size - total memory allocated for the process execution`,
+    heapTotal: `${formatMemoryUsage(memoryData.heapTotal)} -> total size of the allocated heap`,
+    heapUsed: `${formatMemoryUsage(memoryData.heapUsed)} -> actual memory used during the execution`,
+    external: `${formatMemoryUsage(memoryData.external)} -> V8 external memory`,
+  };
+
+  console.log(memoryUsage);
+}
+
 describe('File storage', () => {
   const {
     bucketIds: [bucketId],
@@ -55,7 +70,11 @@ describe('File storage', () => {
         size: fileSize,
       });
 
+      printMemoryUsage();
+
       fileCid = await fileStorage.store(bucketId, file);
+
+      printMemoryUsage();
 
       expect(fileCid).toEqual(expect.any(String));
     });

--- a/tests/specs/FileStorage.spec.ts
+++ b/tests/specs/FileStorage.spec.ts
@@ -7,21 +7,6 @@ import { FileStorage, File } from '@cere-ddc-sdk/file-storage';
 
 import { createDataStream, getBlockchainState, getClientConfig, MB, ROOT_USER_SEED } from '../helpers';
 
-function printMemoryUsage() {
-  const formatMemoryUsage = (data: number) => `${Math.round((data / 1024 / 1024) * 100) / 100} MB`;
-
-  const memoryData = process.memoryUsage();
-
-  const memoryUsage = {
-    rss: `${formatMemoryUsage(memoryData.rss)} -> Resident Set Size - total memory allocated for the process execution`,
-    heapTotal: `${formatMemoryUsage(memoryData.heapTotal)} -> total size of the allocated heap`,
-    heapUsed: `${formatMemoryUsage(memoryData.heapUsed)} -> actual memory used during the execution`,
-    external: `${formatMemoryUsage(memoryData.external)} -> V8 external memory`,
-  };
-
-  console.log(memoryUsage);
-}
-
 describe('File storage', () => {
   const {
     bucketIds: [bucketId],
@@ -63,18 +48,16 @@ describe('File storage', () => {
   describe('Large file', () => {
     let fileCid: string;
     const fileSize = 150 * MB;
-    const fileStream = createDataStream(fileSize);
+    const fileStream = createDataStream(fileSize, {
+      chunkSize: 1 * MB, // Use 1 MB chank size to make the test faster
+    });
 
     test('Store a file', async () => {
       const file = new File(fileStream, {
         size: fileSize,
       });
 
-      printMemoryUsage();
-
       fileCid = await fileStorage.store(bucketId, file);
-
-      printMemoryUsage();
 
       expect(fileCid).toEqual(expect.any(String));
     });

--- a/tests/specs/FileStorage.spec.ts
+++ b/tests/specs/FileStorage.spec.ts
@@ -18,6 +18,10 @@ describe('File storage', () => {
     fileStorage = await FileStorage.create(ROOT_USER_SEED, getClientConfig());
   });
 
+  afterAll(async () => {
+    await fileStorage.disconnect();
+  });
+
   describe('Small file', () => {
     let fileCid: string;
     const fileSize = 2 * MB;


### PR DESCRIPTION
- [x] Re-create piece with static content during re-try
- [x] Re-try file upload operations 

Note: Tests for this feature currently covers only happy pass - could not find an easy way to simulate failing storage node. Will try to find a way in another PR about re-triable download operations.