### PR TITLE
fix(ci): refresh package-lock.json and guard against staleness

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -49,6 +49,19 @@ jobs:
       - name: Install packages
         run: npm ci --legacy-peer-deps
 
+      # `npm ci` rewrites package-lock.json when it disagrees with the workspace
+      # package.json files. That leaves the tree dirty, and `lerna publish` then
+      # aborts with an opaque `EUNCOMMIT ... M package-lock.json` at the very last
+      # step (run 30500853727). Fail here instead, with a message that says what to do.
+      - name: Verify package-lock.json is up to date
+        run: |
+          if ! git diff --exit-code --quiet package-lock.json; then
+            echo "::error::package-lock.json is out of date — 'npm ci' rewrote it."
+            echo "Run 'npm ci --legacy-peer-deps' locally in a clean checkout and commit the result."
+            git diff --stat package-lock.json
+            exit 1
+          fi
+
       - name: Build packages
         run: npm run build
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,6 +39,19 @@ jobs:
       - name: Install packages
         run: npm ci
 
+      # Catch a stale lockfile on the PR that introduces it, rather than at the
+      # publish step where it surfaces as `lerna ERR! EUNCOMMIT` (run 30500853727).
+      # Adding/changing `engines`, deps, or a workspace's version all require the
+      # lockfile to be regenerated and committed alongside.
+      - name: Verify package-lock.json is up to date
+        run: |
+          if ! git diff --exit-code --quiet package-lock.json; then
+            echo "::error::package-lock.json is out of date — 'npm ci' rewrote it."
+            echo "Run 'npm ci' locally in a clean checkout and commit the result."
+            git diff --stat package-lock.json
+            exit 1
+          fi
+
       - name: Check code style
         run: npm run lint
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,8 +36,12 @@ jobs:
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
 
+      # Must match publish.yaml's install flags. Without --legacy-peer-deps npm
+      # records some transitive packages as `peer` rather than `dev`, so the two
+      # workflows would each rewrite the lockfile the other committed and no single
+      # lockfile could satisfy both.
       - name: Install packages
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       # Catch a stale lockfile on the PR that introduces it, rather than at the
       # publish step where it surfaces as `lerna ERR! EUNCOMMIT` (run 30500853727).
@@ -47,7 +51,7 @@ jobs:
         run: |
           if ! git diff --exit-code --quiet package-lock.json; then
             echo "::error::package-lock.json is out of date — 'npm ci' rewrote it."
-            echo "Run 'npm ci' locally in a clean checkout and commit the result."
+            echo "Run 'npm ci --legacy-peer-deps' locally in a clean checkout and commit the result."
             git diff --stat package-lock.json
             exit 1
           fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,1745 +43,6 @@
         "@cere-ddc-sdk/cli": "3.0.0"
       }
     },
