### PR TITLE
fix(ddc): Do not sign an access token if already signed properly

### DIFF
--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -2,6 +2,8 @@ name: Deploy playground
 
 on:
   workflow_dispatch:
+  release:
+    types: [published]
 
 permissions:
   contents: read

--- a/packages/ddc/src/auth/AuthToken.ts
+++ b/packages/ddc/src/auth/AuthToken.ts
@@ -109,6 +109,13 @@ export class AuthToken {
     return this.token.payload!.expiresAt!;
   }
 
+  /**
+   * Whether the token is properly signed.
+   */
+  get isSigned() {
+    return this.subject ? this.signature?.signer === this.subject : !!this.signature;
+  }
+
   private toBinary() {
     return Token.toBinary(this.token);
   }

--- a/packages/ddc/src/nodes/StorageNode.ts
+++ b/packages/ddc/src/nodes/StorageNode.ts
@@ -111,10 +111,16 @@ export class StorageNode implements NodeInterface {
   }
 
   private async createAuthToken({ accessToken }: OperationAuthOptions = {}) {
-    const token = AuthToken.maybeToken(accessToken) || (await this.getRootToken());
-    const sdkSigner = token.subject && getSdkSigner(this.signer, token.subject);
+    const inputToken = AuthToken.maybeToken(accessToken);
 
-    return AuthToken.from(token).sign(sdkSigner || this.signer);
+    if (inputToken?.isSigned) {
+      return inputToken;
+    }
+
+    const unsignedToken = inputToken || (await this.getRootToken());
+    const sdkSigner = unsignedToken.subject && getSdkSigner(this.signer, unsignedToken.subject);
+
+    return AuthToken.from(unsignedToken).sign(sdkSigner || this.signer);
   }
 
   /**


### PR DESCRIPTION
The SDK was always signing a provided access token event if it is already signed. It led to problems with signed, not delegated tokens shared between  users. The tokens signature was updated making the tokens invalid.

After this fix, if the token is already properly signed the SDK will not sign it again.

Related bug report:
https://www.notion.so/cere/One-level-access-tokens-72b586e30b1744768ed480689043ff45?pvs=4