### PR TITLE
fix: Cere Wallet signer not triggering 3rd party extensions consent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2022,9 +2022,9 @@
       "link": true
     },
     "node_modules/@cere/embed-wallet": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@cere/embed-wallet/-/embed-wallet-0.17.0.tgz",
-      "integrity": "sha512-Cw+INQaTHDdW0bjQ+m3rk0QVDaU9nm9ajNzGIpDxz9DATduoEzaa+qGxYypAxa8Jj8pSQ7pM/unoBMGZTKhE1g==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@cere/embed-wallet/-/embed-wallet-0.20.1.tgz",
+      "integrity": "sha512-rDE1PcQVQd1p0qonxDqZLokBzFlLK+yI4LBnJfsIcKk9Yt2yq405G5GO5YYJ+28oikS7Nkkx6Hn5yDLNNMAa3Q==",
       "dependencies": {
         "@cere/torus-embed": "0.2.8",
         "@types/bn.js": "^5.1.1",
@@ -2033,9 +2033,9 @@
       }
     },
     "node_modules/@cere/embed-wallet-inject": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@cere/embed-wallet-inject/-/embed-wallet-inject-0.18.2.tgz",
-      "integrity": "sha512-olJyqYF+Mwu6cpSvevUXMI5swcoazPLKLjgqtcIOd2mlq24DhxeOcFkNVS3Gntq7HmVmoSJXTuTbdk0fY3ViBg==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@cere/embed-wallet-inject/-/embed-wallet-inject-0.20.1.tgz",
+      "integrity": "sha512-xvbvIuKNuwnODHXcy9Jq+nBOJ7FucjRMU+U8ZLbIwbwjcPLsZY7AjMUGgzPMLfmjnBSYdHcXZredTakzYyvVhw==",
       "dependencies": {
         "@polkadot/extension-inject": "^0.46.6"
       },
@@ -20890,7 +20890,7 @@
       "version": "2.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cere/embed-wallet-inject": "^0.18.2",
+        "@cere/embed-wallet-inject": "^0.20.1",
         "@polkadot/api": "^10.11.2",
         "@polkadot/api-base": "^10.11.2",
         "@polkadot/api-contract": "^10.11.2",
@@ -21043,7 +21043,7 @@
       "dependencies": {
         "@cere-ddc-sdk/blockchain": "2.10.0",
         "@cere-ddc-sdk/ddc-client": "2.12.0",
-        "@cere/embed-wallet": "^0.17.0",
+        "@cere/embed-wallet": "^0.20.1",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
         "@mui/icons-material": "^5.15.16",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -31,7 +31,7 @@
   "author": "Cere Network <contact@cere.io (https://www.cere.io/)",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cere/embed-wallet-inject": "^0.18.2",
+    "@cere/embed-wallet-inject": "^0.20.1",
     "@polkadot/api": "^10.11.2",
     "@polkadot/api-base": "^10.11.2",
     "@polkadot/api-contract": "^10.11.2",

--- a/playground/package.json
+++ b/playground/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@cere-ddc-sdk/blockchain": "2.10.0",
     "@cere-ddc-sdk/ddc-client": "2.12.0",
-    "@cere/embed-wallet": "^0.17.0",
+    "@cere/embed-wallet": "^0.20.1",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@mui/icons-material": "^5.15.16",


### PR DESCRIPTION
Refactored Cere Wallet signer to not use `inject` package from Polkadot.