-    "examples/cli/node_modules/@cere-ddc-sdk/blockchain": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/@cere-ddc-sdk/blockchain/-/blockchain-2.16.1.tgz",
-      "integrity": "sha512-Jln6bGL5NA6vuAhTXuLl0V95eHx1ISWDVEQ3tt3H8PFWjSovW0bWdiydMLsYfCmWaVo4Ofz7aqqhzEtk180k0Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cere/embed-wallet-inject": "^0.20.1",
-        "@polkadot/api": "^16.4.9",
-        "@polkadot/api-base": "^16.4.9",
-        "@polkadot/api-contract": "^16.4.9",
-        "@polkadot/extension-dapp": "^0.62.2",
-        "@polkadot/extension-inject": "^0.62.2",
-        "@polkadot/keyring": "^13.3.1",
-        "@polkadot/rpc-core": "^16.4.9",
-        "@polkadot/rpc-provider": "^16.4.9",
-        "@polkadot/types": "^16.4.9",
-        "@polkadot/types-codec": "^16.4.9",
-        "@polkadot/types-create": "^16.4.9",
-        "@polkadot/util": "^13.5.7",
-        "@polkadot/util-crypto": "^13.5.7"
-      },
-      "peerDependencies": {
-        "@cere/embed-wallet": "*"
-      },
-      "peerDependenciesMeta": {
-        "@cere/embed-wallet": {
-          "optional": true
-        }
-      }
-    },
-    "examples/cli/node_modules/@cere-ddc-sdk/ddc": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/@cere-ddc-sdk/ddc/-/ddc-2.16.1.tgz",
-      "integrity": "sha512-Hwx96Izb/2VMQz1nmYlUmJ+HDdLjIW1kD+FeOmzdPkQvqfXMy8zcCAAR06gKnPyNzv/0nOfjSAFZohcyLuNa3Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cere-ddc-sdk/blockchain": "2.16.1",
-        "@grpc/grpc-js": "^1.9.13",
-        "@protobuf-ts/grpc-transport": "^2.9.3",
-        "@protobuf-ts/runtime": "^2.9.3",
-        "@protobuf-ts/runtime-rpc": "^2.9.3",
-        "async-retry": "^1.3.3",
-        "bs58": "^5.0.0",
-        "buffer": "^6.0.3",
-        "cross-fetch": "^4.0.0",
-        "format-util": "^1.0.5",
-        "hash-wasm": "^4.11.0",
-        "pino": "^8.17.2",
-        "pino-pretty": "^10.3.1",
-        "rfc4648": "^1.5.3",
-        "uuid": "^9.0.1"
-      }
-    },
-    "examples/cli/node_modules/@cere-ddc-sdk/ddc-client": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/@cere-ddc-sdk/ddc-client/-/ddc-client-2.16.1.tgz",
-      "integrity": "sha512-fN0IhCA0pgkqFIk39x7C1LNvVW/vuWREEbf4wtHl8vO9IwKZnGMsHIIBrHP/t3yaAdsOwPZ05GTytj2SdndgIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cere-ddc-sdk/blockchain": "2.16.1",
-        "@cere-ddc-sdk/ddc": "2.16.1",
-        "@cere-ddc-sdk/file-storage": "2.16.1"
-      }
-    },
-    "examples/cli/node_modules/@cere-ddc-sdk/file-storage": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/@cere-ddc-sdk/file-storage/-/file-storage-2.16.1.tgz",
-      "integrity": "sha512-K5k56i3V5mIrTM6m4qHqYmTwoS26lWsZ2TX9/WbDWfzmhhNJP1alQRvx4ewUT12pRsOrebpEwKvMmCSyVHKWIw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cere-ddc-sdk/blockchain": "2.16.1",
-        "@cere-ddc-sdk/ddc": "2.16.1"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api": {
-      "version": "16.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-16.5.6.tgz",
-      "integrity": "sha512-5h/X3pY8WpqGk4XTaiIUjKD6Pnk8k4bJ6EIwPKLP8/kfFWKSOenpN6ggZxANr+Qj+RgXrp4TxJVcuhXSiBh9Sg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api-augment": "16.5.6",
-        "@polkadot/api-base": "16.5.6",
-        "@polkadot/api-derive": "16.5.6",
-        "@polkadot/keyring": "^14.0.3",
-        "@polkadot/rpc-augment": "16.5.6",
-        "@polkadot/rpc-core": "16.5.6",
-        "@polkadot/rpc-provider": "16.5.6",
-        "@polkadot/types": "16.5.6",
-        "@polkadot/types-augment": "16.5.6",
-        "@polkadot/types-codec": "16.5.6",
-        "@polkadot/types-create": "16.5.6",
-        "@polkadot/types-known": "16.5.6",
-        "@polkadot/util": "^14.0.3",
-        "@polkadot/util-crypto": "^14.0.3",
-        "eventemitter3": "^5.0.1",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api-augment": {
-      "version": "16.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-16.5.6.tgz",
-      "integrity": "sha512-bunJF1c3nIuDtU6iwa+reTt9U47Y8iOC8Gw7PfANlZmLJmO/XVXnWc3JJLM+g9ESDn2raHJELeWBFVOXQrbtUw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api-base": "16.5.6",
-        "@polkadot/rpc-augment": "16.5.6",
-        "@polkadot/types": "16.5.6",
-        "@polkadot/types-augment": "16.5.6",
-        "@polkadot/types-codec": "16.5.6",
-        "@polkadot/util": "^14.0.3",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api-augment/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api-augment/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api-augment/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api-augment/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api-base": {
-      "version": "16.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-16.5.6.tgz",
-      "integrity": "sha512-eBLIv86ZZY4t5OrobVoGC+QXbErOGlBpI2rJI5OMvTNPoVvtEoI++u+wwRScjkOZaUhXyQikd+0Uv71qr3xnsA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/rpc-core": "16.5.6",
-        "@polkadot/types": "16.5.6",
-        "@polkadot/util": "^14.0.3",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api-base/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api-base/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api-base/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api-base/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api-derive": {
-      "version": "16.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-16.5.6.tgz",
-      "integrity": "sha512-cHdvPvhYFch18uPTcuOZJ8VceOfercod2fi4xCnHJAmattzlgj9qCgnOoxdmBS9GZ403ZyRHOjBuUwZy/IsUWQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api": "16.5.6",
-        "@polkadot/api-augment": "16.5.6",
-        "@polkadot/api-base": "16.5.6",
-        "@polkadot/rpc-core": "16.5.6",
-        "@polkadot/types": "16.5.6",
-        "@polkadot/types-codec": "16.5.6",
-        "@polkadot/util": "^14.0.3",
-        "@polkadot/util-crypto": "^14.0.3",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api-derive/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api-derive/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
-      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.3",
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-randomvalues": "14.0.3",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api-derive/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api-derive/node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
-      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api-derive/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api-derive/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api/node_modules/@polkadot/keyring": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
-      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
-      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.3",
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-randomvalues": "14.0.3",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api/node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
-      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/api/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/extension-dapp": {
-      "version": "0.62.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/extension-dapp/-/extension-dapp-0.62.6.tgz",
-      "integrity": "sha512-g4RWsKbH///iz/Cp5axNyJ+t/k9oTtoP3ND6ErkqDPMq6JUHwTE+D1RYIxnto7UgMei/gGQXBT6xIeUwhfY5tw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/extension-inject": "0.62.6",
-        "@polkadot/util": "^13.5.9",
-        "@polkadot/util-crypto": "^13.5.9",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/api": "*",
-        "@polkadot/util": "*",
-        "@polkadot/util-crypto": "*"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/extension-inject": {
-      "version": "0.62.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/extension-inject/-/extension-inject-0.62.6.tgz",
-      "integrity": "sha512-CC7OS2WwUqEqQwORHehT6+fvS9KzFXtzoRsKLfo1yfWXUgcGMI4VYSMGKEX9sllktkvuc0ww4Ct5NIygsGNf2w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api": "^16.5.3",
-        "@polkadot/rpc-provider": "^16.5.3",
-        "@polkadot/types": "^16.5.3",
-        "@polkadot/util": "^13.5.9",
-        "@polkadot/util-crypto": "^13.5.9",
-        "@polkadot/x-global": "^13.5.9",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/api": "*",
-        "@polkadot/util": "*"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/networks": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-14.0.3.tgz",
-      "integrity": "sha512-/VqTLUDn+Wm8S2L/yaGFddo3oW4vRYav0Rg4pLg/semMZLaN8PJ6h927ucn9JyWdH82QfZfyiIPORt0ZF3isyw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.3",
-        "@substrate/ss58-registry": "^1.51.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/networks/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/networks/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/networks/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/networks/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-augment": {
-      "version": "16.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-16.5.6.tgz",
-      "integrity": "sha512-vlrNvl2VtU09jZV/AvH7jBb/cNUO+dWu8Xj9pId5ctSUnZHm8o8wRk9ekyieKP57OUoKMd8+VScwMKd624SxTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/rpc-core": "16.5.6",
-        "@polkadot/types": "16.5.6",
-        "@polkadot/types-codec": "16.5.6",
-        "@polkadot/util": "^14.0.3",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-augment/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-core": {
-      "version": "16.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-16.5.6.tgz",
-      "integrity": "sha512-l6od++WlvKH4mw5mtsIh2AhiBs3H+TtdOoUHVLCx/R9il7+gl+arltzZ8vBuffyh/O+uQ36lI8yUoD1g4gi1tA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/rpc-augment": "16.5.6",
-        "@polkadot/rpc-provider": "16.5.6",
-        "@polkadot/types": "16.5.6",
-        "@polkadot/util": "^14.0.3",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-core/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-provider": {
-      "version": "16.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-16.5.6.tgz",
-      "integrity": "sha512-46sHIjKYr4aSzBCfbyqtCwuP8MMJ3jOp0xx9eggOGbKyP8Z0j0Cp+1nNkZUYzehcdGjjrmCxCbQp17wc6cj4zA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/keyring": "^14.0.3",
-        "@polkadot/types": "16.5.6",
-        "@polkadot/types-support": "16.5.6",
-        "@polkadot/util": "^14.0.3",
-        "@polkadot/util-crypto": "^14.0.3",
-        "@polkadot/x-fetch": "^14.0.3",
-        "@polkadot/x-global": "^14.0.3",
-        "@polkadot/x-ws": "^14.0.3",
-        "eventemitter3": "^5.0.1",
-        "mock-socket": "^9.3.1",
-        "nock": "^13.5.5",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@substrate/connect": "0.8.11"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/keyring": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
-      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
-      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.3",
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-randomvalues": "14.0.3",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
-      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types": {
-      "version": "16.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-16.5.6.tgz",
-      "integrity": "sha512-X/sfMHJS4RkRhnsc4CQqzUy7BM/s2y71TrBFHPYAjs2q/rbZ/BwvBk70SrUiSa0+iRRn3RewbBZm+AB8CbkdKw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/keyring": "^14.0.3",
-        "@polkadot/types-augment": "16.5.6",
-        "@polkadot/types-codec": "16.5.6",
-        "@polkadot/types-create": "16.5.6",
-        "@polkadot/util": "^14.0.3",
-        "@polkadot/util-crypto": "^14.0.3",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-augment": {
-      "version": "16.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-16.5.6.tgz",
-      "integrity": "sha512-QN5UrluUZCVgknUDW0gps/FRQ13Qgm24w53pCd2HgD0nmTtXDt9D4psjWwx5JkGTkUAvpzFWwN41bkxAeCiV6g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/types": "16.5.6",
-        "@polkadot/types-codec": "16.5.6",
-        "@polkadot/util": "^14.0.3",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-augment/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-augment/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-augment/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-augment/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-codec": {
-      "version": "16.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.5.6.tgz",
-      "integrity": "sha512-3tzUv1LZOL97IlQmko4dqbfRC0cg9IQ2QAHRVoDIWsXrVovp1V3kPdP0o6e3I8T2XB9IlbabK91v+ZiIxhGMZw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "^14.0.3",
-        "@polkadot/x-bigint": "^14.0.3",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-codec/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-codec/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-codec/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-codec/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-create": {
-      "version": "16.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-16.5.6.tgz",
-      "integrity": "sha512-g7g3hrjpz4KgqQqei9PU0JY9fsFHBmThWALZk5pWB32vyDyDcXZiyhH3agDhqfmzQiolTW2FuvcNJxgS634J1w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/types-codec": "16.5.6",
-        "@polkadot/util": "^14.0.3",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-create/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-create/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-create/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-create/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-known": {
-      "version": "16.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-16.5.6.tgz",
-      "integrity": "sha512-c78NcVO3LIvi4xzxB39WewE+80I4jOYUtPBaB4AzSMespEwIr92VTeX3KzFWuutxDXLSPqeVfXhaAhBB0NssiQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/networks": "^14.0.3",
-        "@polkadot/types": "16.5.6",
-        "@polkadot/types-codec": "16.5.6",
-        "@polkadot/types-create": "16.5.6",
-        "@polkadot/util": "^14.0.3",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-known/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-known/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-known/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-known/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-support": {
-      "version": "16.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-16.5.6.tgz",
-      "integrity": "sha512-Hqpa/hCvXZXUTUiJMAE55UXpzAeCVLaFlzzXQXLkne0vhmv3/JkWcBnX755a/b9+C4b3MKEz2i0tSKLsa3DldA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "^14.0.3",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-support/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-support/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-support/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types-support/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types/node_modules/@polkadot/keyring": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
-      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
-      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.3",
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-randomvalues": "14.0.3",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types/node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
-      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
-      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/types/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
-      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/util": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.5.9.tgz",
-      "integrity": "sha512-pIK3XYXo7DKeFRkEBNYhf3GbCHg6dKQisSvdzZwuyzA6m7YxQq4DFw4IE464ve4Z7WsJFt3a6C9uII36hl9EWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "13.5.9",
-        "@polkadot/x-global": "13.5.9",
-        "@polkadot/x-textdecoder": "13.5.9",
-        "@polkadot/x-textencoder": "13.5.9",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/util-crypto": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-13.5.9.tgz",
-      "integrity": "sha512-foUesMhxkTk8CZ0/XEcfvHk6I0O+aICqqVJllhOpyp/ZVnrTBKBf59T6RpsXx2pCtBlMsLRvg/6Mw7RND1HqDg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "13.5.9",
-        "@polkadot/util": "13.5.9",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "13.5.9",
-        "@polkadot/x-randomvalues": "13.5.9",
-        "@scure/base": "^1.1.7",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "13.5.9"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/util-crypto/node_modules/@polkadot/networks": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-13.5.9.tgz",
-      "integrity": "sha512-nmKUKJjiLgcih0MkdlJNMnhEYdwEml2rv/h59ll2+rAvpsVWMTLCb6Cq6q7UC44+8kiWK2UUJMkFU+3PFFxndA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "13.5.9",
-        "@substrate/ss58-registry": "^1.51.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-bigint": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.5.9.tgz",
-      "integrity": "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/util/node_modules/@polkadot/x-bigint": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.5.9.tgz",
-      "integrity": "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/wasm-bridge": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.5.4.tgz",
-      "integrity": "sha512-6xaJVvoZbnbgpQYXNw9OHVNWjXmtcoPcWh7hlwx3NpfiLkkjljj99YS+XGZQlq7ks2fVCg7FbfknkNb8PldDaA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/wasm-util": "7.5.4",
-        "tslib": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "*",
-        "@polkadot/x-randomvalues": "*"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/wasm-crypto": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.5.4.tgz",
-      "integrity": "sha512-1seyClxa7Jd7kQjfnCzTTTfYhTa/KUTDUaD3DMHBk5Q4ZUN1D1unJgX+v1aUeXSPxmzocdZETPJJRZjhVOqg9g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/wasm-bridge": "7.5.4",
-        "@polkadot/wasm-crypto-asmjs": "7.5.4",
-        "@polkadot/wasm-crypto-init": "7.5.4",
-        "@polkadot/wasm-crypto-wasm": "7.5.4",
-        "@polkadot/wasm-util": "7.5.4",
-        "tslib": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "*",
-        "@polkadot/x-randomvalues": "*"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/wasm-crypto-asmjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.5.4.tgz",
-      "integrity": "sha512-ZYwxQHAJ8pPt6kYk9XFmyuFuSS+yirJLonvP+DYbxOrARRUHfN4nzp4zcZNXUuaFhpbDobDSFn6gYzye6BUotA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "*"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/wasm-crypto-init": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.5.4.tgz",
-      "integrity": "sha512-U6s4Eo2rHs2n1iR01vTz/sOQ7eOnRPjaCsGWhPV+ZC/20hkVzwPAhiizu/IqMEol4tO2yiSheD4D6bn0KxUJhg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/wasm-bridge": "7.5.4",
-        "@polkadot/wasm-crypto-asmjs": "7.5.4",
-        "@polkadot/wasm-crypto-wasm": "7.5.4",
-        "@polkadot/wasm-util": "7.5.4",
-        "tslib": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "*",
-        "@polkadot/x-randomvalues": "*"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/wasm-crypto-wasm": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.5.4.tgz",
-      "integrity": "sha512-PsHgLsVTu43eprwSvUGnxybtOEuHPES6AbApcs7y5ZbM2PiDMzYbAjNul098xJK/CPtrxZ0ePDFnaQBmIJyTFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/wasm-util": "7.5.4",
-        "tslib": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "*"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/wasm-util": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.5.4.tgz",
-      "integrity": "sha512-hqPpfhCpRAqCIn/CYbBluhh0TXmwkJnDRjxrU9Bnqtw9nMNa97D8JuOjdd2pi0rxm+eeLQ/f1rQMp71RMM9t4w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "*"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/x-bigint": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-14.0.3.tgz",
-      "integrity": "sha512-U0al6BKgldFrEbmSObRAlzv9VDs5SMa/rbvZKvvkVec0sWTzYPWQZU1ZC/biXLYdjdKML89BeuCKmXZtCcGhUQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/x-bigint/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/x-fetch": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-14.0.3.tgz",
-      "integrity": "sha512-695c5aPBPtYcnn2zM+u0mXgyNHINlO0qGlGcJq3/0t5NVRZv5KZhk7NNm6antOay9uUjGG40F/r+LPzDT3QamA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "node-fetch": "^3.3.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/x-fetch/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/x-global": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
-      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/x-randomvalues": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.5.9.tgz",
-      "integrity": "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "13.5.9",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/x-textdecoder": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-13.5.9.tgz",
-      "integrity": "sha512-W2HhVNUbC/tuFdzNMbnXAWsIHSg9SC9QWDNmFD3nXdSzlXNgL8NmuiwN2fkYvCQBtp/XSoy0gDLx0C+Fo19cfw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/x-textencoder": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-13.5.9.tgz",
-      "integrity": "sha512-SG0MHnLUgn1ZxFdm0KzMdTHJ47SfqFhdIPMcGA0Mg/jt2rwrfrP3jtEIJMsHfQpHvfsNPfv55XOMmoPWuQnP/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/x-ws": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-14.0.3.tgz",
-      "integrity": "sha512-tOPdkMye3iuXnuFtdNg5+iSu7Cz9LRL8z5psMuZpUpThMYChGsS2pDFtNvXOKU8ohhO+frY9VdJ9VBg1WL9Iug==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@polkadot/x-ws/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/cli/node_modules/@scure/sr25519": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@scure/sr25519/-/sr25519-0.2.0.tgz",
-      "integrity": "sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "~1.9.2",
-        "@noble/hashes": "~1.8.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "examples/cli/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "examples/cli/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "examples/node": {
       "name": "@cere-ddc-sdk/node-examples",
       "version": "3.0.0",
@@ -1797,6 +58,7 @@
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-16.5.6.tgz",
       "integrity": "sha512-5h/X3pY8WpqGk4XTaiIUjKD6Pnk8k4bJ6EIwPKLP8/kfFWKSOenpN6ggZxANr+Qj+RgXrp4TxJVcuhXSiBh9Sg==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api-augment": "16.5.6",
@@ -1825,6 +87,7 @@
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-16.5.6.tgz",
       "integrity": "sha512-bunJF1c3nIuDtU6iwa+reTt9U47Y8iOC8Gw7PfANlZmLJmO/XVXnWc3JJLM+g9ESDn2raHJELeWBFVOXQrbtUw==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api-base": "16.5.6",
@@ -1839,40 +102,11 @@
         "node": ">=18"
       }
     },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api-augment/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api-augment/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api-base": {
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-16.5.6.tgz",
       "integrity": "sha512-eBLIv86ZZY4t5OrobVoGC+QXbErOGlBpI2rJI5OMvTNPoVvtEoI++u+wwRScjkOZaUhXyQikd+0Uv71qr3xnsA==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/rpc-core": "16.5.6",
