### PR TITLE
Release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.1](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v3.0.0...v3.0.1) (2026-07-30)
+
+
+### Documentation
+
+* fix UriSigner examples that throw, and overstated CommonJS restriction ([#314](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/314)) ([5cf7a6b](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/5cf7a6bff90b3e8ff0fbf3d483a6b95c2a9e1ca6))
+
+
+
 ## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
 
 3.0 replaces the `@polkadot/api` chain layer with

--- a/examples/cli/CHANGELOG.md
+++ b/examples/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.1](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v3.0.0...v3.0.1) (2026-07-30)
+
+**Note:** Version bump only for package @cere-ddc-sdk/cli-examples
+
+
+
+
+
 ## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
 
 

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@cere-ddc-sdk/cli-examples",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "dependencies": {
-    "@cere-ddc-sdk/cli": "3.0.0"
+    "@cere-ddc-sdk/cli": "3.0.1"
   }
 }

--- a/examples/node/CHANGELOG.md
+++ b/examples/node/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.1](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v3.0.0...v3.0.1) (2026-07-30)
+
+**Note:** Version bump only for package @cere-ddc-sdk/node-examples
+
+
+
+
+
 ## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
 
 

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cere-ddc-sdk/node-examples",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "type": "module",
   "scripts": {
@@ -14,8 +14,8 @@
     "example:8": "ts-node --esm ./8-sudo-batch-remove-buckets/index.ts"
   },
   "dependencies": {
-    "@cere-ddc-sdk/blockchain": "3.0.0",
-    "@cere-ddc-sdk/ddc-client": "3.0.0",
+    "@cere-ddc-sdk/blockchain": "3.0.1",
+    "@cere-ddc-sdk/ddc-client": "3.0.1",
     "@types/json-bigint": "^1.0.4",
     "json-bigint": "^1.0.0",
     "ts-node": "^10.9.2"

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "command": {
     "publish": {
       "directory": "{workspaceRoot}/{projectRoot}/package"

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,17 +38,17 @@
     },
     "examples/cli": {
       "name": "@cere-ddc-sdk/cli-examples",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
-        "@cere-ddc-sdk/cli": "3.0.0"
+        "@cere-ddc-sdk/cli": "3.0.1"
       }
     },
     "examples/node": {
       "name": "@cere-ddc-sdk/node-examples",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
-        "@cere-ddc-sdk/blockchain": "3.0.0",
-        "@cere-ddc-sdk/ddc-client": "3.0.0",
+        "@cere-ddc-sdk/blockchain": "3.0.1",
+        "@cere-ddc-sdk/ddc-client": "3.0.1",
         "@types/json-bigint": "^1.0.4",
         "json-bigint": "^1.0.0",
         "ts-node": "^10.9.2"
@@ -23595,7 +23595,7 @@
     },
     "packages/blockchain": {
       "name": "@cere-ddc-sdk/blockchain",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot-api/descriptors": "file:.papi/descriptors",
@@ -23634,7 +23634,7 @@
     },
     "packages/changelog-preset": {
       "name": "@cere-ddc-sdk/conventional-changelog-changelog-preset",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "conventional-changelog-conventionalcommits": "^7.0.2"
@@ -23642,11 +23642,11 @@
     },
     "packages/cli": {
       "name": "@cere-ddc-sdk/cli",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cere-ddc-sdk/ddc": "3.0.0",
-        "@cere-ddc-sdk/ddc-client": "3.0.0",
+        "@cere-ddc-sdk/ddc": "3.0.1",
+        "@cere-ddc-sdk/ddc-client": "3.0.1",
         "@polkadot/util-crypto": "^13.5.7",
         "@types/yargs": "^17.0.32",
         "yargs": "^17.7.2"
@@ -23660,10 +23660,10 @@
     },
     "packages/ddc": {
       "name": "@cere-ddc-sdk/ddc",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cere-ddc-sdk/blockchain": "3.0.0",
+        "@cere-ddc-sdk/blockchain": "3.0.1",
         "@grpc/grpc-js": "^1.9.13",
         "@protobuf-ts/grpc-transport": "^2.9.3",
         "@protobuf-ts/runtime": "^2.9.3",
@@ -23695,12 +23695,12 @@
     },
     "packages/ddc-client": {
       "name": "@cere-ddc-sdk/ddc-client",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cere-ddc-sdk/blockchain": "3.0.0",
-        "@cere-ddc-sdk/ddc": "3.0.0",
-        "@cere-ddc-sdk/file-storage": "3.0.0"
+        "@cere-ddc-sdk/blockchain": "3.0.1",
+        "@cere-ddc-sdk/ddc": "3.0.1",
+        "@cere-ddc-sdk/file-storage": "3.0.1"
       },
       "engines": {
         "node": ">=22.11"
@@ -23741,7 +23741,7 @@
     },
     "packages/eslint-config": {
       "name": "@cere-ddc-sdk/eslint-config",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^6.16.0",
@@ -23758,11 +23758,11 @@
     },
     "packages/file-storage": {
       "name": "@cere-ddc-sdk/file-storage",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cere-ddc-sdk/blockchain": "3.0.0",
-        "@cere-ddc-sdk/ddc": "3.0.0"
+        "@cere-ddc-sdk/blockchain": "3.0.1",
+        "@cere-ddc-sdk/ddc": "3.0.1"
       },
       "engines": {
         "node": ">=22.11"
@@ -23770,7 +23770,7 @@
     },
     "packages/typedoc-config": {
       "name": "@cere-ddc-sdk/typedoc-config",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "typedoc-plugin-markdown": "^4.12.0"
@@ -23781,10 +23781,10 @@
     },
     "playground": {
       "name": "@cere-ddc-sdk/playground",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
-        "@cere-ddc-sdk/blockchain": "3.0.0",
-        "@cere-ddc-sdk/ddc-client": "3.0.0",
+        "@cere-ddc-sdk/blockchain": "3.0.1",
+        "@cere-ddc-sdk/ddc-client": "3.0.1",
         "@cere/embed-wallet": "^0.20.1",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
@@ -23808,12 +23808,12 @@
     },
     "tests": {
       "name": "@cere-ddc-sdk/tests",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
-        "@cere-ddc-sdk/blockchain": "3.0.0",
-        "@cere-ddc-sdk/ddc": "3.0.0",
-        "@cere-ddc-sdk/ddc-client": "3.0.0",
-        "@cere-ddc-sdk/file-storage": "3.0.0",
+        "@cere-ddc-sdk/blockchain": "3.0.1",
+        "@cere-ddc-sdk/ddc": "3.0.1",
+        "@cere-ddc-sdk/ddc-client": "3.0.1",
+        "@cere-ddc-sdk/file-storage": "3.0.1",
         "@polkadot-labs/hdkd-helpers": "^0.0.31",
         "@types/jest": "^29.5.11",
         "jest": "^29.7.0",

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.1](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v3.0.0...v3.0.1) (2026-07-30)
+
+
+### Documentation
+
+* fix UriSigner examples that throw, and overstated CommonJS restriction ([#314](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/314)) ([5cf7a6b](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/5cf7a6bff90b3e8ff0fbf3d483a6b95c2a9e1ca6))
+
+
+
 ## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
 
 

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cere-ddc-sdk/blockchain",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Cere Blockchain client",
   "type": "module",
   "main": "./dist/papi/index.js",

--- a/packages/changelog-preset/CHANGELOG.md
+++ b/packages/changelog-preset/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.1](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v3.0.0...v3.0.1) (2026-07-30)
+
+**Note:** Version bump only for package @cere-ddc-sdk/conventional-changelog-changelog-preset
+
+
+
+
+
 ## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
 
 

--- a/packages/changelog-preset/package.json
+++ b/packages/changelog-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cere-ddc-sdk/conventional-changelog-changelog-preset",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "author": "Cere Network <contact@cere.io (https://www.cere.io/)",
   "license": "Apache-2.0",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.1](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v3.0.0...v3.0.1) (2026-07-30)
+
+**Note:** Version bump only for package @cere-ddc-sdk/cli
+
+
+
+
+
 ## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
 
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cere-ddc-sdk/cli",
   "description": "DDC command line interface",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "repository": {
     "type": "git",
     "directory": "packages/cli",
@@ -22,8 +22,8 @@
     "clean": "rimraf dist package"
   },
   "dependencies": {
-    "@cere-ddc-sdk/ddc": "3.0.0",
-    "@cere-ddc-sdk/ddc-client": "3.0.0",
+    "@cere-ddc-sdk/ddc": "3.0.1",
+    "@cere-ddc-sdk/ddc-client": "3.0.1",
     "@polkadot/util-crypto": "^13.5.7",
     "@types/yargs": "^17.0.32",
     "yargs": "^17.7.2"

--- a/packages/ddc-client/CHANGELOG.md
+++ b/packages/ddc-client/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.1](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v3.0.0...v3.0.1) (2026-07-30)
+
+
+### Documentation
+
+* fix UriSigner examples that throw, and overstated CommonJS restriction ([#314](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/314)) ([5cf7a6b](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/5cf7a6bff90b3e8ff0fbf3d483a6b95c2a9e1ca6))
+
+
+
 ## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
 
 

--- a/packages/ddc-client/package.json
+++ b/packages/ddc-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cere-ddc-sdk/ddc-client",
   "description": "DDC client",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "repository": {
     "type": "git",
@@ -33,9 +33,9 @@
     "build:web": "microbundle --tsconfig tsconfig.build.json --format modern --output dist/browser.js"
   },
   "dependencies": {
-    "@cere-ddc-sdk/blockchain": "3.0.0",
-    "@cere-ddc-sdk/ddc": "3.0.0",
-    "@cere-ddc-sdk/file-storage": "3.0.0"
+    "@cere-ddc-sdk/blockchain": "3.0.1",
+    "@cere-ddc-sdk/ddc": "3.0.1",
+    "@cere-ddc-sdk/file-storage": "3.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ddc/CHANGELOG.md
+++ b/packages/ddc/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.1](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v3.0.0...v3.0.1) (2026-07-30)
+
+**Note:** Version bump only for package @cere-ddc-sdk/ddc
+
+
+
+
+
 ## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
 
 

--- a/packages/ddc/package.json
+++ b/packages/ddc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cere-ddc-sdk/ddc",
   "description": "DDC nodes API",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     "build:web": "microbundle --tsconfig tsconfig.web.json --format modern --output dist/browser.js"
   },
   "dependencies": {
-    "@cere-ddc-sdk/blockchain": "3.0.0",
+    "@cere-ddc-sdk/blockchain": "3.0.1",
     "@grpc/grpc-js": "^1.9.13",
     "@protobuf-ts/grpc-transport": "^2.9.3",
     "@protobuf-ts/runtime": "^2.9.3",

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.1](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v3.0.0...v3.0.1) (2026-07-30)
+
+**Note:** Version bump only for package @cere-ddc-sdk/eslint-config
+
+
+
+
+
 ## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
 
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cere-ddc-sdk/eslint-config",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "index.js",
   "private": true,
   "author": "Cere Network <contact@cere.io (https://www.cere.io/)",

--- a/packages/file-storage/CHANGELOG.md
+++ b/packages/file-storage/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.1](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v3.0.0...v3.0.1) (2026-07-30)
+
+
+### Documentation
+
+* fix UriSigner examples that throw, and overstated CommonJS restriction ([#314](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/issues/314)) ([5cf7a6b](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/commit/5cf7a6bff90b3e8ff0fbf3d483a6b95c2a9e1ca6))
+
+
+
 ## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
 
 

--- a/packages/file-storage/package.json
+++ b/packages/file-storage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cere-ddc-sdk/file-storage",
   "description": "File storage client",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "repository": {
     "type": "git",
@@ -33,8 +33,8 @@
     "build:web": "microbundle --tsconfig tsconfig.web.json --format modern --output dist/browser.js"
   },
   "dependencies": {
-    "@cere-ddc-sdk/blockchain": "3.0.0",
-    "@cere-ddc-sdk/ddc": "3.0.0"
+    "@cere-ddc-sdk/blockchain": "3.0.1",
+    "@cere-ddc-sdk/ddc": "3.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/typedoc-config/CHANGELOG.md
+++ b/packages/typedoc-config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.1](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v3.0.0...v3.0.1) (2026-07-30)
+
+**Note:** Version bump only for package @cere-ddc-sdk/typedoc-config
+
+
+
+
+
 ## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
 
 

--- a/packages/typedoc-config/package.json
+++ b/packages/typedoc-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cere-ddc-sdk/typedoc-config",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "author": "Cere Network <contact@cere.io (https://www.cere.io/)",
   "license": "Apache-2.0",

--- a/playground/CHANGELOG.md
+++ b/playground/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.1](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v3.0.0...v3.0.1) (2026-07-30)
+
+**Note:** Version bump only for package @cere-ddc-sdk/playground
+
+
+
+
+
 ## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
 
 

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cere-ddc-sdk/playground",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "type": "module",
   "scripts": {
@@ -11,8 +11,8 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@cere-ddc-sdk/blockchain": "3.0.0",
-    "@cere-ddc-sdk/ddc-client": "3.0.0",
+    "@cere-ddc-sdk/blockchain": "3.0.1",
+    "@cere-ddc-sdk/ddc-client": "3.0.1",
     "@cere/embed-wallet": "^0.20.1",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",

--- a/tests/CHANGELOG.md
+++ b/tests/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.1](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v3.0.0...v3.0.1) (2026-07-30)
+
+**Note:** Version bump only for package @cere-ddc-sdk/tests
+
+
+
+
+
 ## [3.0.0](https://github.com/Cerebellum-Network/cere-ddc-sdk-js/compare/v2.14.1...v3.0.0) (2026-07-30)
 
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@cere-ddc-sdk/tests",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Cere DDC SDK tests",
   "private": true,
   "scripts": {
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.papi.config.ts --runInBand"
   },
   "dependencies": {
-    "@cere-ddc-sdk/blockchain": "3.0.0",
-    "@cere-ddc-sdk/ddc": "3.0.0",
-    "@cere-ddc-sdk/ddc-client": "3.0.0",
-    "@cere-ddc-sdk/file-storage": "3.0.0",
+    "@cere-ddc-sdk/blockchain": "3.0.1",
+    "@cere-ddc-sdk/ddc": "3.0.1",
+    "@cere-ddc-sdk/ddc-client": "3.0.1",
+    "@cere-ddc-sdk/file-storage": "3.0.1",
     "@polkadot-labs/hdkd-helpers": "^0.0.31",
     "@types/jest": "^29.5.11",
     "jest": "^29.7.0",


### PR DESCRIPTION
Docs-only patch to ship #314's fixes to npm. No source changes since 3.0.0.

## Why

3.0.0 shipped a doc bug inside the published tarballs: the `DdcClient.create` / `FileStorage.create` TSDoc showed `new UriSigner('//Alice')`, which throws (`UriSigner` deliberately rejects an empty phrase). #314 fixed it on `main`, but until 3.0.1 publishes, editor tooltips for anyone on `3.0.0` still show the throwing example.

Also corrects the overstated "no `require()`" claim — on Node 22 (which 3.0 mandates) `require()` of these ESM packages works via Node's interop.

## Lockfile

Same care as 3.0.0. `lerna version` rewrites `package-lock.json` and destabilizes it (drops the generated `@polkadot-api/descriptors` workspace link; the result isn't a `npm ci` fixpoint). This commit instead takes `main`'s known-stable lockfile and updates only the 12 workspace `version` fields to 3.0.1, preserving the dependency graph.

**Verified a stable fixpoint**: two `npm ci --legacy-peer-deps` passes leave the tree clean → the #312 guard passes. (This is the exact failure that broke 3.0.0's first publish.)

| Gate | Result |
| --- | --- |
| `npm run lint` | 0 |
| `npm run build` | 0 |
| `npm run check-types:ci` | 0 |
| `npm run test:ci` | 0 — 37 passed, 29 chain-gated skipped |
| `npm run package` | 0 — all five packages stamped 3.0.1 |
| lockfile guard (`npm ci` → clean) | ✅ |

## After merge

I'll tag `v3.0.1`, trigger Publish, and confirm all five packages at `3.0.1` on npm.

**Known issue (unchanged):** mainnet storage/CDN load balancers (`*.dragon-1.xyz`) reject the WebSocket grpc-web upgrade with HTTP 403 — server-side infra. Verified still present on 2026-07-30 (HTTP probe: mainnet 403 vs testnet/devnet 405/404; SDK store→read passes on testnet, times out on mainnet). Not something any SDK version fixes; tracked for the infra team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)