### PR TITLE
fix: Update SDK token if signer address changed

### DIFF
--- a/packages/ddc/src/auth/sdkToken.ts
+++ b/packages/ddc/src/auth/sdkToken.ts
@@ -29,6 +29,10 @@ export const getSdkSigner = (signer: Signer, address: string) => {
   return getRegestry(signer).get(address);
 };
 
+export const isValidSdkToken = (signer: Signer, token: AuthToken) => {
+  return signer.address === token.signature?.signer;
+};
+
 export const createSdkToken = async (signer: Signer) => {
   if (!isWeb3Signer(signer)) {
     return AuthToken.fullAccess().sign(signer);


### PR DESCRIPTION
Cere Wallet signer address can be changed without re-initialization of the SDK. We need to rebuild the internal SDK token for new accounts of the signer.