@@ -1885,40 +119,11 @@
         "node": ">=18"
       }
     },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api-base/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api-base/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api-contract": {
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/api-contract/-/api-contract-16.5.6.tgz",
       "integrity": "sha512-SswGhCSSYTSeoCT1GwtP1km3FdD7a5oD5LGNNXmMnkCOkIYKYWiqCKmStOu8yw35F2tkZdApczhPNuX1PXTV2A==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "16.5.6",
@@ -1935,82 +140,11 @@
         "node": ">=18"
       }
     },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api-contract/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api-contract/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
-      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.3",
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-randomvalues": "14.0.3",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api-contract/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api-contract/node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
-      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-util": "*"
-      }
-    },
     "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api-derive": {
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-16.5.6.tgz",
       "integrity": "sha512-cHdvPvhYFch18uPTcuOZJ8VceOfercod2fi4xCnHJAmattzlgj9qCgnOoxdmBS9GZ403ZyRHOjBuUwZy/IsUWQ==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "16.5.6",
@@ -2028,172 +162,11 @@
         "node": ">=18"
       }
     },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api-derive/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api-derive/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
-      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.3",
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-randomvalues": "14.0.3",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api-derive/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api-derive/node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
-      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api/node_modules/@polkadot/keyring": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
-      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
-      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.3",
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-randomvalues": "14.0.3",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/api/node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
-      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-util": "*"
-      }
-    },
     "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/extension-dapp": {
       "version": "0.62.6",
       "resolved": "https://registry.npmjs.org/@polkadot/extension-dapp/-/extension-dapp-0.62.6.tgz",
       "integrity": "sha512-g4RWsKbH///iz/Cp5axNyJ+t/k9oTtoP3ND6ErkqDPMq6JUHwTE+D1RYIxnto7UgMei/gGQXBT6xIeUwhfY5tw==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/extension-inject": "0.62.6",
@@ -2214,6 +187,7 @@
       "version": "0.62.6",
       "resolved": "https://registry.npmjs.org/@polkadot/extension-inject/-/extension-inject-0.62.6.tgz",
       "integrity": "sha512-CC7OS2WwUqEqQwORHehT6+fvS9KzFXtzoRsKLfo1yfWXUgcGMI4VYSMGKEX9sllktkvuc0ww4Ct5NIygsGNf2w==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^16.5.3",
@@ -2236,6 +210,7 @@
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-14.0.3.tgz",
       "integrity": "sha512-/VqTLUDn+Wm8S2L/yaGFddo3oW4vRYav0Rg4pLg/semMZLaN8PJ6h927ucn9JyWdH82QfZfyiIPORt0ZF3isyw==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/util": "14.0.3",
@@ -2246,40 +221,11 @@
         "node": ">=18"
       }
     },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/networks/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/networks/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/rpc-augment": {
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-16.5.6.tgz",
       "integrity": "sha512-vlrNvl2VtU09jZV/AvH7jBb/cNUO+dWu8Xj9pId5ctSUnZHm8o8wRk9ekyieKP57OUoKMd8+VScwMKd624SxTw==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/rpc-core": "16.5.6",
@@ -2292,40 +238,11 @@
         "node": ">=18"
       }
     },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/rpc-augment/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/rpc-core": {
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-16.5.6.tgz",
       "integrity": "sha512-l6od++WlvKH4mw5mtsIh2AhiBs3H+TtdOoUHVLCx/R9il7+gl+arltzZ8vBuffyh/O+uQ36lI8yUoD1g4gi1tA==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/rpc-augment": "16.5.6",
@@ -2339,40 +256,11 @@
         "node": ">=18"
       }
     },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/rpc-core/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/rpc-provider": {
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-16.5.6.tgz",
       "integrity": "sha512-46sHIjKYr4aSzBCfbyqtCwuP8MMJ3jOp0xx9eggOGbKyP8Z0j0Cp+1nNkZUYzehcdGjjrmCxCbQp17wc6cj4zA==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/keyring": "^14.0.3",
@@ -2395,100 +283,11 @@
         "@substrate/connect": "0.8.11"
       }
     },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/keyring": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
