### PR TITLE
feature: Add support for correlationId to group several requests

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,7 +8,7 @@ import { mnemonicGenerate } from '@polkadot/util-crypto';
 import { upload } from './upload';
 import { createBucket } from './createBucket';
 import { deposit } from './deposit';
-import { withClient } from './createClient';
+import { withClient, createCorrelationId } from './createClient';
 import { account } from './account';
 import { download } from './download';
 import { decodeToken, createToken } from './token';
@@ -79,11 +79,20 @@ yargs(hideBin(process.argv))
           alias: ['t', 'token'],
           type: 'string',
           describe: 'Access token to upload the file',
+        })
+        .option('correlationId', {
+          type: 'string',
+          default: '',
+          defaultDescription: 'Randomly generated',
+          describe: 'Correlation ID for DDC opperations',
         }),
     async (argv) => {
+      argv.correlationId ||= createCorrelationId();
+
       const { isDirectory, cid } = await withClient(argv, (client) => upload(client, argv.path, argv));
 
       console.group(isDirectory ? 'Directory upload completed' : 'File upload completed');
+      console.log('Correlation ID:', argv.correlationId);
       console.log('Network:', argv.network);
       console.log('Bucket ID:', BigInt(argv.bucketId));
       console.log('Path:', argv.path);
@@ -122,11 +131,20 @@ yargs(hideBin(process.argv))
           type: 'string',
           demandOption: true,
           describe: 'Bucket ID',
+        })
+        .option('correlationId', {
+          type: 'string',
+          default: '',
+          defaultDescription: 'Randomly generated',
+          describe: 'Correlation ID for DDC opperations',
         }),
     async (argv) => {
+      argv.correlationId ||= createCorrelationId();
+
       const result = await withClient(argv, (client) => download(client, argv.source, argv.dest, argv));
 
       console.group(result.isDirectory ? 'Directory download completed' : 'File download completed');
+      console.log('Correlation ID:', argv.correlationId);
       console.log('Network:', argv.network);
       console.log('Bucket ID:', argv.bucketId);
       console.log('CID:', result.cid);

--- a/packages/cli/src/createClient.ts
+++ b/packages/cli/src/createClient.ts
@@ -3,6 +3,8 @@ import { readFile } from 'fs/promises';
 import { StorageNodeMode } from '@cere-ddc-sdk/ddc';
 import { DdcClient, DEVNET, TESTNET, MAINNET, DdcClientConfig, UriSigner, JsonSigner } from '@cere-ddc-sdk/ddc-client';
 
+export { createCorrelationId } from '@cere-ddc-sdk/ddc-client';
+
 type NodeConfig = {
   grpcUrl: string;
   httpUrl: string;

--- a/packages/cli/src/download/downloadDir.ts
+++ b/packages/cli/src/download/downloadDir.ts
@@ -8,16 +8,17 @@ import { isCLIDirData } from '../upload/uploadDir';
 export type DownloadDirOptions = {
   bucketId: string;
   accessToken?: string;
+  correlationId?: string;
 };
 
 export const downloadDir = async (
   client: DdcClient,
   source: string,
   dest: string,
-  { bucketId, accessToken }: DownloadDirOptions,
+  { bucketId, accessToken, correlationId }: DownloadDirOptions,
 ) => {
   const dagUri = new DagNodeUri(BigInt(bucketId), source);
-  const response = await client.read(dagUri, { accessToken });
+  const response = await client.read(dagUri, { accessToken, correlationId });
 
   try {
     const data = JSON.parse(response.data.toString());
@@ -33,7 +34,7 @@ export const downloadDir = async (
   const promises = response.links.map((link) => {
     const filePath = path.join(dest, link.name);
 
-    return downloadFile(client, link.cid, filePath, { bucketId, accessToken });
+    return downloadFile(client, link.cid, filePath, { bucketId, accessToken, correlationId });
   });
 
   await Promise.all(promises);

--- a/packages/cli/src/download/downloadFile.ts
+++ b/packages/cli/src/download/downloadFile.ts
@@ -8,18 +8,19 @@ import { DdcClient, FileUri } from '@cere-ddc-sdk/ddc-client';
 export type DownloadFileOptions = {
   bucketId: string;
   accessToken?: string;
+  correlationId?: string;
 };
 
 export const downloadFile = async (
   client: DdcClient,
   source: string,
   dest: string,
-  { bucketId, accessToken }: DownloadFileOptions,
+  { bucketId, accessToken, correlationId }: DownloadFileOptions,
 ) => {
   await mkdir(path.dirname(dest), { recursive: true });
 
   const fileUri = new FileUri(BigInt(bucketId), source);
-  const fileResponse = await client.read(fileUri, { accessToken });
+  const fileResponse = await client.read(fileUri, { accessToken, correlationId });
   const outputFileStream = createWriteStream(dest);
 
   await pipeline(Readable.fromWeb(fileResponse.body), outputFileStream);

--- a/packages/cli/src/upload/index.ts
+++ b/packages/cli/src/upload/index.ts
@@ -7,6 +7,7 @@ import { DdcClient } from '@cere-ddc-sdk/ddc-client';
 export type UploadOptions = {
   bucketId: string;
   name?: string;
+  correlationId?: string;
 };
 
 export const upload = async (client: DdcClient, path: string, options: UploadOptions) => {

--- a/packages/cli/src/upload/uploadDir.ts
+++ b/packages/cli/src/upload/uploadDir.ts
@@ -9,6 +9,7 @@ export type UploadDirOptions = {
   bucketId: string;
   name?: string;
   accessToken?: string;
+  correlationId?: string;
 };
 
 export type RootDagNodeData = {
@@ -26,10 +27,11 @@ async function uploadFileLink(
   rootDir: string,
   filePath: string,
   stats: Stats,
-  { accessToken }: UploadDirOptions,
+  { accessToken, correlationId }: UploadDirOptions,
 ) {
   const cid = await uploadFile(client, filePath, stats, {
     accessToken,
+    correlationId,
     bucketId: bucketId.toString(),
   });
 
@@ -78,6 +80,7 @@ export const uploadDir = async (client: DdcClient, path: string, options: Upload
   const rootDagNode = new DagNode(JSON.stringify(data), fileLinks);
   const rootDagNodeUri = await client.store(bucketId, rootDagNode, {
     name: options.name,
+    correlationId: options.correlationId,
     accessToken: options.accessToken,
   });
 

--- a/packages/cli/src/upload/uploadFile.ts
+++ b/packages/cli/src/upload/uploadFile.ts
@@ -5,18 +5,19 @@ export type UploadFileOptions = {
   bucketId: string;
   name?: string;
   accessToken?: string;
+  correlationId?: string;
 };
 
 export const uploadFile = async (
   client: DdcClient,
   path: string,
   stats: Stats,
-  { name, bucketId, accessToken }: UploadFileOptions,
+  { name, bucketId, accessToken, correlationId }: UploadFileOptions,
 ) => {
   const fileStream = createReadStream(path);
   const ddcFile = new File(fileStream, { size: stats.size });
 
-  const fileUri = await client.store(BigInt(bucketId), ddcFile, { name, accessToken });
+  const fileUri = await client.store(BigInt(bucketId), ddcFile, { name, accessToken, correlationId });
 
   return fileUri.cid;
 };

--- a/packages/ddc-client/src/index.ts
+++ b/packages/ddc-client/src/index.ts
@@ -2,6 +2,7 @@ export * from './DdcClient';
 export * from './DdcUri';
 
 export {
+  createCorrelationId,
   KB,
   MB,
   DagNode,
@@ -11,6 +12,7 @@ export {
   UriSigner,
   JsonSigner,
   KeyringSigner,
+  CereWalletSigner,
   TESTNET,
   DEVNET,
   MAINNET,

--- a/packages/ddc/src/CnsApi/CnsApi.ts
+++ b/packages/ddc/src/CnsApi/CnsApi.ts
@@ -91,7 +91,7 @@ export class CnsApi {
    * ```
    */
   async putRecord({ token, bucketId, record, correlationId }: PutRequest): Promise<Record> {
-    this.logger.debug({ bucketId, record, token }, 'Storing CNS record');
+    this.logger.debug({ bucketId, record, token, correlationId }, 'Storing CNS record');
 
     const meta = createCorrelationRpcMeta(correlationId, createAuthRpcMeta(token));
     const { signer } = this.options;
@@ -109,7 +109,7 @@ export class CnsApi {
 
     await this.api.put({ bucketId, record: { ...record, signature } }, { meta });
 
-    this.logger.debug({ ...record }, 'CNS record stored');
+    this.logger.debug({ record, correlationId }, 'CNS record stored');
 
     return {
       ...record,
@@ -139,7 +139,7 @@ export class CnsApi {
    * ```
    */
   async getRecord({ token, name, bucketId, correlationId }: GetRequest): Promise<Record | undefined> {
-    this.logger.debug({ name, bucketId, token }, 'Retrieving CNS record');
+    this.logger.debug({ name, bucketId, token, correlationId }, 'Retrieving CNS record');
 
     let record: ProtoRecord | undefined;
     const meta = createCorrelationRpcMeta(correlationId, createAuthRpcMeta(token));
@@ -168,12 +168,12 @@ export class CnsApi {
     }
 
     if (!record?.signature) {
-      this.logger.debug({ name, bucketId }, 'CNS record not found');
+      this.logger.debug({ name, bucketId, correlationId }, 'CNS record not found');
 
       return undefined;
     }
 
-    this.logger.debug({ ...record }, 'CNS record retrieved');
+    this.logger.debug({ record, correlationId }, 'CNS record retrieved');
 
     return {
       ...record,

--- a/packages/ddc/src/CnsApi/CnsApi.ts
+++ b/packages/ddc/src/CnsApi/CnsApi.ts
@@ -2,25 +2,30 @@ import { RpcError } from '@protobuf-ts/runtime-rpc';
 import type { Signer } from '@cere-ddc-sdk/blockchain';
 
 import { RpcTransport } from '../transports';
-import { createRpcMeta, AuthToken } from '../auth';
+import { createRpcMeta as createAuthRpcMeta, AuthMetaParams } from '../auth';
 import { Logger, LoggerOptions, createLogger } from '../logger';
 import { GrpcStatus } from '../grpc/status';
 import { createSignature, mapSignature, Signature } from '../signature';
 import { CnsApiClient } from '../grpc/cns_api.client';
 import { GetRequest as ProtoGetRequest, PutRequest as ProtoPutRequest, Record as ProtoRecord } from '../grpc/cns_api';
-import { ActivityRequestType, createActivityRequest } from '../activity';
+import {
+  ActivityRequestType,
+  createActivityRequest,
+  CorrelationMetaParams,
+  createRpcMeta as createCorrelationRpcMeta,
+} from '../activity';
 
-type AuthParams = { token?: AuthToken };
 export type Record = Omit<ProtoRecord, 'signature'> & {
   signature: Signature;
 };
 
 type PutRequest = Omit<ProtoPutRequest, 'record'> &
-  AuthParams & {
+  CorrelationMetaParams &
+  AuthMetaParams & {
     record: Omit<Record, 'signature'>;
   };
 
-type GetRequest = ProtoGetRequest & AuthParams;
+type GetRequest = CorrelationMetaParams & ProtoGetRequest & AuthMetaParams;
 
 const createSignatureMessage = (record: Omit<Record, 'signature'>) => {
   const message = ProtoRecord.create(record);
@@ -85,10 +90,10 @@ export class CnsApi {
    * console.log(record); //
    * ```
    */
-  async putRecord({ token, bucketId, record }: PutRequest): Promise<Record> {
+  async putRecord({ token, bucketId, record, correlationId }: PutRequest): Promise<Record> {
     this.logger.debug({ bucketId, record, token }, 'Storing CNS record');
 
-    const meta = createRpcMeta(token);
+    const meta = createCorrelationRpcMeta(correlationId, createAuthRpcMeta(token));
     const { signer } = this.options;
 
     if (!signer) {
@@ -133,11 +138,11 @@ export class CnsApi {
    * console.log(record);
    * ```
    */
-  async getRecord({ token, name, bucketId }: GetRequest): Promise<Record | undefined> {
+  async getRecord({ token, name, bucketId, correlationId }: GetRequest): Promise<Record | undefined> {
     this.logger.debug({ name, bucketId, token }, 'Retrieving CNS record');
 
     let record: ProtoRecord | undefined;
-    const meta = createRpcMeta(token);
+    const meta = createCorrelationRpcMeta(correlationId, createAuthRpcMeta(token));
 
     if (this.options.signer) {
       meta.request = await createActivityRequest(

--- a/packages/ddc/src/DagApi/DagApi.ts
+++ b/packages/ddc/src/DagApi/DagApi.ts
@@ -74,7 +74,7 @@ export class DagApi {
   async putNode({ token, bucketId, node, cid, correlationId }: PutRequest) {
     const meta = createCorrelationRpcMeta(correlationId, createAuthRpcMeta(token));
 
-    this.logger.debug({ token, bucketId, node, cid }, 'Storing DAG Node');
+    this.logger.debug({ token, correlationId, bucketId, node, cid }, 'Storing DAG Node');
 
     if (this.options.signer && node) {
       meta.request = await createActivityRequest(
@@ -85,7 +85,7 @@ export class DagApi {
 
     const { response } = await this.api.put({ bucketId, node, cid }, { meta });
 
-    this.logger.debug({ cid }, 'DAG Node stored');
+    this.logger.debug({ cid, correlationId }, 'DAG Node stored');
 
     return new Uint8Array(response.cid);
   }
@@ -108,7 +108,7 @@ export class DagApi {
    * ```
    */
   async getNode({ token, correlationId, ...request }: GetRequest): Promise<Node | undefined> {
-    this.logger.debug({ ...request, token }, 'Retrieving DAG Node');
+    this.logger.debug({ ...request, token, correlationId }, 'Retrieving DAG Node');
 
     /**
      * In case a sub-node requested using root CID + path - we don't have the target node CID, so we can't authenticate it.
@@ -136,7 +136,7 @@ export class DagApi {
 
     await validator.validate();
 
-    this.logger.debug({ node: response.node }, 'DAG Node retrieved');
+    this.logger.debug({ node: response.node, correlationId }, 'DAG Node retrieved');
 
     return (
       response.node && {

--- a/packages/ddc/src/FileApi/FileApi.ts
+++ b/packages/ddc/src/FileApi/FileApi.ts
@@ -92,7 +92,7 @@ export class FileApi {
     const { signer } = this.options;
     const meta = createCorrelationRpcMeta(correlationId, createAuthRpcMeta(token));
     const partSize = ceilToPowerOf2(request.partSize);
-    this.logger.debug({ ...request, partSize, token }, 'Storing multipart piece');
+    this.logger.debug({ ...request, partSize, token, correlationId }, 'Storing multipart piece');
 
     if (signer) {
       meta.request = await createActivityRequest(
@@ -107,7 +107,7 @@ export class FileApi {
 
     const { response } = await this.api.putMultipartPiece({ ...request, partSize }, { meta });
 
-    this.logger.debug({ response }, 'Multipart piece stored');
+    this.logger.debug({ response, correlationId }, 'Multipart piece stored');
 
     return new Uint8Array(response.cid);
   }
@@ -142,7 +142,7 @@ export class FileApi {
     const size = getContentSize(content, metadata.size);
     const { signer } = this.options;
 
-    this.logger.debug({ metadata, token }, 'Storing raw piece of size %d', size);
+    this.logger.debug({ metadata, token, correlationId }, 'Storing raw piece of size %d', size);
 
     if (!size) {
       throw new Error('Cannot determine the raw piece size');
@@ -172,7 +172,7 @@ export class FileApi {
      * Wait for responce headers before start streaming piece content.
      */
     const headers = await call.headers;
-    this.logger.debug({ headers }, 'Server responded with headers');
+    this.logger.debug({ headers, correlationId }, 'Server responded with headers');
 
     let bytesSent = 0;
     const contentStream = isContentStream(content) ? content : createContentStream(content);
@@ -196,7 +196,7 @@ export class FileApi {
 
     await call.requests.complete();
     const { cid } = await call.response;
-    this.logger.debug({ cid }, 'Raw piece stored');
+    this.logger.debug({ cid, correlationId }, 'Raw piece stored');
 
     return new Uint8Array(cid);
   }
@@ -223,7 +223,7 @@ export class FileApi {
   async getFile({ token, correlationId, ...request }: GetFileRequest) {
     const { enableAcks, signer, authenticate = false } = this.options;
 
-    this.logger.debug({ request, token }, 'Started reading data');
+    this.logger.debug({ request, token, correlationId }, 'Started reading data');
 
     const requestId = createRequestId();
     const meta = createCorrelationRpcMeta(correlationId, createAuthRpcMeta(token));
@@ -263,7 +263,7 @@ export class FileApi {
      * Wait for responce headers to be received.
      */
     const headers = await call.headers;
-    this.logger.debug({ headers }, 'Server responded with headers');
+    this.logger.debug({ headers, correlationId }, 'Server responded with headers');
 
     /**
      * Create data stream from responce messages.

--- a/packages/ddc/src/activity/createCorrelationId.ts
+++ b/packages/ddc/src/activity/createCorrelationId.ts
@@ -1,0 +1,6 @@
+import { v4 as uuid } from 'uuid';
+
+/**
+ * Generate a random correlation ID.
+ */
+export const createCorrelationId = () => uuid();

--- a/packages/ddc/src/activity/createRpcMeta.ts
+++ b/packages/ddc/src/activity/createRpcMeta.ts
@@ -1,0 +1,8 @@
+import { v4 as uuid } from 'uuid';
+import { RpcMetadata } from '@protobuf-ts/runtime-rpc';
+
+export type CorrelationMetaParams = { correlationId?: string };
+
+export const createRpcMeta = (correlationId?: string, meta?: RpcMetadata): RpcMetadata => {
+  return { ...meta, CorrelationID: correlationId || uuid() };
+};

--- a/packages/ddc/src/activity/index.ts
+++ b/packages/ddc/src/activity/index.ts
@@ -1,3 +1,4 @@
 export * from './createActivityRequest';
 export * from './createAck';
 export * from './createRpcMeta';
+export * from './createCorrelationId';

--- a/packages/ddc/src/activity/index.ts
+++ b/packages/ddc/src/activity/index.ts
@@ -1,2 +1,3 @@
 export * from './createActivityRequest';
 export * from './createAck';
+export * from './createRpcMeta';

--- a/packages/ddc/src/auth/createRpcMeta.ts
+++ b/packages/ddc/src/auth/createRpcMeta.ts
@@ -1,6 +1,8 @@
 import { RpcMetadata } from '@protobuf-ts/runtime-rpc';
 import { AuthToken } from './AuthToken';
 
+export type AuthMetaParams = { token?: AuthToken };
+
 export const createRpcMeta = (token?: AuthToken, meta?: RpcMetadata): RpcMetadata => {
   const authMeta: RpcMetadata = {};
   if (token) {

--- a/packages/ddc/src/index.ts
+++ b/packages/ddc/src/index.ts
@@ -16,10 +16,12 @@ export * from './Piece';
 export { DagNode, DagNodeResponse, Link, Tag } from './DagNode';
 export { CnsRecord, CnsRecordResponse } from './CnsRecord';
 export { AuthToken, AuthTokenOperation, type AuthTokenParams } from './auth';
+export { createCorrelationId } from './activity';
 export {
   UriSigner,
   JsonSigner,
   KeyringSigner,
+  CereWalletSigner,
   StorageNodeMode,
   type Signer,
   type SignerType,

--- a/packages/ddc/src/nodes/BalancedNode.ts
+++ b/packages/ddc/src/nodes/BalancedNode.ts
@@ -51,6 +51,7 @@ export type BalancedNodeConfig = LoggerOptions & {
  */
 export class BalancedNode implements NodeInterface {
   readonly nodeId = 'BalancedNode';
+  readonly displayName = 'BalancedNode';
 
   private router: Router;
   private logger: Logger;
@@ -107,6 +108,15 @@ export class BalancedNode implements NodeInterface {
            * In case we fail to get a node, we retry with previous nodes that failed until the max attempts.
            */
           node = exclude.pop() || node;
+
+          if (node) {
+            this.logger.info(
+              `Reusing previous node for operation "%s" in bucket %s: %s`,
+              operation,
+              bucketId,
+              node.displayName,
+            );
+          }
         }
 
         if (!node) {

--- a/packages/ddc/src/nodes/NodeInterface.ts
+++ b/packages/ddc/src/nodes/NodeInterface.ts
@@ -12,6 +12,10 @@ type NamingOptions = {
   name?: string;
 };
 
+type ActivityOptions = {
+  correlationId?: string;
+};
+
 /**
  * The `OperationAuthOptions` type defines the authentication options for a DDC operation.
  *
@@ -30,12 +34,13 @@ export type OperationAuthOptions = {
  * @hidden
  * @extends OperationAuthOptions
  */
-export type PieceReadOptions = OperationAuthOptions & {
-  /**
-   * An optional range to read from the piece.
-   */
-  range?: ReadFileRange;
-};
+export type PieceReadOptions = ActivityOptions &
+  OperationAuthOptions & {
+    /**
+     * An optional range to read from the piece.
+     */
+    range?: ReadFileRange;
+  };
 
 /**
  * The `DagNodeGetOptions` type defines the options for retrieving a DAG node.
@@ -43,12 +48,13 @@ export type PieceReadOptions = OperationAuthOptions & {
  * @hidden
  * @extends OperationAuthOptions
  */
-export type DagNodeGetOptions = OperationAuthOptions & {
-  /**
-   * An optional path to retrieve from the DAG node.
-   */
-  path?: string;
-};
+export type DagNodeGetOptions = ActivityOptions &
+  OperationAuthOptions & {
+    /**
+     * An optional path to retrieve from the DAG node.
+     */
+    path?: string;
+  };
 
 /**
  * The `CnsRecordGetOptions` type defines the options for retrieving a CNS record.
@@ -56,12 +62,13 @@ export type DagNodeGetOptions = OperationAuthOptions & {
  * @hidden
  * @extends OperationAuthOptions
  */
-export type CnsRecordGetOptions = OperationAuthOptions & {
-  /**
-   * An optional path to retrieve from the CNS record.
-   */
-  path?: string;
-};
+export type CnsRecordGetOptions = ActivityOptions &
+  OperationAuthOptions & {
+    /**
+     * An optional path to retrieve from the CNS record.
+     */
+    path?: string;
+  };
 
 /**
  * The `PieceStoreOptions` type defines the options for storing a piece.
@@ -70,7 +77,7 @@ export type CnsRecordGetOptions = OperationAuthOptions & {
  * @extends NamingOptions
  * @extends OperationAuthOptions
  */
-export type PieceStoreOptions = NamingOptions & OperationAuthOptions;
+export type PieceStoreOptions = ActivityOptions & NamingOptions & OperationAuthOptions;
 
 /**
  * The `DagNodeStoreOptions` type defines the options for storing a DAG node.
@@ -79,7 +86,7 @@ export type PieceStoreOptions = NamingOptions & OperationAuthOptions;
  * @extends NamingOptions
  * @extends OperationAuthOptions
  */
-export type DagNodeStoreOptions = NamingOptions & OperationAuthOptions;
+export type DagNodeStoreOptions = ActivityOptions & NamingOptions & OperationAuthOptions;
 
 /**
  * The `CnsRecordStoreOptions` type defines the options for storing a CNS record.
@@ -87,7 +94,7 @@ export type DagNodeStoreOptions = NamingOptions & OperationAuthOptions;
  * @hidden
  * @extends OperationAuthOptions
  */
-export type CnsRecordStoreOptions = OperationAuthOptions;
+export type CnsRecordStoreOptions = ActivityOptions & OperationAuthOptions;
 
 /**
  * The `NodeInterface` interface defines the methods to interact with DDC storage nodes.
@@ -99,6 +106,11 @@ export interface NodeInterface {
    * The identifier of the node.
    */
   readonly nodeId: string;
+
+  /**
+   * The display name of the node.
+   */
+  readonly displayName: string;
 
   /**
    * Stores a piece in a specific bucket.

--- a/packages/ddc/src/routing/Router.ts
+++ b/packages/ddc/src/routing/Router.ts
@@ -72,14 +72,16 @@ export class Router {
       throw new Error('No nodes available to handle the operation');
     }
 
-    this.logger.info(`Selected node for operation "%s" in bucket %s: %s`, operation, bucketId, node.httpUrl);
-    this.logger.debug({ bucketId, node }, 'Selected node');
-
-    return new StorageNode(this.signer, {
+    const storageNode = new StorageNode(this.signer, {
       ...node,
       logger: this.logger,
       authToken: await this.sdkTokenPromise,
       nodeId: node.nodeId || node.grpcUrl,
     });
+
+    this.logger.info(`Selected node for operation "%s" in bucket %s: %s`, operation, bucketId, storageNode.displayName);
+    this.logger.debug({ bucketId, node }, 'Selected node');
+
+    return storageNode;
   }
 }

--- a/packages/ddc/src/transports/RpcTransport.ts
+++ b/packages/ddc/src/transports/RpcTransport.ts
@@ -1,11 +1,13 @@
 export type { RpcTransport } from '@protobuf-ts/runtime-rpc';
 
+import type { RpcOptions } from '@protobuf-ts/runtime-rpc';
+
 /**
  * The `RpcTransportOptions` type represents the options for an RPC transport.
  *
  * @group RPC Transport
  */
-export type RpcTransportOptions = {
+export type RpcTransportOptions = Pick<RpcOptions, 'interceptors'> & {
   /**
    * An optional number indicating the timeout for the connection.
    */

--- a/packages/file-storage/src/index.ts
+++ b/packages/file-storage/src/index.ts
@@ -2,4 +2,14 @@ export * from './File';
 export * from './FileStorage';
 export * from './constants';
 
-export { TESTNET, DEVNET, MAINNET, UriSigner, type Signer } from '@cere-ddc-sdk/ddc';
+export {
+  TESTNET,
+  DEVNET,
+  MAINNET,
+  UriSigner,
+  CereWalletSigner,
+  JsonSigner,
+  KeyringSigner,
+  type Signer,
+  createCorrelationId,
+} from '@cere-ddc-sdk/ddc';

--- a/tests/helpers/ddc.ts
+++ b/tests/helpers/ddc.ts
@@ -7,12 +7,13 @@ type NodeConfig = StorageNodeConfig & {
   mnemonic: string;
 };
 
-export const getStorageNodes = (host = 'localhost'): NodeConfig[] => [
+export const getStorageNodes = (host = 'localhost', options: Partial<StorageNodeConfig> = {}): NodeConfig[] => [
   {
     mode: StorageNodeMode.Storage,
     grpcUrl: `grpc://${host}:9091`,
     httpUrl: `http://${host}:8091`,
     mnemonic: 'whip clump surface eternal summer acoustic broom duty magic extend virtual fly',
+    ...options,
   },
 
   {
@@ -27,6 +28,7 @@ export const getStorageNodes = (host = 'localhost'): NodeConfig[] => [
     grpcUrl: `grpc://${host}:9093`,
     httpUrl: `http://${host}:8093`,
     mnemonic: 'rule output true detect matrix wife raven wreck primary mansion spike coral',
+    ...options,
   },
 
   {
@@ -34,6 +36,7 @@ export const getStorageNodes = (host = 'localhost'): NodeConfig[] => [
     grpcUrl: `grpc://${host}:9094`,
     httpUrl: `http://${host}:8094`,
     mnemonic: 'paper salon seed crystal gun envelope wolf twice pistol episode guitar borrow',
+    ...options,
   },
 
   {
@@ -41,6 +44,7 @@ export const getStorageNodes = (host = 'localhost'): NodeConfig[] => [
     grpcUrl: `grpc://${host}:9095`,
     httpUrl: `http://${host}:8095`,
     mnemonic: 'spike sun exchange lava weekend october sock wait attend garden carbon promote',
+    ...options,
   },
 ];
 


### PR DESCRIPTION
- Add new optional option to all operation methods: `correlationId`
- Pass this new option to gRPC meta by name `CorrelationID`
- If not provided - generate a random string in `uuid` format
- Add the support to CLI
- Cover with tests