### PR TITLE
Support breaking changes in DDC SDK

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,7 +38,7 @@ jobs:
         if: ${{ !inputs.skipTests }}
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          role-to-assume: arn:aws:iam::${{ vars.DEV_NETWORK_AWS_ACCOUNT_ID }}:role/github
+          role-to-assume: arn:aws:iam::${{ vars.SHARED_AWS_ACCOUNT_ID }}:role/github
           role-session-name: ${{ github.event.repository.name }}
           aws-region: us-west-2
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          role-to-assume: arn:aws:iam::${{ vars.DEV_NETWORK_AWS_ACCOUNT_ID }}:role/github
+          role-to-assume: arn:aws:iam::${{ vars.SHARED_AWS_ACCOUNT_ID }}:role/github
           role-session-name: ${{ github.event.repository.name }}
           aws-region: us-west-2
 

--- a/examples/node/1-create-bucket/index.ts
+++ b/examples/node/1-create-bucket/index.ts
@@ -1,33 +1,36 @@
-import { DdcClient, TESTNET } from '@cere-ddc-sdk/ddc-client';
+import { DdcClient, UriSigner } from '@cere-ddc-sdk/ddc-client';
+import type { ClusterId } from '@cere-ddc-sdk/blockchain';
 
 const CERE = 10_000_000_000n;
 
 /**
  * The wallet should have enough CERE to pay for the transaction fees
  */
-const user = 'hybrid label reunion only dawn maze asset draft cousin height flock nation';
+const user = 'material own find flush hour view off begin crater weather world arrow';
 
 /**
  * The DDC cluster where the bucket will be created
  */
-const clusterId = '0x825c4b2352850de9986d9d28568db6f0c023a1e3';
+const clusterId: ClusterId = '0x825c4b2352850de9986d9d28568db6f0c023a1e3';
 
 /**
  * Create a DDC client instance and connect it to DDC TESTNET
  */
-const client = await DdcClient.create(user, TESTNET);
+const client = await DdcClient.create(new UriSigner(user, { type: 'ed25519' }), {
+  blockchain: 'wss://rpc.devnet.cere.network/ws',
+});
 
 /**
  * Get current deposit of the DDC customer
  */
-const deposit = await client.getDeposit();
+const deposit = await client.getDeposit(clusterId);
 console.log('Current deposit', deposit / CERE, 'CERE');
 
 /**
  * If the deposit is 0, deposit 5 CERE
  */
 if (deposit === 0n) {
-  await client.depositBalance(5n * CERE);
+  await client.depositBalance(clusterId, 5n * CERE);
   console.log('Deposited 5 CERE');
 }
 

--- a/packages/blockchain/docs/classes/DDCCustomersPallet.md
+++ b/packages/blockchain/docs/classes/DDCCustomersPallet.md
@@ -45,14 +45,15 @@ ___
 
 ### deposit
 
-▸ **deposit**(`value`): `Sendable`
+▸ **deposit**(`clusterId`, `value`): `Sendable`
 
-Deposits funds to the account.
+Deposits funds to the account for the specified cluster.
 
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
+| `clusterId` | \`0x$\{string}\` | The ID of the cluster. |
 | `value` | `bigint` | The amount to deposit. |
 
 #### Returns
@@ -64,7 +65,7 @@ An extrinsic to deposit funds.
 **`Example`**
 
 ```typescript
-const tx = blockchain.ddcCustomers.deposit(100n);
+const tx = blockchain.ddcCustomers.deposit('0x...', 100n);
 
 await blockchain.send(tx, { account });
 ```
@@ -73,14 +74,15 @@ ___
 
 ### depositExtra
 
-▸ **depositExtra**(`maxAdditional`): `Sendable`
+▸ **depositExtra**(`clusterId`, `maxAdditional`): `Sendable`
 
-Deposits additional funds to the account.
+Deposits additional funds to the account for the specified cluster.
 
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
+| `clusterId` | \`0x$\{string}\` | The ID of the cluster. |
 | `maxAdditional` | `bigint` | The maximum amount to deposit. |
 
 #### Returns
@@ -92,7 +94,38 @@ An extrinsic to deposit additional funds.
 **`Example`**
 
 ```typescript