-      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
-      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.3",
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-randomvalues": "14.0.3",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
-      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-util": "*"
-      }
-    },
     "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types": {
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-16.5.6.tgz",
       "integrity": "sha512-X/sfMHJS4RkRhnsc4CQqzUy7BM/s2y71TrBFHPYAjs2q/rbZ/BwvBk70SrUiSa0+iRRn3RewbBZm+AB8CbkdKw==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/keyring": "^14.0.3",
@@ -2508,6 +307,7 @@
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-16.5.6.tgz",
       "integrity": "sha512-QN5UrluUZCVgknUDW0gps/FRQ13Qgm24w53pCd2HgD0nmTtXDt9D4psjWwx5JkGTkUAvpzFWwN41bkxAeCiV6g==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/types": "16.5.6",
@@ -2519,40 +319,11 @@
         "node": ">=18"
       }
     },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types-augment/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types-augment/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types-codec": {
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.5.6.tgz",
       "integrity": "sha512-3tzUv1LZOL97IlQmko4dqbfRC0cg9IQ2QAHRVoDIWsXrVovp1V3kPdP0o6e3I8T2XB9IlbabK91v+ZiIxhGMZw==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/util": "^14.0.3",
@@ -2563,40 +334,11 @@
         "node": ">=18"
       }
     },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types-codec/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types-codec/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types-create": {
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-16.5.6.tgz",
       "integrity": "sha512-g7g3hrjpz4KgqQqei9PU0JY9fsFHBmThWALZk5pWB32vyDyDcXZiyhH3agDhqfmzQiolTW2FuvcNJxgS634J1w==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/types-codec": "16.5.6",
@@ -2607,40 +349,11 @@
         "node": ">=18"
       }
     },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types-create/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types-create/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types-known": {
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-16.5.6.tgz",
       "integrity": "sha512-c78NcVO3LIvi4xzxB39WewE+80I4jOYUtPBaB4AzSMespEwIr92VTeX3KzFWuutxDXLSPqeVfXhaAhBB0NssiQ==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/networks": "^14.0.3",
@@ -2654,40 +367,11 @@
         "node": ">=18"
       }
     },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types-known/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types-known/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types-support": {
       "version": "16.5.6",
       "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-16.5.6.tgz",
       "integrity": "sha512-Hqpa/hCvXZXUTUiJMAE55UXpzAeCVLaFlzzXQXLkne0vhmv3/JkWcBnX755a/b9+C4b3MKEz2i0tSKLsa3DldA==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/util": "^14.0.3",
@@ -2697,145 +381,14 @@
         "node": ">=18"
       }
     },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types-support/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types-support/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types/node_modules/@polkadot/keyring": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
-      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types/node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
-      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.3",
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-randomvalues": "14.0.3",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/types/node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
-      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-util": "*"
-      }
-    },
     "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/x-bigint": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-14.0.3.tgz",
       "integrity": "sha512-U0al6BKgldFrEbmSObRAlzv9VDs5SMa/rbvZKvvkVec0sWTzYPWQZU1ZC/biXLYdjdKML89BeuCKmXZtCcGhUQ==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/x-bigint/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -2846,6 +399,7 @@
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-14.0.3.tgz",
       "integrity": "sha512-695c5aPBPtYcnn2zM+u0mXgyNHINlO0qGlGcJq3/0t5NVRZv5KZhk7NNm6antOay9uUjGG40F/r+LPzDT3QamA==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/x-global": "14.0.3",
@@ -2856,37 +410,14 @@
         "node": ">=18"
       }
     },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/x-fetch/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/x-textdecoder": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
       "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/x-textdecoder/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -2897,21 +428,10 @@
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
       "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/x-global": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/x-textencoder/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -2922,6 +442,7 @@
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-14.0.3.tgz",
       "integrity": "sha512-tOPdkMye3iuXnuFtdNg5+iSu7Cz9LRL8z5psMuZpUpThMYChGsS2pDFtNvXOKU8ohhO+frY9VdJ9VBg1WL9Iug==",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/x-global": "14.0.3",
@@ -2932,41 +453,9 @@
         "node": ">=18"
       }
     },
