### PR TITLE
feature: Improve re-try logic with exponential backoff strategy

### DIFF
--- a/packages/ddc/src/routing/NodeTypeStrategy.ts
+++ b/packages/ddc/src/routing/NodeTypeStrategy.ts
@@ -55,10 +55,10 @@ export abstract class NodeTypeStrategy extends BaseStrategy {
     const operationNodes = nodes.filter(({ mode }) => opertaionPriorityMap[mode] !== undefined);
 
     return operationNodes.sort((a, b) => {
-      const aPriority = a.priority || opertaionPriorityMap[a.mode] || 0;
-      const bPriority = a.priority || opertaionPriorityMap[b.mode] || 0;
+      const aPriority = a.priority ?? opertaionPriorityMap[a.mode] ?? 0;
+      const bPriority = b.priority ?? opertaionPriorityMap[b.mode] ?? 0;
 
-      return aPriority - bPriority;
+      return bPriority - aPriority;
     });
   }
 

--- a/packages/ddc/src/routing/NodeTypeStrategy.ts
+++ b/packages/ddc/src/routing/NodeTypeStrategy.ts
@@ -6,6 +6,10 @@ import { BaseStrategy } from './BaseStrategy.web';
 type ModePriorityMap = Partial<Record<Mode, number>>;
 type OperationPriorityMap = Record<Operation, ModePriorityMap>;
 
+/**
+ * The `priorityMap` defines the priority of the operation for each mode.
+ * The lower the number, the higher the priority.
+ */
 const priorityMap: OperationPriorityMap = {
   [Operation.READ_DAG_NODE]: {
     [Mode.Full]: 1,
@@ -58,7 +62,7 @@ export abstract class NodeTypeStrategy extends BaseStrategy {
       const aPriority = a.priority ?? opertaionPriorityMap[a.mode] ?? 0;
       const bPriority = b.priority ?? opertaionPriorityMap[b.mode] ?? 0;
 
-      return bPriority - aPriority;
+      return aPriority - bPriority;
     });
   }
 

--- a/packages/file-storage/src/FileStorage.ts
+++ b/packages/file-storage/src/FileStorage.ts
@@ -18,14 +18,13 @@ import {
   BalancedNode,
   withChunkSize,
   streamConsumers,
+  BalancedNodeConfig,
 } from '@cere-ddc-sdk/ddc';
 
 import { File, FileResponse } from './File';
 import { DEFAULT_BUFFER_SIZE, MAX_BUFFER_SIZE, MIN_BUFFER_SIZE } from './constants';
 
-type Config = LoggerOptions & {
-  retries?: number;
-};
+type Config = LoggerOptions & Pick<BalancedNodeConfig, 'retries'>;
 
 export type FileStorageConfig = Config &
   Omit<ConfigPreset, 'blockchain'> & {


### PR DESCRIPTION
- Enable exponential backoff re-try strategy by default starting from 50ms timeout
- Fix ping based routing node selection - it was sometimes selecting not pinged node
- Allow configuring re-try policy