-const tx = blockchain.ddcCustomers.depositExtra(100n);
+const tx = blockchain.ddcCustomers.depositExtra('0x...', 100n);
+
+await blockchain.send(tx, { account });
+```
+
+___
+
+### depositFor
+
+▸ **depositFor**(`targetAddress`, `clusterId`, `amount`): `Sendable`
+
+Deposits funds to the target address for the specified cluster.
+This allows a third party to deposit funds on behalf of another address.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `targetAddress` | `string` | The target address to deposit funds for. |
+| `clusterId` | \`0x$\{string}\` | The ID of the cluster. |
+| `amount` | `bigint` | The amount to deposit. |
+
+#### Returns
+
+`Sendable`
+
+An extrinsic to deposit funds for the target address.
+
+**`Example`**
+
+```typescript
+const tx = blockchain.ddcCustomers.depositFor('5D5PhZQNJzcJXVBxwJxZcsutjKPqUPydrvpu6HeiBfMae2Qu', '0x...', 100n);
 
 await blockchain.send(tx, { account });
 ```
@@ -207,9 +240,40 @@ ___
 
 ### getStackingInfo
 
-▸ **getStackingInfo**(`accountId`): `Promise`\<`undefined` \| `StakingInfo`\>
+▸ **getStackingInfo**(`clusterId`, `accountId`): `Promise`\<`undefined` \| `StakingInfo`\>
 
-Returns the staking info for the given account.
+Returns the staking info for the given account in the specified cluster.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `clusterId` | \`0x$\{string}\` | The ID of the cluster. |
+| `accountId` | `string` | The ID of the account. |
+
+#### Returns
+
+`Promise`\<`undefined` \| `StakingInfo`\>
+
+A promise that resolves to the staking info.
+
+**`Example`**
+
+```typescript
+const stakingInfo = await blockchain.ddcCustomers.getStackingInfo('0x...', '5D5PhZQNJzcJXVBxwJxZcsutjKPqUPydrvpu6HeiBfMae2Qu');
+
+console.log(stakingInfo);
+```
+
+___
+
+### getStackingInfoLegacy
+
+▸ **getStackingInfoLegacy**(`accountId`): `Promise`\<`undefined` \| `StakingInfo`\>
+
+Returns the staking info for the given account (legacy method - deprecated).
+This method is deprecated because the storage has migrated to cluster-based ledger.
+Use getStackingInfo(clusterId, accountId) instead.
 
 #### Parameters
 
@@ -223,13 +287,9 @@ Returns the staking info for the given account.
 
 A promise that resolves to the staking info.
 
-**`Example`**
+**`Deprecated`**
 
-```typescript
-const stakingInfo = await blockchain.ddcCustomers.getStackingInfo('5D5PhZQNJzcJXVBxwJxZcsutjKPqUPydrvpu6HeiBfMae2Qu');
-
-console.log(stakingInfo);
-```
+Use getStackingInfo(clusterId, accountId) instead.
 
 ___
 
@@ -314,26 +374,27 @@ ___
 
 ### unlockDeposit
 
-▸ **unlockDeposit**(`value`): `Sendable`
+▸ **unlockDeposit**(`clusterId`, `value`): `Sendable`
 
-Withdraws funds from the account.
+Unlocks deposit funds from the account for the specified cluster.
 
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `value` | `bigint` | The amount to withdraw. |
+| `clusterId` | \`0x$\{string}\` | The ID of the cluster. |
+| `value` | `bigint` | The amount to unlock. |
 
 #### Returns
 
 `Sendable`
 
-An extrinsic to withdraw funds.
+An extrinsic to unlock deposit funds.
 
 **`Example`**
 
 ```typescript