-    "examples/node/node_modules/@cere-ddc-sdk/blockchain/node_modules/@polkadot/x-ws/node_modules/@polkadot/x-global": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
-      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/ddc": {
-      "version": "2.15.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cere-ddc-sdk/blockchain": "2.15.0",
-        "@grpc/grpc-js": "^1.9.13",
-        "@protobuf-ts/grpc-transport": "^2.9.3",
-        "@protobuf-ts/runtime": "^2.9.3",
-        "@protobuf-ts/runtime-rpc": "^2.9.3",
-        "async-retry": "^1.3.3",
-        "bs58": "^5.0.0",
-        "buffer": "^6.0.3",
-        "cross-fetch": "^4.0.0",
-        "format-util": "^1.0.5",
-        "hash-wasm": "^4.11.0",
-        "pino": "^8.17.2",
-        "pino-pretty": "^10.3.1",
-        "rfc4648": "^1.5.3",
-        "uuid": "^9.0.1"
-      }
-    },
     "examples/node/node_modules/@cere-ddc-sdk/ddc-client/node_modules/@cere-ddc-sdk/blockchain": {
       "version": "2.15.0",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@cere/embed-wallet-inject": "^0.20.1",
@@ -2987,584 +476,6 @@
         "@cere/embed-wallet": {
           "optional": true
         }
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/ddc/node_modules/@cere-ddc-sdk/blockchain": {
-      "version": "2.15.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cere/embed-wallet-inject": "^0.20.1",
-        "@polkadot/api": "^15.5.1",
-        "@polkadot/api-base": "^15.5.1",
-        "@polkadot/api-contract": "^15.5.1",
-        "@polkadot/extension-dapp": "^0.58.2",
-        "@polkadot/extension-inject": "^0.58.2",
-        "@polkadot/keyring": "^13.3.1",
-        "@polkadot/types": "^15.5.1",
-        "@polkadot/util": "^13.3.1",
-        "@polkadot/util-crypto": "^13.3.1"
-      },
-      "peerDependencies": {
-        "@cere/embed-wallet": "*"
-      },
-      "peerDependenciesMeta": {
-        "@cere/embed-wallet": {
-          "optional": true
-        }
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/file-storage": {
-      "version": "2.15.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cere-ddc-sdk/blockchain": "2.15.0",
-        "@cere-ddc-sdk/ddc": "2.15.0"
-      }
-    },
-    "examples/node/node_modules/@cere-ddc-sdk/file-storage/node_modules/@cere-ddc-sdk/blockchain": {
-      "version": "2.15.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cere/embed-wallet-inject": "^0.20.1",
-        "@polkadot/api": "^15.5.1",
-        "@polkadot/api-base": "^15.5.1",
-        "@polkadot/api-contract": "^15.5.1",
-        "@polkadot/extension-dapp": "^0.58.2",
-        "@polkadot/extension-inject": "^0.58.2",
-        "@polkadot/keyring": "^13.3.1",
-        "@polkadot/types": "^15.5.1",
-        "@polkadot/util": "^13.3.1",
-        "@polkadot/util-crypto": "^13.3.1"
-      },
-      "peerDependencies": {
-        "@cere/embed-wallet": "*"
-      },
-      "peerDependenciesMeta": {
-        "@cere/embed-wallet": {
-          "optional": true
-        }
-      }
-    },
-    "examples/node/node_modules/@polkadot/api": {
-      "version": "15.10.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api-augment": "15.10.2",
-        "@polkadot/api-base": "15.10.2",
-        "@polkadot/api-derive": "15.10.2",
-        "@polkadot/keyring": "^13.4.4",
-        "@polkadot/rpc-augment": "15.10.2",
-        "@polkadot/rpc-core": "15.10.2",
-        "@polkadot/rpc-provider": "15.10.2",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/types-augment": "15.10.2",
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/types-create": "15.10.2",
-        "@polkadot/types-known": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "@polkadot/util-crypto": "^13.4.4",
-        "eventemitter3": "^5.0.1",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/api-augment": {
-      "version": "15.10.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api-base": "15.10.2",
-        "@polkadot/rpc-augment": "15.10.2",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/types-augment": "15.10.2",
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/api-base": {
-      "version": "15.10.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/rpc-core": "15.10.2",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/api-contract": {
-      "version": "15.10.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-contract/-/api-contract-15.10.2.tgz",
-      "integrity": "sha512-vAWBrzu8iMVYDXQnAQNB2rjeLydKNfP3G2xFRo4t/HlLQwxxdwud7IV4sKiuGSaucvnA9RFzKrMOq3n1/Kq2lw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api": "15.10.2",
-        "@polkadot/api-augment": "15.10.2",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/types-create": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "@polkadot/util-crypto": "^13.4.4",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/api-derive": {
-      "version": "15.10.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api": "15.10.2",
-        "@polkadot/api-augment": "15.10.2",
-        "@polkadot/api-base": "15.10.2",
-        "@polkadot/rpc-core": "15.10.2",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "@polkadot/util-crypto": "^13.4.4",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/extension-inject": {
-      "version": "0.58.10",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api": "^15.10.2",
-        "@polkadot/rpc-provider": "^15.10.2",
-        "@polkadot/types": "^15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "@polkadot/util-crypto": "^13.4.4",
-        "@polkadot/x-global": "^13.4.4",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/api": "*",
-        "@polkadot/util": "*"
-      }
-    },
-    "examples/node/node_modules/@polkadot/networks": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-13.5.9.tgz",
-      "integrity": "sha512-nmKUKJjiLgcih0MkdlJNMnhEYdwEml2rv/h59ll2+rAvpsVWMTLCb6Cq6q7UC44+8kiWK2UUJMkFU+3PFFxndA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "13.5.9",
-        "@substrate/ss58-registry": "^1.51.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/rpc-augment": {
-      "version": "15.10.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/rpc-core": "15.10.2",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/rpc-core": {
-      "version": "15.10.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/rpc-augment": "15.10.2",
-        "@polkadot/rpc-provider": "15.10.2",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/rpc-provider": {
-      "version": "15.10.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/keyring": "^13.4.4",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/types-support": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "@polkadot/util-crypto": "^13.4.4",
-        "@polkadot/x-fetch": "^13.4.4",
-        "@polkadot/x-global": "^13.4.4",
-        "@polkadot/x-ws": "^13.4.4",
-        "eventemitter3": "^5.0.1",
-        "mock-socket": "^9.3.1",
-        "nock": "^13.5.5",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@substrate/connect": "0.8.11"
-      }
-    },
-    "examples/node/node_modules/@polkadot/types": {
-      "version": "15.10.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/keyring": "^13.4.4",
-        "@polkadot/types-augment": "15.10.2",
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/types-create": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "@polkadot/util-crypto": "^13.4.4",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/types-augment": {
-      "version": "15.10.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/types": "15.10.2",
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/types-codec": {
-      "version": "15.10.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "^13.4.4",
-        "@polkadot/x-bigint": "^13.4.4",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/types-create": {
-      "version": "15.10.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/types-known": {
-      "version": "15.10.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/networks": "^13.4.4",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/types-create": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/types-support": {
-      "version": "15.10.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "^13.4.4",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/util": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.5.9.tgz",
-      "integrity": "sha512-pIK3XYXo7DKeFRkEBNYhf3GbCHg6dKQisSvdzZwuyzA6m7YxQq4DFw4IE464ve4Z7WsJFt3a6C9uII36hl9EWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "13.5.9",
-        "@polkadot/x-global": "13.5.9",
-        "@polkadot/x-textdecoder": "13.5.9",
-        "@polkadot/x-textencoder": "13.5.9",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/util-crypto": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-13.5.9.tgz",
-      "integrity": "sha512-foUesMhxkTk8CZ0/XEcfvHk6I0O+aICqqVJllhOpyp/ZVnrTBKBf59T6RpsXx2pCtBlMsLRvg/6Mw7RND1HqDg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "13.5.9",
-        "@polkadot/util": "13.5.9",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "13.5.9",
-        "@polkadot/x-randomvalues": "13.5.9",
-        "@scure/base": "^1.1.7",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "13.5.9"
-      }
-    },
-    "examples/node/node_modules/@polkadot/wasm-bridge": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.5.4.tgz",
-      "integrity": "sha512-6xaJVvoZbnbgpQYXNw9OHVNWjXmtcoPcWh7hlwx3NpfiLkkjljj99YS+XGZQlq7ks2fVCg7FbfknkNb8PldDaA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/wasm-util": "7.5.4",
-        "tslib": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "*",
-        "@polkadot/x-randomvalues": "*"
-      }
-    },
-    "examples/node/node_modules/@polkadot/wasm-crypto": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.5.4.tgz",
-      "integrity": "sha512-1seyClxa7Jd7kQjfnCzTTTfYhTa/KUTDUaD3DMHBk5Q4ZUN1D1unJgX+v1aUeXSPxmzocdZETPJJRZjhVOqg9g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/wasm-bridge": "7.5.4",
-        "@polkadot/wasm-crypto-asmjs": "7.5.4",
-        "@polkadot/wasm-crypto-init": "7.5.4",
-        "@polkadot/wasm-crypto-wasm": "7.5.4",
-        "@polkadot/wasm-util": "7.5.4",
-        "tslib": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "*",
-        "@polkadot/x-randomvalues": "*"
-      }
-    },
-    "examples/node/node_modules/@polkadot/wasm-crypto-asmjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.5.4.tgz",
-      "integrity": "sha512-ZYwxQHAJ8pPt6kYk9XFmyuFuSS+yirJLonvP+DYbxOrARRUHfN4nzp4zcZNXUuaFhpbDobDSFn6gYzye6BUotA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "*"
-      }
-    },
-    "examples/node/node_modules/@polkadot/wasm-crypto-init": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.5.4.tgz",
-      "integrity": "sha512-U6s4Eo2rHs2n1iR01vTz/sOQ7eOnRPjaCsGWhPV+ZC/20hkVzwPAhiizu/IqMEol4tO2yiSheD4D6bn0KxUJhg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/wasm-bridge": "7.5.4",
-        "@polkadot/wasm-crypto-asmjs": "7.5.4",
-        "@polkadot/wasm-crypto-wasm": "7.5.4",
-        "@polkadot/wasm-util": "7.5.4",
-        "tslib": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "*",
-        "@polkadot/x-randomvalues": "*"
-      }
-    },
-    "examples/node/node_modules/@polkadot/wasm-crypto-wasm": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.5.4.tgz",
-      "integrity": "sha512-PsHgLsVTu43eprwSvUGnxybtOEuHPES6AbApcs7y5ZbM2PiDMzYbAjNul098xJK/CPtrxZ0ePDFnaQBmIJyTFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/wasm-util": "7.5.4",
-        "tslib": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "*"
-      }
-    },
-    "examples/node/node_modules/@polkadot/wasm-util": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.5.4.tgz",
-      "integrity": "sha512-hqPpfhCpRAqCIn/CYbBluhh0TXmwkJnDRjxrU9Bnqtw9nMNa97D8JuOjdd2pi0rxm+eeLQ/f1rQMp71RMM9t4w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "*"
-      }
-    },
-    "examples/node/node_modules/@polkadot/x-bigint": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.5.9.tgz",
-      "integrity": "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/x-global": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
-      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/x-randomvalues": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.5.9.tgz",
-      "integrity": "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "13.5.9",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "examples/node/node_modules/@polkadot/x-textdecoder": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-13.5.9.tgz",
-      "integrity": "sha512-W2HhVNUbC/tuFdzNMbnXAWsIHSg9SC9QWDNmFD3nXdSzlXNgL8NmuiwN2fkYvCQBtp/XSoy0gDLx0C+Fo19cfw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@polkadot/x-textencoder": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-13.5.9.tgz",
-      "integrity": "sha512-SG0MHnLUgn1ZxFdm0KzMdTHJ47SfqFhdIPMcGA0Mg/jt2rwrfrP3jtEIJMsHfQpHvfsNPfv55XOMmoPWuQnP/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "examples/node/node_modules/@scure/sr25519": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@scure/sr25519/-/sr25519-0.2.0.tgz",
-      "integrity": "sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "~1.9.2",
-        "@noble/hashes": "~1.8.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "examples/node/node_modules/buffer": {
-      "version": "6.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "examples/node/node_modules/uuid": {
-      "version": "9.0.1",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5546,19 +2457,6 @@
         "bn.js": "^5.2.1"
       }
     },
-    "node_modules/@cere/embed-wallet-inject": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@cere/embed-wallet-inject/-/embed-wallet-inject-0.20.1.tgz",
-      "integrity": "sha512-xvbvIuKNuwnODHXcy9Jq+nBOJ7FucjRMU+U8ZLbIwbwjcPLsZY7AjMUGgzPMLfmjnBSYdHcXZredTakzYyvVhw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/extension-inject": "^0.46.6"
-      },
-      "peerDependencies": {
-        "@cere/embed-wallet": "*",
-        "@polkadot/types": "^10.2.1"
-      }
-    },
     "node_modules/@cere/torus-embed": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/@cere/torus-embed/-/torus-embed-0.2.8.tgz",
