### PR TITLE
Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,56 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
+
+3.0 replaces the `@polkadot/api` chain layer with
+[`polkadot-api`](https://github.com/polkadot-api/polkadot-api) (papi). The full
+upgrade guide, with before/after examples for every renamed API, is in
+[MIGRATION.md](./MIGRATION.md).
+
+### ⚠ BREAKING CHANGES
+
+* **blockchain:** the `Blockchain` class, its `ddcX` pallet wrappers, and the
+  `@cere-ddc-sdk/blockchain/papi` subpath are gone. There is one entry point:
+  `connect({ network })` → `CereClient`, with pallets at `client.clusters`,
+  `client.nodes`, `client.customers`, `client.staking`, `client.clustersGov`, and
+  extrinsic submission at `client.tx.send(tx, { signer })`.
+* **packaging:** `blockchain`, `ddc`, `ddc-client` and `file-storage` are
+  **ESM-only** — they no longer publish a CommonJS entry, so `require()` is not
+  supported. Use `import`, a dynamic `await import(...)`, or a bundler.
+* **node:** **Node >= 22.11** is now required (declared via `engines`). The
+  storage transport speaks grpc-web over WebSockets and needs a global
+  `WebSocket`, which Node provides from 22.
+* **config:** the network presets (`TESTNET` / `DEVNET` / `MAINNET`) are removed.
+  `DdcClient` now takes explicit `blockchain`, `clusterId` and `storageUrl` (plus
+  optional `cdnUrl`); `FileStorage` takes `storageUrl`. `createBucket()` no longer
+  takes a cluster argument — it uses the configured `clusterId`.
+* **signers:** the abstract `Signer` base class and `getSigner()` factory are
+  replaced by a chain-free `Signer` interface. `MnemonicSigner` is absorbed into
+  `UriSigner`, and `ExtensionSigner` into `Web3Signer` — neither old name exists.
+* **staking:** CDN-node staking (`ddcStaking.serve` and the other CDN-node calls)
+  is removed. It was dropped from the runtime itself, not just the SDK, so there
+  is no equivalent. `client.staking` covers storage-node and cluster staking.
+* **customers:** `getStackingInfo(...).owner` now reflects the account you
+  queried rather than the deposit contract's raw (mis-encoded) `owner` field.
+
+### Features
+
+* **ddc:** Phase 1 protocol compatibility (contract deposits, pallet/type drift fixes) ([#300](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/300)) ([421373e](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/421373e9050fe2e23358ef5e9da27c0bf8b4bb53))
+
+
+### Bug Fixes
+
+* **blockchain:** send an explicit storage_deposit_limit on ink! deposit calls ([#311](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/311)) ([9264ae2](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/9264ae274cdb4055492f41ba517a58ea5a54744b))
+* **ci:** refresh package-lock.json and guard against staleness ([#312](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/312)) ([3b855a5](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/3b855a52933f8d31006ff9d9bf85d9df3725ac8d))
+
+
+### Miscellaneous Chores
+
+* **release:** pre-3.0.0 cleanup — stale docs, dead scripts, engines floor ([#310](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/310)) ([41d9551](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/41d955151ea917b6f54206ce68b367533689d717))
+
+
+
 ## [2.15.3](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v2.15.3) (2025-10-21)
 
 ### Bug Fixes

--- a/examples/cli/CHANGELOG.md
+++ b/examples/cli/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
+
+
+### Features
+
+* **ddc:** Phase 1 protocol compatibility (contract deposits, pallet/type drift fixes) ([#300](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/300)) ([421373e](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/421373e9050fe2e23358ef5e9da27c0bf8b4bb53))
+
+
+
 ## [2.15.3](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v2.15.3) (2025-10-21)
 
 **Note:** Version bump only for package @cere-ddc-sdk/cli-examples

--- a/examples/node/CHANGELOG.md
+++ b/examples/node/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
+
+
+### Features
+
+* **ddc:** Phase 1 protocol compatibility (contract deposits, pallet/type drift fixes) ([#300](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/300)) ([421373e](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/421373e9050fe2e23358ef5e9da27c0bf8b4bb53))
+
+
+
 ## [2.15.3](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v2.15.3) (2025-10-21)
 
 **Note:** Version bump only for package @cere-ddc-sdk/node-examples

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
+
+
+### Features
+
+* **ddc:** Phase 1 protocol compatibility (contract deposits, pallet/type drift fixes) ([#300](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/300)) ([421373e](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/421373e9050fe2e23358ef5e9da27c0bf8b4bb53))
+
+
+### Bug Fixes
+
+* **blockchain:** send an explicit storage_deposit_limit on ink! deposit calls ([#311](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/311)) ([9264ae2](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/9264ae274cdb4055492f41ba517a58ea5a54744b))
+
+
+### Miscellaneous Chores
+
+* **release:** pre-3.0.0 cleanup — stale docs, dead scripts, engines floor ([#310](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/310)) ([41d9551](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/41d955151ea917b6f54206ce68b367533689d717))
+
+
+
 ## [2.15.3](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v2.15.3) (2025-10-21)
 
 **Note:** Version bump only for package @cere-ddc-sdk/blockchain

--- a/packages/changelog-preset/CHANGELOG.md
+++ b/packages/changelog-preset/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
+
+
+### Features
+
+* **ddc:** Phase 1 protocol compatibility (contract deposits, pallet/type drift fixes) ([#300](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/300)) ([421373e](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/421373e9050fe2e23358ef5e9da27c0bf8b4bb53))
+
+
+
 ## [2.15.3](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v2.15.3) (2025-10-21)
 
 **Note:** Version bump only for package @cere-ddc-sdk/conventional-changelog-changelog-preset

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
+
+
+### Features
+
+* **ddc:** Phase 1 protocol compatibility (contract deposits, pallet/type drift fixes) ([#300](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/300)) ([421373e](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/421373e9050fe2e23358ef5e9da27c0bf8b4bb53))
+
+
+### Miscellaneous Chores
+
+* **release:** pre-3.0.0 cleanup — stale docs, dead scripts, engines floor ([#310](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/310)) ([41d9551](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/41d955151ea917b6f54206ce68b367533689d717))
+
+
+
 ## [2.15.3](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v2.15.3) (2025-10-21)
 
 **Note:** Version bump only for package @cere-ddc-sdk/cli

--- a/packages/ddc-client/CHANGELOG.md
+++ b/packages/ddc-client/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
+
+
+### Features
+
+* **ddc:** Phase 1 protocol compatibility (contract deposits, pallet/type drift fixes) ([#300](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/300)) ([421373e](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/421373e9050fe2e23358ef5e9da27c0bf8b4bb53))
+
+
+### Bug Fixes
+
+* **blockchain:** send an explicit storage_deposit_limit on ink! deposit calls ([#311](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/311)) ([9264ae2](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/9264ae274cdb4055492f41ba517a58ea5a54744b))
+
+
+### Miscellaneous Chores
+
+* **release:** pre-3.0.0 cleanup — stale docs, dead scripts, engines floor ([#310](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/310)) ([41d9551](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/41d955151ea917b6f54206ce68b367533689d717))
+
+
+
 ## [2.15.3](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v2.15.3) (2025-10-21)
 
 ### Bug Fixes

--- a/packages/ddc/CHANGELOG.md
+++ b/packages/ddc/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
+
+
+### Features
+
+* **ddc:** Phase 1 protocol compatibility (contract deposits, pallet/type drift fixes) ([#300](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/300)) ([421373e](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/421373e9050fe2e23358ef5e9da27c0bf8b4bb53))
+
+
+### Miscellaneous Chores
+
+* **release:** pre-3.0.0 cleanup — stale docs, dead scripts, engines floor ([#310](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/310)) ([41d9551](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/41d955151ea917b6f54206ce68b367533689d717))
+
+
+
 ## [2.15.3](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v2.15.3) (2025-10-21)
 
 **Note:** Version bump only for package @cere-ddc-sdk/ddc

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
+
+
+### Features
+
+* **ddc:** Phase 1 protocol compatibility (contract deposits, pallet/type drift fixes) ([#300](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/300)) ([421373e](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/421373e9050fe2e23358ef5e9da27c0bf8b4bb53))
+
+
+
 ## [2.15.3](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v2.15.3) (2025-10-21)
 
 **Note:** Version bump only for package @cere-ddc-sdk/eslint-config

--- a/packages/file-storage/CHANGELOG.md
+++ b/packages/file-storage/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
+
+
+### Features
+
+* **ddc:** Phase 1 protocol compatibility (contract deposits, pallet/type drift fixes) ([#300](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/300)) ([421373e](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/421373e9050fe2e23358ef5e9da27c0bf8b4bb53))
+
+
+### Miscellaneous Chores
+
+* **release:** pre-3.0.0 cleanup — stale docs, dead scripts, engines floor ([#310](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/310)) ([41d9551](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/41d955151ea917b6f54206ce68b367533689d717))
+
+
+
 ## [2.15.3](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v2.15.3) (2025-10-21)
 
 **Note:** Version bump only for package @cere-ddc-sdk/file-storage

--- a/packages/typedoc-config/CHANGELOG.md
+++ b/packages/typedoc-config/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
+
+
+### Features
+
+* **ddc:** Phase 1 protocol compatibility (contract deposits, pallet/type drift fixes) ([#300](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/300)) ([421373e](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/421373e9050fe2e23358ef5e9da27c0bf8b4bb53))
+
+
+
 ## [2.15.3](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v2.15.3) (2025-10-21)
 
 **Note:** Version bump only for package @cere-ddc-sdk/typedoc-config

--- a/playground/CHANGELOG.md
+++ b/playground/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
+
+
+### Features
+
+* **ddc:** Phase 1 protocol compatibility (contract deposits, pallet/type drift fixes) ([#300](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/300)) ([421373e](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/421373e9050fe2e23358ef5e9da27c0bf8b4bb53))
+
+
+
 ## [2.15.3](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v2.15.3) (2025-10-21)
 
 **Note:** Version bump only for package @cere-ddc-sdk/playground

--- a/tests/CHANGELOG.md
+++ b/tests/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
+
+
+### Features
+
+* **ddc:** Phase 1 protocol compatibility (contract deposits, pallet/type drift fixes) ([#300](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/300)) ([421373e](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/421373e9050fe2e23358ef5e9da27c0bf8b4bb53))
+
+
+### Bug Fixes
+
+* **blockchain:** send an explicit storage_deposit_limit on ink! deposit calls ([#311](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/311)) ([9264ae2](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/9264ae274cdb4055492f41ba517a58ea5a54744b))
+
+
+
 ## [2.15.3](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v2.15.3) (2025-10-21)
 
 **Note:** Version bump only for package @cere-ddc-sdk/tests


### PR DESCRIPTION
Cuts 3.0.0. Merge this, then I trigger the Publish workflow.

## Why not `npm run release`

`npm run release` is `lerna version --conventional-graduate`, which would compute **3.1.0**: `lerna.json` is fixed-mode at 3.0.0 and the squash-merged commits carry no `BREAKING CHANGE:` footer, so the bump reads as a minor and **3.0.0 would be skipped entirely** — with `2.16.1` as the last published version. Cut with an explicit `npx lerna version 3.0.0` instead (`exact: true` is already set in `lerna.json`).

## Hand-written breaking-change section

Because those footers didn't survive squashing, the generated CHANGELOG had only "Features"/"Bug Fixes" for the largest breaking release this SDK has had. Added a `⚠ BREAKING CHANGES` block to the root CHANGELOG, derived from MIGRATION.md:

- papi replaces the `@polkadot/api` chain layer; `Blockchain`, the `ddcX` wrappers and the `/papi` subpath are gone → `connect({ network })` → `CereClient`
- ESM-only for `blockchain`/`ddc`/`ddc-client`/`file-storage` (no `require()`)
- **Node >= 22.11** required
- network presets removed → explicit `blockchain`/`clusterId`/`storageUrl`; `createBucket()` drops its cluster argument
- `MnemonicSigner` → `UriSigner`, `ExtensionSigner` → `Web3Signer`
- CDN-node staking removed (gone from the runtime)
- `getStackingInfo().owner` now reflects the queried account

## What is deliberately NOT in this PR

**`package-lock.json`.** `lerna version` rewrites it — dropping the generated `@polkadot-api/descriptors` workspace link and marking ~24 entries `extraneous`. Committing that would reintroduce the exact `EUNCOMMIT` publish failure #312 just fixed. `main`'s lockfile is already correct and verified stable under repeated `npm ci --legacy-peer-deps`, so it's left untouched.

This is worth knowing for every future release: **do not commit the lockfile that `lerna version` produces.**

## Verification on this commit

| Gate | Result |
| --- | --- |
| `npm run lint` | 0 |
| `npm run build` | 0 |
| `npm run check-types:ci` | 0 |
| `npm run test:ci` | 0 — 37 passed, 29 chain-gated skipped |
| `npm run package` | 0 — all five packages stamped `3.0.0` |
| `npm ci --legacy-peer-deps` → tree clean | ✅ so `lerna publish from-package` proceeds |

## After merge

1. Tag `v3.0.0` (no v3 tag exists yet).
2. Run [Publish](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/actions/workflows/publish.yaml) — currently all five packages are `2.16.1` on npm.
3. Run Deploy playground.

Release notes should carry one known issue: mainnet storage/CDN load balancers reject the WebSocket grpc-web upgrade with HTTP 403 (server-side infra; chain calls work, devnet/testnet storage verified end to end). #308/#309 are resolved in code by #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)