### PR TITLE
feat(cli): Allow configuring DDC nodes list in CLI config

### DIFF
--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -44,6 +44,7 @@ This example shows how to use DDC CLI
       Network: testnet
       Type: sr25519
       Address: 6PxrvjkVJFrQs6Tqdeov1GcJkS5rpzuM3NYGhX8KQErv49V2
+      Public key: 0x140366f3907d204001192a29c9e38243d344bae9b83726e531e46839ac461214
       Balance: 50
       Deposit: 0
     ```
@@ -110,6 +111,19 @@ This example shows how to use DDC CLI
       "bucketId": "27327" // <--
     }
     ```
+
+4. It is also possible to specify a list of DDC nodes to operate with
+    ```json
+    {
+      "nodes": [
+        {
+          "mode": "Full",
+          "grpcUrl": "grpc://128.140.103.37:9090",
+          "httpUrl": "https://storage-1.testnet.cere.network"
+        }
+      ]
+    }
+    ```  
 
   ### Upload/download a file to the bucket
 

--- a/packages/cli/src/account.ts
+++ b/packages/cli/src/account.ts
@@ -18,5 +18,6 @@ export const account = async (client: DdcClient | null, { signer, signerType }: 
     balance: Number(balance / BigInt(CERE)),
     deposit: Number(deposit / BigInt(CERE)),
     address: uriSigner.address,
+    publicKey: '0x' + Buffer.from(uriSigner.publicKey).toString('hex'),
   };
 };

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -217,6 +217,7 @@ yargs(hideBin(process.argv))
 
       console.log('Type:', argv.signerType);
       console.log('Address:', acc.address);
+      console.log('Public key:', acc.publicKey);
 
       if (!argv.random) {
         console.log('Balance:', acc.balance);

--- a/packages/cli/src/createClient.ts
+++ b/packages/cli/src/createClient.ts
@@ -1,10 +1,18 @@
+import { StorageNodeMode } from '@cere-ddc-sdk/ddc';
 import { DdcClient, DEVNET, TESTNET, MAINNET, DdcClientConfig, UriSigner } from '@cere-ddc-sdk/ddc-client';
+
+type NodeConfig = {
+  grpcUrl: string;
+  httpUrl: string;
+  mode?: string;
+};
 
 export type CreateClientOptions = {
   signer: string;
   network: string;
   logLevel: string;
   signerType?: string;
+  nodes?: NodeConfig[];
 };
 
 const networkToPreset = {
@@ -22,6 +30,10 @@ export const createClient = (options: CreateClientOptions) => {
   return DdcClient.create(signer, {
     ...networkToPreset[network],
     logLevel: options.logLevel as DdcClientConfig['logLevel'],
+    nodes: options.nodes?.map((node) => ({
+      ...node,
+      mode: StorageNodeMode[(node.mode as keyof typeof StorageNodeMode) || 'Full'],
+    })),
   });
 };
 


### PR DESCRIPTION
Add support for `nodes` config option to the CLI configuration files

Example of the configuration file:
```json
{
  "signer": "gospel fee escape timber toilet crouch artist catalog salt icon bulb ivory",
  "clusterId": "0x825c4b2352850de9986d9d28568db6f0c023a1e3",
  "bucketId": "27327",
  "nodes": [
      {
        "mode": "Full",
        "grpcUrl": "grpc://128.140.103.37:9090",
        "httpUrl": "https://storage-1.testnet.cere.network"
      }
    ]
}
```

Upload file command example:
```sh
npx @cere-ddc-sdk/cli --config ./ddc.config.json upload ./2mb.jpg
```