-const tx = blockchain.ddcCustomers.withdraw(100n);
+const tx = blockchain.ddcCustomers.unlockDeposit('0x...', 100n);
 
 await blockchain.send(tx, { account });
 ```
@@ -342,9 +403,15 @@ ___
 
 ### withdrawUnlockedDeposit
 
-▸ **withdrawUnlockedDeposit**(): `Sendable`
+▸ **withdrawUnlockedDeposit**(`clusterId`): `Sendable`
 
-Withdraws unlocked funds from the account.
+Withdraws unlocked funds from the account for the specified cluster.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `clusterId` | \`0x$\{string}\` | The ID of the cluster. |
 
 #### Returns
 
@@ -355,7 +422,7 @@ An extrinsic to withdraw unlocked funds.
 **`Example`**
 
 ```typescript
-const tx = blockchain.ddcCustomers.withdrawUnlockedDeposit();
+const tx = blockchain.ddcCustomers.withdrawUnlockedDeposit('0x...');
 
 await blockchain.send(tx, { account });
 ```

--- a/packages/cli/src/account.ts
+++ b/packages/cli/src/account.ts
@@ -8,7 +8,6 @@ export type AccountOptions = Pick<CreateClientOptions, 'signer' | 'signerType'>;
 
 interface AccountResult {
   balance: number;
-  deposit: number;
   address: string;
   type: KeypairType;
   publicKey: string;
@@ -21,11 +20,10 @@ export const account = async (
   const realSigner = await createSigner(signer, signerType);
   await realSigner.isReady();
 
-  const [balance, deposit] = await Promise.all([client?.getBalance() || BigInt(0), client?.getDeposit() || BigInt(0)]);
+  const balance = (await client?.getBalance()) || BigInt(0);
 
   return {
     balance: Number(balance / BigInt(CERE)),
-    deposit: Number(deposit / BigInt(CERE)),
     address: realSigner.address,
     type: realSigner.type,
     publicKey: '0x' + Buffer.from(realSigner.publicKey).toString('hex'),

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { mnemonicGenerate } from '@polkadot/util-crypto';
+import type { ClusterId } from '@cere-ddc-sdk/blockchain';
 
 import { upload } from './upload';
 import { createBucket } from './createBucket';
@@ -160,7 +161,7 @@ yargs(hideBin(process.argv))
   )
   .command(
     'deposit <amount>',
-    'Deposit CERE tokens',
+    'Deposit CERE tokens to a cluster',
     (yargs) =>
       yargs
         .positional('amount', {
@@ -168,16 +169,25 @@ yargs(hideBin(process.argv))
           demandOption: true,
           describe: 'Amount of CERE tokens to deposit',
         })
+        .option('clusterId', {
+          alias: 'c',
+          type: 'string',
+          demandOption: true,
+          describe: 'Cluster ID to deposit tokens for',
+        })
         .option('allowExtra', {
           type: 'boolean',
           default: true,
           describe: 'Whether to allow extra amount to be deposited',
         }),
     async (argv) => {
-      const total = await withClient(argv, (client) => deposit(client, argv.amount, argv));
+      const total = await withClient(argv, (client) =>
+        deposit(client, argv.amount, { ...argv, clusterId: argv.clusterId as ClusterId }),
+      );
 
       console.group('Deposit completed');
       console.log('Network:', argv.network);
+      console.log('Cluster ID:', argv.clusterId);
       console.log('Amount:', argv.amount);
       console.log('Total deposit:', total);
       console.groupEnd();
@@ -253,7 +263,6 @@ yargs(hideBin(process.argv))
 
       if (!argv.random) {
         console.log('Balance:', acc.balance);
-        console.log('Deposit:', acc.deposit);
       }
 
       console.groupEnd();

--- a/packages/cli/src/deposit.ts
+++ b/packages/cli/src/deposit.ts
@@ -1,14 +1,16 @@
 import { DdcClient } from '@cere-ddc-sdk/ddc-client';
+import type { ClusterId } from '@cere-ddc-sdk/blockchain';
 
 import { CERE } from './constants';
 
 export type DepositOptions = {
   allowExtra: boolean;
+  clusterId: ClusterId;
 };
 
 export const deposit = async (client: DdcClient, amount: number, options: DepositOptions) => {
-  await client.depositBalance(BigInt(amount * CERE), options);
-  const totalBalance = await client.getDeposit();
+  await client.depositBalance(options.clusterId, BigInt(amount * CERE), options);
+  const totalBalance = await client.getDeposit(options.clusterId);
 
   return Number(totalBalance / BigInt(CERE));
 };

--- a/packages/ddc-client/docs/classes/DdcClient.md
+++ b/packages/ddc-client/docs/classes/DdcClient.md
@@ -74,16 +74,17 @@ ___
 
 ### depositBalance
 
-▸ **depositBalance**(`amount`, `options?`): `Promise`\<`SendResult`\>
+▸ **depositBalance**(`clusterId`, `amount`, `options?`): `Promise`\<`SendResult`\>
 
-Deposits a specified amount of tokens to the account. The account must have enough tokens to cover the deposit.
+Deposits a specified amount of tokens to the account for a specific cluster. The account must have enough tokens to cover the deposit.
 
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
+| `clusterId` | \`0x$\{string}\` | The ID of the cluster to deposit tokens for. |
 | `amount` | `bigint` | The amount of tokens to deposit. |
-| `options` | `DepositBalanceOptions` | - |
+| `options` | `DepositBalanceOptions` | Additional options for the deposit. |
 
 #### Returns
 
@@ -94,8 +95,43 @@ A promise that resolves to the transaction hash of the deposit.
 **`Example`**
 
 ```typescript
