### PR TITLE
fix: Properly get bucketId from BucketCreated event

### DIFF
--- a/packages/blockchain/src/Blockchain.ts
+++ b/packages/blockchain/src/Blockchain.ts
@@ -191,11 +191,14 @@ export class Blockchain {
       sendable
         .signAndSend(finalAccount, { nonce, signer: finalSigner }, (result) => {
           if (result.status.isFinalized) {
-            const events = result.events.map(({ event }) => ({
+            const events: Event[] = result.events.map(({ event }) => ({
               method: event.method,
               section: event.section,
               meta: event.meta.toJSON(),
               data: event.data.toJSON(),
+              payload: Object.fromEntries(
+                event.meta.fields.map((field, index) => [field.name, event.data[index].toJSON()]),
+              ),
             }));
 
             resolve({
@@ -338,4 +341,5 @@ export type Event = {
   section: string;
   method: string;
   data?: any;
+  payload?: Record<string, any>;
 };

--- a/packages/blockchain/src/DDCCustomersPallet.ts
+++ b/packages/blockchain/src/DDCCustomersPallet.ts
@@ -224,8 +224,8 @@ export class DDCCustomersPallet {
   extractCreatedBucketIds(events: Event[]) {
     return events
       .filter((event) => event.section === 'ddcCustomers' && event.method === 'BucketCreated')
-      .map((event) => event.data?.[0])
-      .filter((bucketId) => bucketId !== undefined && (typeof bucketId === 'number' || typeof bucketId === 'string'))
-      .map((bucketId) => BigInt(bucketId) as BucketId);
+      .map((event) => event.payload?.bucket_id)
+      .filter(Boolean)
+      .map(BigInt);
   }
 }


### PR DESCRIPTION
`BucketCreated` event has been updated on `Devnet` - new fields added in front of old ones (a braking change). have to change the event decoding algo to not rely on args order