@@ -5817,12 +2715,12 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5834,12 +2732,12 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5851,12 +2749,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5868,12 +2766,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5885,12 +2783,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5902,12 +2800,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5919,12 +2817,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5936,12 +2834,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5953,12 +2851,12 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5970,12 +2868,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5987,12 +2885,12 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6004,12 +2902,12 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6021,12 +2919,12 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6038,12 +2936,12 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6055,12 +2953,12 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6072,12 +2970,12 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6089,12 +2987,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6106,12 +3004,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6123,12 +3021,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6140,12 +3038,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6157,12 +3055,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6174,12 +3072,12 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6191,12 +3089,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9248,22 +6146,6 @@
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
-    "node_modules/@polkadot-api/client": {
-      "version": "0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/client/-/client-0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0.tgz",
-      "integrity": "sha512-0fqK6pUKcGHSG2pBvY+gfSS+1mMdjd/qRygAcKI5d05tKsnZLRnmhb9laDguKmGEIB0Bz9vQqNK3gIN/cfvVwg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@polkadot-api/metadata-builders": "0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0",
-        "@polkadot-api/substrate-bindings": "0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0",
-        "@polkadot-api/substrate-client": "0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0",
-        "@polkadot-api/utils": "0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0"
-      },
-      "peerDependencies": {
-        "rxjs": ">=7.8.0"
-      }
-    },
     "node_modules/@polkadot-api/codegen": {
       "version": "0.22.5",
       "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.5.tgz",
@@ -9276,6 +6158,10 @@
         "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
+    },
+    "node_modules/@polkadot-api/descriptors": {
+      "resolved": "packages/blockchain/.papi/descriptors",
+      "link": true
     },
     "node_modules/@polkadot-api/ink-contracts": {
       "version": "0.6.3",
@@ -9690,26 +6576,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@polkadot/api-contract": {
-      "version": "16.4.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-contract/-/api-contract-16.4.9.tgz",
-      "integrity": "sha512-a2EQTsdW+yqLew00bgl1w3oMteTeQ4wt+JnKjX70uyU/07aw7yrxlk8gwVo3SmzS1yHDEXEagpxwB6SlWq10SQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api": "16.4.9",
-        "@polkadot/api-augment": "16.4.9",
-        "@polkadot/types": "16.4.9",
-        "@polkadot/types-codec": "16.4.9",
-        "@polkadot/types-create": "16.4.9",
-        "@polkadot/util": "^13.5.7",
-        "@polkadot/util-crypto": "^13.5.7",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@polkadot/api-derive": {
       "version": "16.4.9",
       "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-16.4.9.tgz",
@@ -9729,779 +6595,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-dapp": {
-      "version": "0.58.10",
-      "resolved": "https://registry.npmjs.org/@polkadot/extension-dapp/-/extension-dapp-0.58.10.tgz",
-      "integrity": "sha512-5R+Nt0IK9pC3QpO/Wf6GE63P7dYvnmf/Slj7HEZxYFoFgjiem7c21uT5D8X0WebHSuCweN0/nSzaZm6AuXfdPQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/extension-inject": "0.58.10",
-        "@polkadot/util": "^13.4.4",
-        "@polkadot/util-crypto": "^13.4.4",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/api": "*",
-        "@polkadot/util": "*",
-        "@polkadot/util-crypto": "*"
-      }
-    },
-    "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/api-augment": {
-      "version": "15.10.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-15.10.2.tgz",
-      "integrity": "sha512-CCli5ltPiJEyQF/8DmTRpTfYKHY4W0B+xQDmzKgFmd+Q64Qot0fGpsaZXZftef1Tuoh0Uqak9qM+6B4APXIPkQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api-base": "15.10.2",
-        "@polkadot/rpc-augment": "15.10.2",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/types-augment": "15.10.2",
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/api-base": {
-      "version": "15.10.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-15.10.2.tgz",
-      "integrity": "sha512-7DJw++5IbPrsLPGcTlIZbMOretfvQJG80CW8+A+t2BLxbbv+I2neWNQ9QV9O28XsbOHzNgKHXuRyirdaG/dvrg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/rpc-core": "15.10.2",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/api-derive": {
-      "version": "15.10.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-15.10.2.tgz",
-      "integrity": "sha512-tF9DZvdm7hkRIJ1HtJzu73vdqQWBr8935YSN/RNsRb4FhJK5cHaC2uB4NLdRMnyUjmH0JRSnvWFq+HHcVxFJZw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api": "15.10.2",
-        "@polkadot/api-augment": "15.10.2",
-        "@polkadot/api-base": "15.10.2",
-        "@polkadot/rpc-core": "15.10.2",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "@polkadot/util-crypto": "^13.4.4",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/api-derive/node_modules/@polkadot/api": {
-      "version": "15.10.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-15.10.2.tgz",
-      "integrity": "sha512-UM/510TwdugPjMpfyhhMNOZJ3M2ftRk0Ftxe+WSWev3o1u0dxqGuIN6fN0c224CHXIr58uWXUoMRHi6Cnfaxhw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api-augment": "15.10.2",
-        "@polkadot/api-base": "15.10.2",
-        "@polkadot/api-derive": "15.10.2",
-        "@polkadot/keyring": "^13.4.4",
-        "@polkadot/rpc-augment": "15.10.2",
-        "@polkadot/rpc-core": "15.10.2",
-        "@polkadot/rpc-provider": "15.10.2",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/types-augment": "15.10.2",
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/types-create": "15.10.2",
-        "@polkadot/types-known": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "@polkadot/util-crypto": "^13.4.4",
-        "eventemitter3": "^5.0.1",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/extension-inject": {
-      "version": "0.58.10",
-      "resolved": "https://registry.npmjs.org/@polkadot/extension-inject/-/extension-inject-0.58.10.tgz",
-      "integrity": "sha512-bjZR/iFtRrQ+YIB1eYzvLWf/N2p1F9N9PcfmvL4z5nIHKZGftmPg18Pg0o3nvGwewjUDYw/YspZHu2NDo9Sslw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api": "^15.10.2",
-        "@polkadot/rpc-provider": "^15.10.2",
-        "@polkadot/types": "^15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "@polkadot/util-crypto": "^13.4.4",
-        "@polkadot/x-global": "^13.4.4",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/api": "*",
-        "@polkadot/util": "*"
-      }
-    },
-    "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/extension-inject/node_modules/@polkadot/api": {
-      "version": "15.10.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-15.10.2.tgz",
-      "integrity": "sha512-UM/510TwdugPjMpfyhhMNOZJ3M2ftRk0Ftxe+WSWev3o1u0dxqGuIN6fN0c224CHXIr58uWXUoMRHi6Cnfaxhw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api-augment": "15.10.2",
-        "@polkadot/api-base": "15.10.2",
-        "@polkadot/api-derive": "15.10.2",
-        "@polkadot/keyring": "^13.4.4",
-        "@polkadot/rpc-augment": "15.10.2",
-        "@polkadot/rpc-core": "15.10.2",
-        "@polkadot/rpc-provider": "15.10.2",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/types-augment": "15.10.2",
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/types-create": "15.10.2",
-        "@polkadot/types-known": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "@polkadot/util-crypto": "^13.4.4",
-        "eventemitter3": "^5.0.1",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/rpc-augment": {
-      "version": "15.10.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-15.10.2.tgz",
-      "integrity": "sha512-9QQ8utyAEdEl7iScteIN59EBu8eNZjZa8AfKBitbdq1Hezd+WPil5LdoYi+wmJOMhZHeDT1s7/j2+kY1Z2Vymg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/rpc-core": "15.10.2",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/rpc-core": {
-      "version": "15.10.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-15.10.2.tgz",
-      "integrity": "sha512-vqDvr1WcHH3WPzDV4WTlf2S5cDmIoFPciynJ8eNcKqR3mG7Cqd0iL+MG6s0KFXdSY2Qvtl+0C6yZN0xr4Ha6BQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/rpc-augment": "15.10.2",
-        "@polkadot/rpc-provider": "15.10.2",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/rpc-provider": {
-      "version": "15.10.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-15.10.2.tgz",
-      "integrity": "sha512-kqpPW8U0stVW+uOZP8g5d87Xb8rbXJR5PUub6xgGG6AOMbbvvuCU3GSohu/iozo4p9uD7TGH90jvbxj1rjJVMA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/keyring": "^13.4.4",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/types-support": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "@polkadot/util-crypto": "^13.4.4",
-        "@polkadot/x-fetch": "^13.4.4",
-        "@polkadot/x-global": "^13.4.4",
-        "@polkadot/x-ws": "^13.4.4",
-        "eventemitter3": "^5.0.1",
-        "mock-socket": "^9.3.1",
-        "nock": "^13.5.5",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@substrate/connect": "0.8.11"
-      }
-    },
-    "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/types": {
-      "version": "15.10.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-15.10.2.tgz",
-      "integrity": "sha512-/wDwKdDijxSXyNk5YezhVitdFxoQaTSSG9KXa7dEWujtmS/51UHmt9+P3W8b8D8kKaCvumahf/ww3GJI6s0Eqw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/keyring": "^13.4.4",
-        "@polkadot/types-augment": "15.10.2",
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/types-create": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "@polkadot/util-crypto": "^13.4.4",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/types-augment": {
-      "version": "15.10.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-15.10.2.tgz",
-      "integrity": "sha512-X/xh+Dzud6OIyr7q8xttAwn+Fb5hKImIWEO1oG8WcInqv+P0vRyu7Tds+2ut9t64sJi3ydJ7I+T+WxZYheCU7g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/types": "15.10.2",
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/types-codec": {
-      "version": "15.10.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-15.10.2.tgz",
-      "integrity": "sha512-dhwbaukUZiYDW3QAAnLAFThYE5hQGdwBMWOVTt9+aBWxEKovLK93j0V30tEzMUtrZy8xaRWdhdDeQ3DSmxEP6w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "^13.4.4",
-        "@polkadot/x-bigint": "^13.4.4",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/types-create": {
-      "version": "15.10.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-15.10.2.tgz",
-      "integrity": "sha512-vqXwPUSgx/By31qSkhOR5GN6zMbF1MkiX3F1g5KKHaRE8p/DdTry4LhufxhtK1mr9eBWvVGXxCOZdwjQco2M1A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/types-known": {
-      "version": "15.10.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-15.10.2.tgz",
-      "integrity": "sha512-vs02WiIlLualrrh/EuA5qzK6QzatVPqBBNqa66dUtmyhJy48OEelBK+QLfOIQvZKU0ModEunoVrnxuY+O1DCmA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/networks": "^13.4.4",
-        "@polkadot/types": "15.10.2",
-        "@polkadot/types-codec": "15.10.2",
-        "@polkadot/types-create": "15.10.2",
-        "@polkadot/util": "^13.4.4",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/types-support": {
-      "version": "15.10.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-15.10.2.tgz",
-      "integrity": "sha512-sHamH6MehJa7aGZ/DHTB6vJAhSN5VrJx5lpDpb3xgBFTr0cVc5IsociqgJ/mgvyEIdLF3laraPxREqxCmuxTaQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "^13.4.4",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject": {
-      "version": "0.46.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/extension-inject/-/extension-inject-0.46.9.tgz",
-      "integrity": "sha512-m0jnrs9+jEOpMH6OUNl7nHpz9SFFWK9LzuqB8T3htEE3RUYPL//SLCPyEKxAAgHu7F8dgkUHssAWQfANofALCQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api": "^10.12.4",
-        "@polkadot/rpc-provider": "^10.12.4",
-        "@polkadot/types": "^10.12.4",
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/util-crypto": "^12.6.2",
-        "@polkadot/x-global": "^12.6.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/api": "*",
-        "@polkadot/util": "*"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api": {
-      "version": "10.13.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-10.13.1.tgz",
-      "integrity": "sha512-YrKWR4TQR5CDyGkF0mloEUo7OsUA+bdtENpJGOtNavzOQUDEbxFE0PVzokzZfVfHhHX2CojPVmtzmmLxztyJkg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api-augment": "10.13.1",
-        "@polkadot/api-base": "10.13.1",
-        "@polkadot/api-derive": "10.13.1",
-        "@polkadot/keyring": "^12.6.2",
-        "@polkadot/rpc-augment": "10.13.1",
-        "@polkadot/rpc-core": "10.13.1",
-        "@polkadot/rpc-provider": "10.13.1",
-        "@polkadot/types": "10.13.1",
-        "@polkadot/types-augment": "10.13.1",
-        "@polkadot/types-codec": "10.13.1",
-        "@polkadot/types-create": "10.13.1",
-        "@polkadot/types-known": "10.13.1",
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/util-crypto": "^12.6.2",
-        "eventemitter3": "^5.0.1",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api-augment": {
-      "version": "10.13.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-10.13.1.tgz",
-      "integrity": "sha512-IAKaCp19QxgOG4HKk9RAgUgC/VNVqymZ2GXfMNOZWImZhxRIbrK+raH5vN2MbWwtVHpjxyXvGsd1RRhnohI33A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api-base": "10.13.1",
-        "@polkadot/rpc-augment": "10.13.1",
-        "@polkadot/types": "10.13.1",
-        "@polkadot/types-augment": "10.13.1",
-        "@polkadot/types-codec": "10.13.1",
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api-base": {
-      "version": "10.13.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-10.13.1.tgz",
-      "integrity": "sha512-Okrw5hjtEjqSMOG08J6qqEwlUQujTVClvY1/eZkzKwNzPelWrtV6vqfyJklB7zVhenlxfxqhZKKcY7zWSW/q5Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/rpc-core": "10.13.1",
-        "@polkadot/types": "10.13.1",
-        "@polkadot/util": "^12.6.2",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api-derive": {
-      "version": "10.13.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-10.13.1.tgz",
-      "integrity": "sha512-ef0H0GeCZ4q5Om+c61eLLLL29UxFC2/u/k8V1K2JOIU+2wD5LF7sjAoV09CBMKKHfkLenRckVk2ukm4rBqFRpg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/api": "10.13.1",
-        "@polkadot/api-augment": "10.13.1",
-        "@polkadot/api-base": "10.13.1",
-        "@polkadot/rpc-core": "10.13.1",
-        "@polkadot/types": "10.13.1",
-        "@polkadot/types-codec": "10.13.1",
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/util-crypto": "^12.6.2",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/keyring": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.6.2.tgz",
-      "integrity": "sha512-O3Q7GVmRYm8q7HuB3S0+Yf/q/EB2egKRRU3fv9b3B7V+A52tKzA+vIwEmNVaD1g5FKW9oB97rmpggs0zaKFqHw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "12.6.2",
-        "@polkadot/util-crypto": "12.6.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "12.6.2",
-        "@polkadot/util-crypto": "12.6.2"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/networks": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.6.2.tgz",
-      "integrity": "sha512-1oWtZm1IvPWqvMrldVH6NI2gBoCndl5GEwx7lAuQWGr7eNL+6Bdc5K3Z9T0MzFvDGoi2/CBqjX9dRKo39pDC/w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "12.6.2",
-        "@substrate/ss58-registry": "^1.44.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/rpc-augment": {
-      "version": "10.13.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-10.13.1.tgz",
-      "integrity": "sha512-iLsWUW4Jcx3DOdVrSHtN0biwxlHuTs4QN2hjJV0gd0jo7W08SXhWabZIf9mDmvUJIbR7Vk+9amzvegjRyIf5+A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/rpc-core": "10.13.1",
-        "@polkadot/types": "10.13.1",
-        "@polkadot/types-codec": "10.13.1",
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/rpc-core": {
-      "version": "10.13.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-10.13.1.tgz",
-      "integrity": "sha512-eoejSHa+/tzHm0vwic62/aptTGbph8vaBpbvLIK7gd00+rT813ROz5ckB1CqQBFB23nHRLuzzX/toY8ID3xrKw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/rpc-augment": "10.13.1",
-        "@polkadot/rpc-provider": "10.13.1",
-        "@polkadot/types": "10.13.1",
-        "@polkadot/util": "^12.6.2",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/rpc-provider": {
-      "version": "10.13.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-10.13.1.tgz",
-      "integrity": "sha512-oJ7tatVXYJ0L7NpNiGd69D558HG5y5ZDmH2Bp9Dd4kFTQIiV8A39SlWwWUPCjSsen9lqSvvprNLnG/VHTpenbw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/keyring": "^12.6.2",
-        "@polkadot/types": "10.13.1",
-        "@polkadot/types-support": "10.13.1",
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/util-crypto": "^12.6.2",
-        "@polkadot/x-fetch": "^12.6.2",
-        "@polkadot/x-global": "^12.6.2",
-        "@polkadot/x-ws": "^12.6.2",
-        "eventemitter3": "^5.0.1",
-        "mock-socket": "^9.3.1",
-        "nock": "^13.5.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@substrate/connect": "0.8.8"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types": {
-      "version": "10.13.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-10.13.1.tgz",
-      "integrity": "sha512-Hfvg1ZgJlYyzGSAVrDIpp3vullgxrjOlh/CSThd/PI4TTN1qHoPSFm2hs77k3mKkOzg+LrWsLE0P/LP2XddYcw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/keyring": "^12.6.2",
-        "@polkadot/types-augment": "10.13.1",
-        "@polkadot/types-codec": "10.13.1",
-        "@polkadot/types-create": "10.13.1",
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/util-crypto": "^12.6.2",
-        "rxjs": "^7.8.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-augment": {
-      "version": "10.13.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-10.13.1.tgz",
-      "integrity": "sha512-TcrLhf95FNFin61qmVgOgayzQB/RqVsSg9thAso1Fh6pX4HSbvI35aGPBAn3SkA6R+9/TmtECirpSNLtIGFn0g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/types": "10.13.1",
-        "@polkadot/types-codec": "10.13.1",
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-codec": {
-      "version": "10.13.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-10.13.1.tgz",
-      "integrity": "sha512-AiQ2Vv2lbZVxEdRCN8XSERiWlOWa2cTDLnpAId78EnCtx4HLKYQSd+Jk9Y4BgO35R79mchK4iG+w6gZ+ukG2bg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "^12.6.2",
-        "@polkadot/x-bigint": "^12.6.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-create": {
-      "version": "10.13.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-10.13.1.tgz",
-      "integrity": "sha512-Usn1jqrz35SXgCDAqSXy7mnD6j4RvB4wyzTAZipFA6DGmhwyxxIgOzlWQWDb+1PtPKo9vtMzen5IJ+7w5chIeA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/types-codec": "10.13.1",
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-known": {
-      "version": "10.13.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-10.13.1.tgz",
-      "integrity": "sha512-uHjDW05EavOT5JeU8RbiFWTgPilZ+odsCcuEYIJGmK+es3lk/Qsdns9Zb7U7NJl7eJ6OWmRtyrWsLs+bU+jjIQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/networks": "^12.6.2",
-        "@polkadot/types": "10.13.1",
-        "@polkadot/types-codec": "10.13.1",
-        "@polkadot/types-create": "10.13.1",
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-support": {
-      "version": "10.13.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-10.13.1.tgz",
-      "integrity": "sha512-4gEPfz36XRQIY7inKq0HXNVVhR6HvXtm7yrEmuBuhM86LE0lQQBkISUSgR358bdn2OFSLMxMoRNoh3kcDvdGDQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "^12.6.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/util": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.6.2.tgz",
-      "integrity": "sha512-l8TubR7CLEY47240uki0TQzFvtnxFIO7uI/0GoWzpYD/O62EIAMRsuY01N4DuwgKq2ZWD59WhzsLYmA5K6ksdw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "12.6.2",
-        "@polkadot/x-global": "12.6.2",
-        "@polkadot/x-textdecoder": "12.6.2",
-        "@polkadot/x-textencoder": "12.6.2",
-        "@types/bn.js": "^5.1.5",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/util-crypto": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.6.2.tgz",
-      "integrity": "sha512-FEWI/dJ7wDMNN1WOzZAjQoIcCP/3vz3wvAp5QQm+lOrzOLj0iDmaIGIcBkz8HVm3ErfSe/uKP0KS4jgV/ib+Mg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "12.6.2",
-        "@polkadot/util": "12.6.2",
-        "@polkadot/wasm-crypto": "^7.3.2",
-        "@polkadot/wasm-util": "^7.3.2",
-        "@polkadot/x-bigint": "12.6.2",
-        "@polkadot/x-randomvalues": "12.6.2",
-        "@scure/base": "^1.1.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "12.6.2"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-bigint": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.6.2.tgz",
-      "integrity": "sha512-HSIk60uFPX4GOFZSnIF7VYJz7WZA7tpFJsne7SzxOooRwMTWEtw3fUpFy5cYYOeLh17/kHH1Y7SVcuxzVLc74Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "12.6.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-fetch": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.6.2.tgz",
-      "integrity": "sha512-8wM/Z9JJPWN1pzSpU7XxTI1ldj/AfC8hKioBlUahZ8gUiJaOF7K9XEFCrCDLis/A1BoOu7Ne6WMx/vsJJIbDWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "12.6.2",
-        "node-fetch": "^3.3.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-global": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.6.2.tgz",
-      "integrity": "sha512-a8d6m+PW98jmsYDtAWp88qS4dl8DyqUBsd0S+WgyfSMtpEXu6v9nXDgPZgwF5xdDvXhm+P0ZfVkVTnIGrScb5g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-randomvalues": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.6.2.tgz",
-      "integrity": "sha512-Vr8uG7rH2IcNJwtyf5ebdODMcr0XjoCpUbI91Zv6AlKVYOGKZlKLYJHIwpTaKKB+7KPWyQrk4Mlym/rS7v9feg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "12.6.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "12.6.2",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-textdecoder": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.6.2.tgz",
-      "integrity": "sha512-M1Bir7tYvNappfpFWXOJcnxUhBUFWkUFIdJSyH0zs5LmFtFdbKAeiDXxSp2Swp5ddOZdZgPac294/o2TnQKN1w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "12.6.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-textencoder": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.6.2.tgz",
-      "integrity": "sha512-4N+3UVCpI489tUJ6cv3uf0PjOHvgGp9Dl+SZRLgFGt9mvxnvpW/7+XBADRMtlG4xi5gaRK7bgl5bmY6OMDsNdw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "12.6.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-ws": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.6.2.tgz",
-      "integrity": "sha512-cGZWo7K5eRRQCRl2LrcyCYsrc3lRbTlixZh3AzgU8uX4wASVGRlNWi/Hf4TtHNe1ExCDmxabJzdIsABIfrr7xw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "12.6.2",
-        "tslib": "^2.6.2",
-        "ws": "^8.15.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@substrate/connect": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.8.tgz",
-      "integrity": "sha512-zwaxuNEVI9bGt0rT8PEJiXOyebLIo6QN1SyiAHRPBOl6g3Sy0KKdSN8Jmyn++oXhVRD8aIe75/V8ZkS81T+BPQ==",
-      "deprecated": "versions below 1.x are no longer maintained",
-      "license": "GPL-3.0-only",
-      "optional": true,
-      "dependencies": {
-        "@substrate/connect-extension-protocol": "^2.0.0",
-        "@substrate/connect-known-chains": "^1.1.1",
-        "@substrate/light-client-extension-helpers": "^0.0.4",
-        "smoldot": "2.0.22"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/@substrate/light-client-extension-helpers": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@substrate/light-client-extension-helpers/-/light-client-extension-helpers-0.0.4.tgz",
-      "integrity": "sha512-vfKcigzL0SpiK+u9sX6dq2lQSDtuFLOxIJx2CKPouPEHIs8C+fpsufn52r19GQn+qDhU8POMPHOVoqLktj8UEA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@polkadot-api/client": "0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0",
-        "@polkadot-api/json-rpc-provider": "0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0",
-        "@polkadot-api/json-rpc-provider-proxy": "0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0",
-        "@polkadot-api/substrate-client": "0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0",
-        "@substrate/connect-extension-protocol": "^2.0.0",
-        "@substrate/connect-known-chains": "^1.1.1",
-        "rxjs": "^7.8.1"
-      },
-      "peerDependencies": {
-        "smoldot": "2.x"
-      }
-    },
-    "node_modules/@polkadot/extension-inject/node_modules/smoldot": {
-      "version": "2.0.22",
-      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.22.tgz",
-      "integrity": "sha512-B50vRgTY6v3baYH6uCgL15tfaag5tcS2o/P5q1OiXcKGv1axZDfz2dzzMuIkVpyMR2ug11F6EAtQlmYBQd292g==",
-      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
-      "optional": true,
-      "dependencies": {
-        "ws": "^8.8.1"
       }
     },
     "node_modules/@polkadot/keyring": {
@@ -12262,6 +8355,7 @@
       "version": "18.3.26",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -15951,6 +12045,7 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -26753,7 +22848,7 @@
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
@@ -26849,14 +22944,14 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite/node_modules/rollup": {
       "version": "4.52.5",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
       "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -27503,6 +23598,7 @@
       "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@polkadot-api/descriptors": "file:.papi/descriptors",
         "@polkadot-api/ink-contracts": "^0.6.3",
         "@polkadot-api/substrate-bindings": "^0.20.3",
         "@polkadot-api/ws-provider": "^0.9.0",
@@ -27517,6 +23613,9 @@
         "@polkadot-api/polkadot-sdk-compat": "^2.4.1",
         "@types/ws": "^8.18.1"
       },
+      "engines": {
+        "node": ">=22.11"
+      },
       "peerDependencies": {
         "@cere/embed-wallet": "*"
       },
@@ -27529,7 +23628,6 @@
     "packages/blockchain/.papi/descriptors": {
       "name": "@polkadot-api/descriptors",
       "version": "0.1.0-autogenerated.1599504347975510607",
-      "extraneous": true,
       "peerDependencies": {
         "polkadot-api": ">=2.0.0"
       }
@@ -27557,7 +23655,7 @@
         "cere-ddc": "dist/cli.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.11"
       }
     },
     "packages/ddc": {
@@ -27590,6 +23688,9 @@
         "multiformats": "^13.0.0",
         "stream-consumers": "^1.0.2",
         "web-streams-polyfill": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=22.11"
       }
     },
     "packages/ddc-client": {
@@ -27600,6 +23701,9 @@
         "@cere-ddc-sdk/blockchain": "3.0.0",
         "@cere-ddc-sdk/ddc": "3.0.0",
         "@cere-ddc-sdk/file-storage": "3.0.0"
+      },
+      "engines": {
+        "node": ">=22.11"
       }
     },
     "packages/ddc/node_modules/buffer": {
@@ -27659,6 +23763,9 @@
       "dependencies": {
         "@cere-ddc-sdk/blockchain": "3.0.0",
         "@cere-ddc-sdk/ddc": "3.0.0"
+      },
+      "engines": {
+        "node": ">=22.11"
       }
     },
     "packages/typedoc-config": {


### PR DESCRIPTION
Unblocks the 3.0.0 release. The publish run ([30500853727](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/actions/runs/30500853727/job/90739982262)) failed at the final step:

```
lerna ERR! EUNCOMMIT Working tree has uncommitted changes, please commit or remove the following changes before continuing:
lerna ERR! EUNCOMMIT  M package-lock.json
```

`lerna publish from-package` refuses to publish from a dirty tree. **Nothing was published** — it aborted before touching the registry. The tree was dirtied two steps earlier by `npm ci --legacy-peer-deps`, which rewrites `package-lock.json` whenever it disagrees with the workspace `package.json` files.

Reproduced with a pristine `git clone` of `main` plus CI's exact install command.

## Two independent sources of drift

**1. Missing `engines` (introduced by #310).** Five `engines: { node: ">=22.11" }` blocks were added to the publishable packages but never mirrored into the lockfile — it carries each workspace's metadata, so it went stale immediately:

```
packages/blockchain:  None              -> {"node": ">=22.11"}
packages/cli:         {"node":">=18.0.0"} -> {"node": ">=22.11"}
packages/ddc, ddc-client, file-storage: None -> {"node": ">=22.11"}
```

**2. 242 stale entries (pre-existing, not from #310).** 195 under `examples/*` plus 47 hoisted `node_modules/*` still pinned `@cere-ddc-sdk/* 2.16.1`/`2.15.0` **tarballs from the registry**. Those workspaces now declare `3.0.0`, which resolves to the local workspace packages instead, so `npm ci` drops all 242. Confirmed by reproducing on `421373e` (pre-#310): also dirty, same 242 entries. **This would have failed the release on its own.**

Regenerating the lockfile fixes both: `4648 insertions, 8541 deletions`.

## The guard

Adds `git diff --exit-code package-lock.json` immediately after `npm ci` in **both** workflows:

- `publish.yaml` — fails fast with an actionable message instead of an opaque `EUNCOMMIT` at the last step.
- `tests.yaml` — catches the PR that *introduces* the drift. None of `build`/`lint`/`check-types`/`test` run `npm ci`, which is exactly why this slipped through #310's gates.

## Verification

| Check | Result |
| --- | --- |
| `npm run build` | 0 |
| `npm run lint` | 0 |
| `npm run check-types:ci` | 0 |
| `npm run test:ci` | 0 — 37 passed, 29 chain-gated skipped |
| `npm run package` | 0 |
| `npm ci` in a **pristine clone** → tree clean | ✅ (was `M package-lock.json`) |
| guard step passes | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)