+const clusterId: ClusterId = '0x...';
 const amount = 100n;
-const txHash = await ddcClient.depositBalance(amount);
+const txHash = await ddcClient.depositBalance(clusterId, amount);
+
+console.log(txHash);
+```
+
+___
+
+### depositBalanceFor
+
+▸ **depositBalanceFor**(`targetAddress`, `clusterId`, `amount`): `Promise`\<`SendResult`\>
+
+Deposits a specified amount of tokens to the target address for a specific cluster.
+This allows depositing funds on behalf of another address.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `targetAddress` | `string` | The target address to deposit funds for. |
+| `clusterId` | \`0x$\{string}\` | The ID of the cluster to deposit tokens for. |
+| `amount` | `bigint` | The amount of tokens to deposit. |
+
+#### Returns
+
+`Promise`\<`SendResult`\>
+
+A promise that resolves to the transaction hash of the deposit.
+
+**`Example`**
+
+```typescript
+const targetAddress = '5D5PhZQNJzcJXVBxwJxZcsutjKPqUPydrvpu6HeiBfMae2Qu';
+const clusterId: ClusterId = '0x...';
+const amount = 100n;
+const txHash = await ddcClient.depositBalanceFor(targetAddress, clusterId, amount);
 
 console.log(txHash);
 ```
@@ -177,9 +213,16 @@ ___
 
 ### getDeposit
 
-▸ **getDeposit**(): `Promise`\<`bigint`\>
+▸ **getDeposit**(`clusterId`, `accountId?`): `Promise`\<`bigint`\>
 
-Retrieves the current active deposit of the account.
+Retrieves the current active deposit of the account for a specific cluster.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `clusterId` | \`0x$\{string}\` | The ID of the cluster to get deposit for. |
+| `accountId?` | `string` | Optional account ID. If not provided, uses the signer's address. |
 
 #### Returns
 
@@ -190,7 +233,8 @@ A promise that resolves to the current active deposit of the account.
 **`Example`**
 
 ```typescript
-const deposit = await ddcClient.getDeposit();
+const clusterId: ClusterId = '0x...';
+const deposit = await ddcClient.getDeposit(clusterId);
 
 console.log(deposit);
 ```
@@ -347,11 +391,71 @@ Will throw an error if the `entity` argument is neither a File nor a DagNode.
 
 ```typescript
 const bucketId: BucketId = 1n;
-const fileContent = ...;
+const fileContent = '...';
 const file: File = new File(fileContent, { size: 1000 });
 const fileUri = await ddcClient.store(bucketId, file);
 
 console.log(fileUri);
