### PR TITLE
feature: Add CNS Record cache control option

### DIFF
--- a/packages/ddc/src/DagNode.ts
+++ b/packages/ddc/src/DagNode.ts
@@ -102,8 +102,8 @@ export class DagNode {
    */
   public tags: Tag[];
 
-  constructor(data: Uint8Array | string | Buffer, links: Link[] = [], tags: Tag[] = []) {
-    this.dataBuffer = Buffer.from(data);
+  constructor(data?: Uint8Array | Buffer | string | null, links: Link[] = [], tags: Tag[] = []) {
+    this.dataBuffer = Buffer.from(data || []);
     this.links = links;
     this.tags = tags;
   }

--- a/packages/ddc/src/nodes/NodeInterface.ts
+++ b/packages/ddc/src/nodes/NodeInterface.ts
@@ -16,6 +16,10 @@ type ActivityOptions = {
   correlationId?: string;
 };
 
+type CacheControlOptions = {
+  cacheControl?: 'no-cache';
+};
+
 /**
  * The `OperationAuthOptions` type defines the authentication options for a DDC operation.
  *
@@ -34,7 +38,8 @@ export type OperationAuthOptions = {
  * @hidden
  * @extends OperationAuthOptions
  */
-export type PieceReadOptions = ActivityOptions &
+export type PieceReadOptions = CacheControlOptions &
+  ActivityOptions &
   OperationAuthOptions & {
     /**
      * An optional range to read from the piece.
@@ -48,7 +53,8 @@ export type PieceReadOptions = ActivityOptions &
  * @hidden
  * @extends OperationAuthOptions
  */
-export type DagNodeGetOptions = ActivityOptions &
+export type DagNodeGetOptions = CacheControlOptions &
+  ActivityOptions &
   OperationAuthOptions & {
     /**
      * An optional path to retrieve from the DAG node.
@@ -62,7 +68,8 @@ export type DagNodeGetOptions = ActivityOptions &
  * @hidden
  * @extends OperationAuthOptions
  */
-export type CnsRecordGetOptions = ActivityOptions &
+export type CnsRecordGetOptions = CacheControlOptions &
+  ActivityOptions &
   OperationAuthOptions & {
     /**
      * An optional path to retrieve from the CNS record.

--- a/packages/ddc/src/nodes/StorageNode.ts
+++ b/packages/ddc/src/nodes/StorageNode.ts
@@ -391,10 +391,10 @@ export class StorageNode implements NodeInterface {
    */
   async getCnsRecord(bucketId: BucketId, name: string, options?: CnsRecordGetOptions) {
     const token = await this.createAuthToken(options);
-    const correlationId = options?.correlationId || createCorrelationId();
+    const { cacheControl, correlationId = createCorrelationId() } = options || {};
 
     this.logger.info(`Getting CNS record by name "${name}" from bucket ${bucketId}`);
-    const record = await this.cnsApi.getRecord({ bucketId, name, token, correlationId });
+    const record = await this.cnsApi.getRecord({ bucketId, name, token, correlationId, cacheControl });
     this.logger.info('Got CNS record by name "%s" from bucket %s', name, bucketId);
 
     return record && new CnsRecordResponse(record.cid, record.name, record.signature);

--- a/tests/specs/CacheControl.spec.ts
+++ b/tests/specs/CacheControl.spec.ts
@@ -1,0 +1,86 @@
+import { DdcClient, DagNode, DagNodeUri } from '@cere-ddc-sdk/ddc-client';
+import { StorageNodeConfig } from '@cere-ddc-sdk/ddc';
+
+import { ROOT_USER_SEED, getStorageNodes, getClientConfig } from '../helpers';
+
+describe('Cache Control', () => {
+  let client: DdcClient;
+
+  const bucketId = 1n;
+  const cacheControlMetaKey = 'cache-control';
+
+  let grpcRequests: { method: string; service: string; meta: any }[] = [];
+  const getRequests = () => grpcRequests;
+  const interceptors: StorageNodeConfig['interceptors'] = [
+    {
+      interceptUnary(next, method, input, options) {
+        grpcRequests.push({ service: method.service.typeName, method: method.name, meta: options.meta });
+
+        return next(method, input, options);
+      },
+    },
+  ];
+
+  beforeAll(async () => {
+    client = await DdcClient.create(ROOT_USER_SEED, {
+      ...getClientConfig(),
+      nodes: getStorageNodes(undefined, { interceptors }),
+    });
+  });
+
+  afterAll(async () => {
+    await client.disconnect();
+  });
+
+  describe('CNS Api', () => {
+    const cnsName = 'test-cns-record';
+    let testUri: DagNodeUri;
+
+    beforeAll(async () => {
+      testUri = await client.store(bucketId, new DagNode(), { name: cnsName });
+    });
+
+    beforeEach(() => {
+      grpcRequests = [];
+    });
+
+    test('Resolve CNS Record', async () => {
+      const cid = await client.resolveName(testUri.bucketId, cnsName, {
+        cacheControl: 'no-cache',
+      });
+
+      expect(cid.toString()).toEqual(testUri.cid);
+      expect(getRequests()).toEqual(
+        expect.arrayContaining([
+          {
+            service: 'cns.CnsApi',
+            method: 'Get',
+            meta: expect.objectContaining({
+              [cacheControlMetaKey]: 'no-cache',
+            }),
+          },
+        ]),
+      );
+    });
+
+    test('Update and read DagNode by the CNS name', async () => {
+      const newUri = await client.store(bucketId, new DagNode(), { name: cnsName });
+      const { cid } = await client.read(new DagNodeUri(bucketId, cnsName), {
+        cacheControl: 'no-cache',
+      });
+
+      expect(cid).toEqual(newUri.cid);
+      expect(getRequests()).toEqual(
+        expect.arrayContaining([
+          {
+            service: 'cns.CnsApi',
+            method: 'Get',
+            meta: expect.objectContaining({
+              [cacheControlMetaKey]: 'no-cache',
+            }),
+          },
+        ]),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Added a new option to all `read` operation of the SDK called `cacheControl`. Currently it allows passing only fixed value `no-cache` - to disable CNS cache completely, but later it can be extended if needed.