### PR TITLE
fix(ddc): Auth token sign method waits the signer to become ready

### DIFF
--- a/packages/ddc/src/routing/BlockchainStrategy.ts
+++ b/packages/ddc/src/routing/BlockchainStrategy.ts
@@ -34,6 +34,10 @@ export class BlockchainStrategy extends PingStrategy {
 
     this.logger.debug({ nodes }, 'Using nodes from blockchain');
 
+    if (!nodes.length) {
+      throw new Error(`No nodes found in the cluster: ${clusterId}`);
+    }
+
     return nodes;
   }
 

--- a/packages/ddc/src/routing/Router.ts
+++ b/packages/ddc/src/routing/Router.ts
@@ -50,7 +50,7 @@ export class Router {
    * Returns an SDK token for the current signer
    */
   private getSdkToken() {
-    this.sdkTokenPromise = Promise.resolve(this.sdkTokenPromise).then((token) =>
+    this.sdkTokenPromise = Promise.all([this.sdkTokenPromise, this.signer.isReady()]).then(([token]) =>
       token && isValidSdkToken(this.signer, token) ? token : createSdkToken(this.signer),
     );
 

--- a/packages/ddc/src/signature/createSignature.ts
+++ b/packages/ddc/src/signature/createSignature.ts
@@ -10,17 +10,17 @@ export type CreateSignatureOptions = {
 };
 
 export const createSignature = async (signer: Signer, message: Uint8Array, { token }: CreateSignatureOptions = {}) => {
-  const finalSigner = maybeSdkSigner(signer, token);
+  const proxySigner = maybeSdkSigner(signer, token);
 
-  await finalSigner.isReady();
+  await proxySigner.isReady();
 
-  if (signer.type !== 'ed25519' && signer.type !== 'sr25519') {
-    throw new Error(`Signer type ${signer.type} is not allowed in DDC`);
+  if (proxySigner.type !== 'ed25519' && proxySigner.type !== 'sr25519') {
+    throw new Error(`Signer type ${proxySigner.type} is not allowed in DDC`);
   }
 
   return Signature.create({
-    algorithm: signer.type === 'ed25519' ? SigAlg.ED_25519 : SigAlg.SR_25519,
-    signer: finalSigner.publicKey,
-    value: await finalSigner.sign(message),
+    algorithm: proxySigner.type === 'ed25519' ? SigAlg.ED_25519 : SigAlg.SR_25519,
+    signer: proxySigner.publicKey,
+    value: await proxySigner.sign(message),
   });
 };


### PR DESCRIPTION
- Fix an issue with Auth tokens signing when it throws an error if the signer is not ready
- Added an explicit error about empty node list in a cluster