+```
+
+___
+
+### unlockDeposit
+
+▸ **unlockDeposit**(`clusterId`, `amount`): `Promise`\<`SendResult`\>
+
+Unlocks deposit funds from the account for the specified cluster.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `clusterId` | \`0x$\{string}\` | The ID of the cluster. |
+| `amount` | `bigint` | The amount to unlock. |
+
+#### Returns
+
+`Promise`\<`SendResult`\>
+
+A promise that resolves to the transaction hash.
+
+**`Example`**
+
+```typescript
+const clusterId: ClusterId = '0x...';
+const amount = 100n;
+const txHash = await ddcClient.unlockDeposit(clusterId, amount);
+
+console.log(txHash);
+```
+
+___
+
+### withdrawUnlockedDeposit
+
+▸ **withdrawUnlockedDeposit**(`clusterId`): `Promise`\<`SendResult`\>
+
+Withdraws unlocked funds from the account for the specified cluster.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `clusterId` | \`0x$\{string}\` | The ID of the cluster. |
+
+#### Returns
+
+`Promise`\<`SendResult`\>
+
+A promise that resolves to the transaction hash.
+
+**`Example`**
+
+```typescript
+const clusterId: ClusterId = '0x...';
+const txHash = await ddcClient.withdrawUnlockedDeposit(clusterId);
+
+console.log(txHash);
 ```
 
 ___

--- a/tests/setup/environment/blockchain.ts
+++ b/tests/setup/environment/blockchain.ts
@@ -166,7 +166,7 @@ export const setupBlockchain = async () => {
   console.time('Create buckets');
   const bucketsSendResult = await blockchain.batchAllSend(
     [
-      blockchain.ddcCustomers.deposit(100n * CERE),
+      blockchain.ddcCustomers.deposit(clusterId, 100n * CERE),
       blockchain.ddcCustomers.createBucket(clusterId, { isPublic: true }), // 1n - public bucket
       blockchain.ddcCustomers.createBucket(clusterId, { isPublic: false }), // 2n - private bucket
     ],

--- a/tests/setup/environment/docker-compose.blockchain.ci.yml
+++ b/tests/setup/environment/docker-compose.blockchain.ci.yml
@@ -4,7 +4,7 @@ services:
   cere-chain:
     platform: linux/amd64
     container_name: cere-chain
-    image: '625402836641.dkr.ecr.us-west-2.amazonaws.com/pos-network-node:dev-latest'
+    image: '553141076202.dkr.ecr.us-west-2.amazonaws.com/pos-network-node:dev-latest'
     command: bash -c "/usr/local/bin/cere --dev --alice --rpc-external"
     ports:
       - '9944:9944'

--- a/tests/setup/environment/docker-compose.blockchain.yml
+++ b/tests/setup/environment/docker-compose.blockchain.yml
@@ -4,7 +4,7 @@ services:
   cere-chain:
     platform: linux/amd64
     container_name: cere-chain
-    image: '625402836641.dkr.ecr.us-west-2.amazonaws.com/pos-network-node:dev-latest'
+    image: '553141076202.dkr.ecr.us-west-2.amazonaws.com/pos-network-node:dev-latest'
     command: bash -c "/usr/local/bin/cere --dev --alice --base-path ./data --rpc-external"
     ports:
       - '9944:9944'

--- a/tests/setup/environment/docker-compose.ddc.yml
+++ b/tests/setup/environment/docker-compose.ddc.yml
@@ -4,7 +4,7 @@ services:
   ddc-storage-node-1:
     platform: linux/amd64
     container_name: ddc-storage-node-1
-    image: 'cerebellumnetwork/ddc-storage-node@sha256:74440417f7403f114af6be04d2e8f4bd783efee1e64bd2abe799d4dbadef5892'
+    image: cerebellumnetwork/ddc-storage-node@sha256:f68d44152d11552c5986f3676fae416ee099f6cc4dac9c44171d42754ab9d894
     environment:
       - 'NODE_ID=1'
       - 'MODE=storage'
@@ -32,7 +32,7 @@ services:
   ddc-storage-node-2:
     platform: linux/amd64
     container_name: ddc-storage-node-2
-    image: 'cerebellumnetwork/ddc-storage-node@sha256:74440417f7403f114af6be04d2e8f4bd783efee1e64bd2abe799d4dbadef5892'
+    image: cerebellumnetwork/ddc-storage-node@sha256:f68d44152d11552c5986f3676fae416ee099f6cc4dac9c44171d42754ab9d894
     environment:
       - 'NODE_ID=2'
       - 'MODE=storage'
@@ -60,7 +60,7 @@ services:
   ddc-storage-node-3:
     platform: linux/amd64
     container_name: ddc-storage-node-3
-    image: 'cerebellumnetwork/ddc-storage-node@sha256:74440417f7403f114af6be04d2e8f4bd783efee1e64bd2abe799d4dbadef5892'
+    image: cerebellumnetwork/ddc-storage-node@sha256:f68d44152d11552c5986f3676fae416ee099f6cc4dac9c44171d42754ab9d894
     environment:
       - 'NODE_ID=3'
       - 'MODE=full'
@@ -88,7 +88,7 @@ services:
   ddc-storage-node-4:
     platform: linux/amd64
     container_name: ddc-storage-node-4
-    image: 'cerebellumnetwork/ddc-storage-node@sha256:74440417f7403f114af6be04d2e8f4bd783efee1e64bd2abe799d4dbadef5892'
+    image: cerebellumnetwork/ddc-storage-node@sha256:f68d44152d11552c5986f3676fae416ee099f6cc4dac9c44171d42754ab9d894
     environment:
       - 'NODE_ID=4'
       - 'MODE=full'
@@ -116,7 +116,7 @@ services:
   ddc-storage-node-5:
     platform: linux/amd64
     container_name: ddc-storage-node-5
-    image: 'cerebellumnetwork/ddc-storage-node@sha256:74440417f7403f114af6be04d2e8f4bd783efee1e64bd2abe799d4dbadef5892'
+    image: cerebellumnetwork/ddc-storage-node@sha256:f68d44152d11552c5986f3676fae416ee099f6cc4dac9c44171d42754ab9d894
     environment:
       - 'NODE_ID=5'
       - 'MODE=cache'

--- a/tests/setup/environment/docker-compose.ddc.yml
+++ b/tests/setup/environment/docker-compose.ddc.yml
@@ -4,7 +4,7 @@ services:
   ddc-storage-node-1:
     platform: linux/amd64
     container_name: ddc-storage-node-1
-    image: 'cerebellumnetwork/ddc-storage-node:devnet'
+    image: 'cerebellumnetwork/ddc-storage-node@sha256:74440417f7403f114af6be04d2e8f4bd783efee1e64bd2abe799d4dbadef5892'
     environment:
       - 'NODE_ID=1'
       - 'MODE=storage'
@@ -32,7 +32,7 @@ services:
   ddc-storage-node-2:
     platform: linux/amd64
     container_name: ddc-storage-node-2
-    image: 'cerebellumnetwork/ddc-storage-node:devnet'
+    image: 'cerebellumnetwork/cerebellumnetwork/ddc-storage-node@sha256:74440417f7403f114af6be04d2e8f4bd783efee1e64bd2abe799d4dbadef5892'
     environment:
       - 'NODE_ID=2'
       - 'MODE=storage'
@@ -60,7 +60,7 @@ services:
   ddc-storage-node-3:
     platform: linux/amd64
     container_name: ddc-storage-node-3
-    image: 'cerebellumnetwork/ddc-storage-node:devnet'
+    image: 'cerebellumnetwork/ddc-storage-node@sha256:74440417f7403f114af6be04d2e8f4bd783efee1e64bd2abe799d4dbadef5892'
     environment:
       - 'NODE_ID=3'
       - 'MODE=full'
@@ -88,7 +88,7 @@ services:
   ddc-storage-node-4:
     platform: linux/amd64
     container_name: ddc-storage-node-4
-    image: 'cerebellumnetwork/ddc-storage-node:devnet'
+    image: 'cerebellumnetwork/ddc-storage-node@sha256:74440417f7403f114af6be04d2e8f4bd783efee1e64bd2abe799d4dbadef5892'
     environment:
       - 'NODE_ID=4'
       - 'MODE=full'
@@ -116,7 +116,7 @@ services:
   ddc-storage-node-5:
     platform: linux/amd64
     container_name: ddc-storage-node-5
-    image: 'cerebellumnetwork/ddc-storage-node:devnet'
+    image: 'cerebellumnetwork/ddc-storage-node@sha256:74440417f7403f114af6be04d2e8f4bd783efee1e64bd2abe799d4dbadef5892'
     environment:
       - 'NODE_ID=5'
       - 'MODE=cache'

--- a/tests/setup/environment/docker-compose.ddc.yml
+++ b/tests/setup/environment/docker-compose.ddc.yml
@@ -32,7 +32,7 @@ services:
   ddc-storage-node-2:
     platform: linux/amd64
     container_name: ddc-storage-node-2
-    image: 'cerebellumnetwork/cerebellumnetwork/ddc-storage-node@sha256:74440417f7403f114af6be04d2e8f4bd783efee1e64bd2abe799d4dbadef5892'
+    image: 'cerebellumnetwork/ddc-storage-node@sha256:74440417f7403f114af6be04d2e8f4bd783efee1e64bd2abe799d4dbadef5892'
     environment:
       - 'NODE_ID=2'
       - 'MODE=storage'

--- a/tests/specs/DdcClient.spec.ts
+++ b/tests/specs/DdcClient.spec.ts
@@ -197,16 +197,16 @@ describe('DDC Client', () => {
     });
 
     test('Get deposit', async () => {
-      const deposit = await client.getDeposit();
+      const deposit = await client.getDeposit(clusterId);
 
       expect(deposit).toEqual(expect.any(BigInt));
     });
 
     test('Deposit balance', async () => {
       const toDeposit = 10n * CERE;
-      const prevDeposit = await client.getDeposit();
-      await client.depositBalance(toDeposit);
-      const nextDeposit = await client.getDeposit();
+      const prevDeposit = await client.getDeposit(clusterId);
+      await client.depositBalance(clusterId, toDeposit);
+      const nextDeposit = await client.getDeposit(clusterId);
 
       expect(nextDeposit - prevDeposit).toEqual(toDeposit);
     });

--- a/tests/specs/Errors.spec.ts
+++ b/tests/specs/Errors.spec.ts
@@ -45,16 +45,10 @@ describe('Errors', () => {
 
     it('should throw an RPC bucket error', async () => {
       const error = await client.store(99n, smallFile).catch((error) => error);
-      console.dir(error, { depth: null });
 
-      expect(error).toBeInstanceOf(NodeError);
-      expect(error).toEqual(
-        expect.objectContaining({
-          code: 'NOT_FOUND',
-          correlationId: expect.any(String),
-          nodeId: expect.any(String),
-        }),
-      );
+      expect(error).toBeInstanceOf(Error);
+
+      expect(error.message).toMatch(/no bucket/i);
     });
   });
 

--- a/tests/specs/Errors.spec.ts
+++ b/tests/specs/Errors.spec.ts
@@ -45,6 +45,7 @@ describe('Errors', () => {
 
     it('should throw an RPC bucket error', async () => {
       const error = await client.store(99n, smallFile).catch((error) => error);
+      console.dir(error, { depth: null });
 
       expect(error).toBeInstanceOf(NodeError);
       expect(error).toEqual(


### PR DESCRIPTION
- Migrated from ledger to clusterLedger in ddcCustomers pallet
- Updated deposit, depositExtra, unlockDeposit, and withdrawUnlockedDeposit methods to support clusterId
- Added new methods: depositFor, depositBalanceFor, getStackingInfoLegacy
- Updated CLI commands: deposit and account
- Updated tests and examples