### PR TITLE
feat(cli): Add CLI option to override default blockchain RPC URL

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -23,6 +23,13 @@ yargs(hideBin(process.argv))
     default: 'testnet',
     describe: 'DDC network',
   })
+
+  .option('blockchainRpc', {
+    alias: ['rpc'],
+    type: 'string',
+    describe: 'Blockchain RPC URL. Owerrides the network default RPC URL',
+  })
+
   .option('signer', {
     alias: 's',
     type: 'string',

--- a/packages/cli/src/createClient.ts
+++ b/packages/cli/src/createClient.ts
@@ -12,6 +12,7 @@ export type CreateClientOptions = {
   network: string;
   logLevel: string;
   signerType?: string;
+  blockchainRpc?: string;
   nodes?: NodeConfig[];
 };
 
@@ -23,13 +24,18 @@ const networkToPreset = {
 
 export const createClient = (options: CreateClientOptions) => {
   const network = options.network as keyof typeof networkToPreset;
+  const preset = networkToPreset[network];
+  const blockchain = options.blockchainRpc || preset.blockchain;
+
   const signer = new UriSigner(options.signer, {
     type: options.signerType === 'ed25519' ? 'ed25519' : 'sr25519',
   });
 
   return DdcClient.create(signer, {
-    ...networkToPreset[network],
+    ...preset,
+    blockchain,
     logLevel: options.logLevel as DdcClientConfig['logLevel'],
+
     nodes: options.nodes?.map((node) => ({
       ...node,
       mode: StorageNodeMode[(node.mode as keyof typeof StorageNodeMode) || 'Full'],


### PR DESCRIPTION
Added new CLI options to override the default blockchain RPC URL:

```bash
npx cere-ddc --config ./ddc.config.json upload ./2mb.jpg --rpc wss://archive.testnet.cere.network/ws
```

or in the config file

```json
{
  "blockchainRpc": "wss://archive.testnet.cere.network/ws",
  "signer": "...",
  "clusterId": "...",
  "bucketId": "27496",
  "nodes": [
    {
      "mode": "Full",
      "grpcUrl": "grpc://ec2-52-27-0-63.us-west-2.compute.amazonaws.com:8080",
      "httpUrl": "http://ec2-52-27-0-63.us-west-2.compute.amazonaws.com:8080"
    }
  ]
}
```